### PR TITLE
Support automatic retry for authenticated requests #16

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -76,27 +76,6 @@ class Client implements GuzzleClientInterface
         return $this->client->request($method, $url, $options);
     }
 
-    public function authenticatedRequest(User $user, $method = 'GET', $url = null, array $options = [])
-    {
-        // @todo Move this whole method to UserSession.
-        if (isset($user)) {
-            $duration = isset($options['timeout']) ? $options['timeout'] : null;
-            $options['query']['token'] = (string) $user->acquireToken($duration);
-        }
-
-        try {
-            return $this->request($method, $url, $options);
-        } catch (ApiException $exception) {
-            // If the token is invalid, we should delete it from storage so that a
-            // fresh token is fetched on the next request.
-            if (401 == $exception->getCode()) {
-                // Ensure the token will be deleted.
-                $user->invalidateToken();
-            }
-            throw $exception;
-        }
-    }
-
     /**
      * Handle an XML API response.
      *

--- a/src/Exception/TokenNotFoundException.php
+++ b/src/Exception/TokenNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Lullabot\Mpx\Exception;
+
+use Lullabot\Mpx\User;
+
+class TokenNotFoundException extends \RuntimeException
+{
+    public function __construct(User $user, int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Token not found for %s.', $user->getUsername()), $code, $previous);
+    }
+}

--- a/src/TokenCachePool.php
+++ b/src/TokenCachePool.php
@@ -2,6 +2,7 @@
 
 namespace Lullabot\Mpx;
 
+use Lullabot\Mpx\Exception\TokenNotFoundException;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -55,12 +56,12 @@ class TokenCachePool
      */
     public function getToken(User $user): Token
     {
-        $item = $this->cacheItemPool->getItem($this->cacheKey($user));
         // @todo Test that the expiresAfter() call works. We don't want to be caught
         // by cron etc.
+        $item = $this->cacheItemPool->getItem($this->cacheKey($user));
+
         if (!$item->isHit()) {
-            // @todo This should be a TokenNotFoundException.
-            throw new \RuntimeException();
+            throw new TokenNotFoundException($user);
         }
 
         return $item->get();

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -224,11 +224,11 @@ class UserSession implements ClientInterface
      */
     private function mergeAuth(array $options, bool $reset = false): array
     {
-        $options += [
-            'auth' => [
-                $this->user->getUsername(),
-                $this->acquireToken(null, $reset)->getValue(),
-            ],
+        if (!isset($options['query'])) {
+            $options['query'] = [];
+        }
+        $options['query'] += [
+            'token' => $this->acquireToken(null, $reset)->getValue(),
         ];
 
         return $options;

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -275,6 +275,11 @@ class UserSession implements ClientInterface
             $first->then(function (ResponseInterface $response) use ($promise) {
                 $promise->resolve($response);
             }, function (RequestException $e) use ($promise, $request, $options) {
+                // Only retry if it's a token auth error.
+                if (!($e instanceof ClientException) || $e->getCode() != 401) {
+                    $promise->reject($e);
+                }
+
                 $merged = $this->mergeAuth($options, true);
                 /** @var \GuzzleHttp\Promise\PromiseInterface $second */
                 $second = $this->client->sendAsync($request, $merged);
@@ -341,6 +346,11 @@ class UserSession implements ClientInterface
             $first->then(function (ResponseInterface $response) use ($promise) {
                 $promise->resolve($response);
             }, function (RequestException $e) use ($promise, $method, $uri, $options) {
+                // Only retry if it's a token auth error.
+                if (!($e instanceof ClientException) || $e->getCode() != 401) {
+                    $promise->reject($e);
+                }
+
                 $merged = $this->mergeAuth($options, true);
                 /** @var \GuzzleHttp\Promise\PromiseInterface $second */
                 $second = $this->client->requestAsync($method, $uri, $merged);

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -215,9 +215,12 @@ class UserSession implements ClientInterface
     }
 
     /**
-     * @param array $options
+     * Merge authentication headers into request options.
      *
-     * @return array
+     * @param array $options The array of request options.
+     * @param bool  $reset   Acquire a new token even if one is cached.
+     *
+     * @return array The updated request options.
      */
     private function mergeAuth(array $options, bool $reset = false): array
     {

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -259,9 +259,8 @@ class UserSession implements ClientInterface
      * promise is created that explicitly rejects the outer promise, as we only
      * want to retry once.
      *
-     * @param string                                $method  HTTP method
-     * @param string|\Psr\Http\Message\UriInterface $uri     URI object or string.
-     * @param array                                 $options Request options to apply.
+     * @param \Psr\Http\Message\RequestInterface $request The request to send.
+     * @param array                              $options Request options to apply.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
@@ -276,7 +275,7 @@ class UserSession implements ClientInterface
                 $promise->resolve($response);
             }, function (RequestException $e) use ($promise, $request, $options) {
                 // Only retry if it's a token auth error.
-                if (!($e instanceof ClientException) || $e->getCode() != 401) {
+                if (!($e instanceof ClientException) || 401 != $e->getCode()) {
                     $promise->reject($e);
                 }
 
@@ -347,7 +346,7 @@ class UserSession implements ClientInterface
                 $promise->resolve($response);
             }, function (RequestException $e) use ($promise, $method, $uri, $options) {
                 // Only retry if it's a token auth error.
-                if (!($e instanceof ClientException) || $e->getCode() != 401) {
+                if (!($e instanceof ClientException) || 401 != $e->getCode()) {
                     $promise->reject($e);
                 }
 

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -5,7 +5,6 @@ namespace Lullabot\Mpx;
 use GuzzleHttp\ClientInterface;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Exception\TokenNotFoundException;
-use Prophecy\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
@@ -250,9 +249,9 @@ class UserSession implements ClientInterface
      * @param array                              $options  An array of request options.
      * @param callable                           $callable The underlying HTTP client method to call.
      *
-     * @return \Prophecy\Promise\PromiseInterface
+     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
-    private function sendWithRetry(RequestInterface $request, array $options, callable $callable): PromiseInterface
+    private function sendWithRetry(RequestInterface $request, array $options, callable $callable)
     {
         $merged = $this->mergeAuth($options);
 
@@ -279,9 +278,9 @@ class UserSession implements ClientInterface
      * @param array                                 $options  Request options to apply.
      * @param callable                              $callable The underlying HTTP client method to call.
      *
-     * @return \Prophecy\Promise\PromiseInterface
+     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
-    private function requestWithRetry(string $method, $uri, array $options, callable $callable): PromiseInterface
+    private function requestWithRetry(string $method, $uri, array $options, callable $callable)
     {
         $merged = $this->mergeAuth($options);
 

--- a/tests/src/Unit/Exception/MpxExceptionTraitTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionTraitTest.php
@@ -89,6 +89,7 @@ class MpxExceptionTraitTest extends TestCase
      * Test validating a valid MPX error.
      *
      * @covers ::validateData
+     * @doesNotPerformAssertions
      */
     public function testValidateData()
     {

--- a/tests/src/Unit/UserSessionTest.php
+++ b/tests/src/Unit/UserSessionTest.php
@@ -3,6 +3,8 @@
 namespace Lullabot\Mpx\Tests\Unit;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
@@ -10,6 +12,7 @@ use Lullabot\Mpx\TokenCachePool;
 use Lullabot\Mpx\User;
 use Lullabot\Mpx\UserSession;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -116,5 +119,72 @@ class UserSessionTest extends TestCase
         $second_token = $session->acquireToken(null, true);
         $this->assertEquals($second_token, $tokenCachePool->getToken($user));
         $this->assertNotSame($first_token, $second_token);
+    }
+
+    /**
+     * Test normal authenticated requests.
+     *
+     * @dataProvider clientMethodDataProvider
+     *
+     * @param string $method The method on UserSession to call.
+     * @param array  $args   The method arguments.
+     *
+     * @covers ::request
+     * @covers ::requestAsync
+     * @covers ::send
+     * @covers ::sendAsync
+     * @covers ::mergeAuth
+     * @covers ::requestWithRetry
+     */
+    public function testAuthenticatedRequest(string $method, array $args)
+    {
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            function (RequestInterface $request) {
+                //  This is what tests mergeAuth().
+                $this->assertEquals('Basic VVNFUi1OQU1FOlRPS0VOLVZBTFVF', $request->getHeaderLine('Authorization'));
+
+                return new JsonResponse(200, [], 'getSelfId.json');
+            },
+        ]);
+        $user = new User('USER-NAME', 'correct-password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+
+        /** @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject $logger */
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->getMock();
+        $logger->expects($this->exactly(1))->method('info')
+            ->with(
+                'Retrieved a new MPX token {token} for user {username} that expires on {date}.'
+            )->willReturnCallback(function ($message, $context) {
+                $this->assertEquals('Retrieved a new MPX token {token} for user {username} that expires on {date}.', $message);
+                $this->assertArraySubset([
+                    'token' => 'TOKEN-VALUE',
+                    'username' => 'USER-NAME',
+                ], $context);
+                $this->assertRegExp('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
+            });
+
+        $session = new UserSession($client, $user, $tokenCachePool, $logger);
+        $response = call_user_func_array([$session, $method], $args);
+        if ($response instanceof PromiseInterface) {
+            $response = $response->wait();
+        }
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Return an array of methods and parameters to call for authenticated requests.
+     *
+     * @return array
+     */
+    public function clientMethodDataProvider()
+    {
+        return [
+            ['request', ['GET', 'https://identity.auth.theplatform.com/idm/web/Self/getSelfId']],
+            ['requestAsync', ['GET', 'https://identity.auth.theplatform.com/idm/web/Self/getSelfId']],
+            ['send', [new Request('GET', 'https://identity.auth.theplatform.com/idm/web/Self/getSelfId')]],
+            ['sendAsync', [new Request('GET', 'https://identity.auth.theplatform.com/idm/web/Self/getSelfId')]],
+        ];
     }
 }

--- a/tests/src/Unit/UserSessionTest.php
+++ b/tests/src/Unit/UserSessionTest.php
@@ -184,7 +184,9 @@ class UserSessionTest extends TestCase
      * @param array  $args   The method arguments.
      *
      * @covers ::requestWithRetry
+     * @covers ::requestAsyncWithRetry
      * @covers ::sendWithRetry
+     * @covers ::sendAsyncWithRetry
      */
     public function testRetriedAuthenticatedRequest(string $method, array $args)
     {

--- a/tests/src/Unit/UserSessionTest.php
+++ b/tests/src/Unit/UserSessionTest.php
@@ -27,6 +27,7 @@ class UserSessionTest extends TestCase
      * @covers ::__construct
      * @covers ::acquireToken
      * @covers ::signIn
+     * @covers ::tokenFromResponse
      * @covers ::signOut
      */
     public function testAcquireToken()
@@ -135,6 +136,7 @@ class UserSessionTest extends TestCase
      * @covers ::sendAsync
      * @covers ::mergeAuth
      * @covers ::requestWithRetry
+     * @covers ::sendWithRetry
      */
     public function testAuthenticatedRequest(string $method, array $args)
     {

--- a/tests/src/Unit/UserSessionTest.php
+++ b/tests/src/Unit/UserSessionTest.php
@@ -118,7 +118,8 @@ class UserSessionTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             function (RequestInterface $request) {
                 //  This is what tests mergeAuth().
-                $this->assertEquals('Basic VVNFUi1OQU1FOlRPS0VOLVZBTFVF', $request->getHeaderLine('Authorization'));
+                $parts = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
+                $this->assertEquals('TOKEN-VALUE', $parts['token']);
 
                 return new JsonResponse(200, [], 'getSelfId.json');
             },

--- a/tests/src/Unit/UserSessionTest.php
+++ b/tests/src/Unit/UserSessionTest.php
@@ -39,9 +39,9 @@ class UserSessionTest extends TestCase
             ->getMock();
         $logger->expects($this->once())->method('info')
             ->with(
-                'Refreshed token with a new mpx token {token} for user {username} that expires on {date}.'
+                'Retrieved a new MPX token {token} for user {username} that expires on {date}.'
             )->willReturnCallback(function ($message, $context) {
-                $this->assertEquals('Refreshed token with a new mpx token {token} for user {username} that expires on {date}.', $message);
+                $this->assertEquals('Retrieved a new MPX token {token} for user {username} that expires on {date}.', $message);
                 $this->assertArraySubset([
                     'token' => 'TOKEN-VALUE',
                     'username' => 'USER-NAME',


### PR DESCRIPTION
This PR solves #16 by automatically retrying a request if it fails with a 401, which indicates that the token has expired. While we automatically expire tokens locally, it's possible for them to be deleted server side or through a signout call.

There's a little bit of code duplication in that we want to be sure we call the appropriate underlying client method. Technically we could maintain the API contract even if we convert a blocking request into a promise, and then wait ourselves, but that would mean that the `request()` and `send()` methods in the HTTP client wouldn't be used, even when the calling code is completely blocking.