### PR TITLE
Store the user UID from tokens

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -24,6 +24,16 @@ class Token
     protected $lifetime;
 
     /**
+     * The full ID of the user, as a URL.
+     *
+     * While this properly belongs on a User, MPX returns it in the token as
+     * well, and many API calls need the account to be specified.
+     *
+     * @var string
+     */
+    protected $userId;
+
+    /**
      * The time this token was created. This is determined client-side.
      *
      * @var int
@@ -33,15 +43,17 @@ class Token
     /**
      * Construct a new authentication token for a user.
      *
+     * @param string $userId   The full user ID as a URL.
      * @param string $value    The value of the authentication token as returned by MPX.
      * @param int    $lifetime The number of seconds the token is valid for.
      */
-    public function __construct($value, $lifetime)
+    public function __construct(string $userId, string $value, int $lifetime)
     {
         if ($lifetime <= 0) {
             throw new \InvalidArgumentException('$lifetime must be greater than zero.');
         }
 
+        $this->userId = $userId;
         $this->value = $value;
         $this->lifetime = $lifetime;
         $this->created = time();
@@ -61,7 +73,7 @@ class Token
         // @todo fix this as idle != duration.
         // @todo We need to store the date this token was created.
         $lifetime = (int) floor(min($data['signInResponse']['duration'], $data['signInResponse']['idleTimeout']) / 1000);
-        $token = new self($data['signInResponse']['token'], $lifetime);
+        $token = new self($data['signInResponse']['userId'], $data['signInResponse']['token'], $lifetime);
 
         return $token;
     }
@@ -119,5 +131,13 @@ class Token
     public function getCreated(): int
     {
         return $this->created;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserId(): string
+    {
+        return $this->userId;
     }
 }

--- a/src/UserSession.php
+++ b/src/UserSession.php
@@ -227,8 +227,9 @@ class UserSession implements ClientInterface
         if (!isset($options['query'])) {
             $options['query'] = [];
         }
+        $token = $this->acquireToken(null, $reset);
         $options['query'] += [
-            'token' => $this->acquireToken(null, $reset)->getValue(),
+            'token' => $token->getValue(),
         ];
 
         return $options;

--- a/tests/src/Unit/TokenCachePoolTest.php
+++ b/tests/src/Unit/TokenCachePoolTest.php
@@ -29,7 +29,7 @@ class TokenCachePoolTest extends TestCase
     public function setUp()
     {
         $this->user = new User('username', 'password');
-        $this->token = new Token('value', time() + 60);
+        $this->token = new Token('https://example.com/idm/data/User/mpx/123456', 'value', time() + 60);
     }
 
     /**
@@ -53,7 +53,7 @@ class TokenCachePoolTest extends TestCase
      */
     public function testExpiresToken()
     {
-        $token = new Token('value', 1);
+        $token = new Token('https://example.com/idm/data/User/mpx/123456', 'value', 1);
         $cache = new TokenCachePool(new ArrayCachePool());
         $cache->setToken($this->user, $token);
         sleep(1);

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -90,20 +90,6 @@ class TokenTest extends TestCase
     }
 
     /**
-     * Test parsing a response array into a Token.
-     *
-     * @covers ::fromResponse
-     */
-    public function testFromResponse()
-    {
-        $response = new JsonResponse(200, [], 'signin-success.json');
-        $token = Token::fromResponse(json_decode($response->getBody(), true));
-        $this->assertEquals('TOKEN-VALUE', $token->getValue());
-        $this->assertEquals(14400, $token->getLifetime());
-        $this->assertEquals('https://identity.auth.theplatform.com/idm/data/User/mpx/1', $token->getUserId());
-    }
-
-    /**
      * Test creating a token from an MPX response.
      *
      * @covers ::fromResponseData

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -2,7 +2,6 @@
 
 namespace Lullabot\Mpx\Tests\Unit;
 
-use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Token;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Lullabot\Mpx\Tests\Unit;
 
+use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Token;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class TokenTest extends TestCase
     public function testToken()
     {
         $time = time();
-        $token = new Token('value', 30);
+        $token = new Token('https://example.com/idm/data/User/mpx/123456', 'value', 30);
         $this->assertSame('value', (string) $token);
         $this->assertSame('value', $token->getValue());
         $this->assertSame(30, $token->getLifetime());
@@ -41,12 +42,12 @@ class TokenTest extends TestCase
         $this->assertFalse($token->isValid(60));
 
         // Test that a token expires after passing time.
-        $token = new Token('value', 1);
+        $token = new Token('https://example.com/idm/data/User/mpx/123456', 'value', 1);
         $this->assertTrue($token->isValid());
         sleep(1);
         $this->assertFalse($token->isValid());
 
-        $token = new Token('value', 59);
+        $token = new Token('https://identity.auth.theplatform.com/idm/data/User/mpx/2685072', 'value', 59);
         $this->assertTrue($token->isValid());
         $this->assertTrue($token->isValid(30));
         $this->assertFalse($token->isValid(60));
@@ -61,6 +62,44 @@ class TokenTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$lifetime must be greater than zero.');
-        new Token('value', 0);
+        new Token('https://identity.auth.theplatform.com/idm/data/User/mpx/2685072', 'value', 0);
+    }
+
+    /**
+     * Test getting the full User ID.
+     *
+     * @covers ::__construct
+     * @covers ::getUserId
+     */
+    public function testGetUserId()
+    {
+        $userId = 'https://identity.auth.theplatform.com/idm/data/User/mpx/2685072';
+        $token = new Token($userId, 'value', 59);
+        $this->assertEquals($userId, $token->getUserId());
+    }
+
+    /**
+     * Test that created is a timestamp.
+     *
+     * @covers ::getCreated
+     */
+    public function testCreated()
+    {
+        $token = new Token('https://identity.auth.theplatform.com/idm/data/User/mpx/2685072', 'value', 59);
+        $this->assertInternalType('integer', $token->getCreated());
+    }
+
+    /**
+     * Test parsing a response array into a Token.
+     *
+     * @covers ::fromResponse
+     */
+    public function testFromResponse()
+    {
+        $response = new JsonResponse(200, [], 'signin-success.json');
+        $token = Token::fromResponse(json_decode($response->getBody(), true));
+        $this->assertEquals('TOKEN-VALUE', $token->getValue());
+        $this->assertEquals(14400, $token->getLifetime());
+        $this->assertEquals('https://identity.auth.theplatform.com/idm/data/User/mpx/1', $token->getUserId());
     }
 }


### PR DESCRIPTION
This depends on #22 . By storing this ID, we save future work from having to do a second call to load a user account, as most account context filters are by the full user ID and not the user name.