### PR TITLE
Implement annotations for Media and Accounts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,8 @@
       "Lullabot\\Mpx\\Tests\\": "tests/src/",
       "Lullabot\\Mpx\\Command\\": "command/src/"
     }
+  },
+  "extra": {
+    "composer-version": "^1.6.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "psr/log": "^1.0",
     "cache/cache": "^1.0",
     "symfony/serializer": "^3.4",
-    "symfony/property-access": "^3.4"
+    "symfony/property-access": "^3.4",
+    "doctrine/annotations": "^1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",

--- a/src/CreateKeyInterface.php
+++ b/src/CreateKeyInterface.php
@@ -11,6 +11,8 @@ use Psr\Http\Message\UriInterface;
  * create request, instead of creating a new object.
  *
  * @see https://docs.theplatform.com/help/wsf-creating-or-updating-data-objects-using-create-keys
+ *
+ * @todo Move to the annotation and convert to CustomKeyInterface.
  */
 interface CreateKeyInterface
 {

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -129,7 +129,7 @@ class Account
     protected $version;
 
     /**
-     * Returns The date and time that this object was created.
+     * Returns the date and time that this object was created.
      *
      * @return \DateTime
      */
@@ -139,7 +139,7 @@ class Account
     }
 
     /**
-     * Set The date and time that this object was created.
+     * Set the date and time that this object was created.
      *
      * @param \DateTime
      */
@@ -149,7 +149,7 @@ class Account
     }
 
     /**
-     * Returns The id of the user that created this object.
+     * Returns the id of the user that created this object.
      *
      * @return \Psr\Http\Message\UriInterface
      */
@@ -159,7 +159,7 @@ class Account
     }
 
     /**
-     * Set The id of the user that created this object.
+     * Set the id of the user that created this object.
      *
      * @param \Psr\Http\Message\UriInterface
      */
@@ -169,7 +169,7 @@ class Account
     }
 
     /**
-     * Returns The description of this object.
+     * Returns the description of this object.
      *
      * @return string
      */
@@ -179,7 +179,7 @@ class Account
     }
 
     /**
-     * Set The description of this object.
+     * Set the description of this object.
      *
      * @param string
      */
@@ -209,7 +209,7 @@ class Account
     }
 
     /**
-     * Returns The id field values of the Role objects that define the domains, or service instances, that this account is permitted to use.
+     * Returns the id field values of the Role objects that define the domains, or service instances, that this account is permitted to use.
      *
      * @return \Psr\Http\Message\UriInterface[]
      */
@@ -219,7 +219,7 @@ class Account
     }
 
     /**
-     * Set The id field values of the Role objects that define the domains, or service instances, that this account is permitted to use.
+     * Set the id field values of the Role objects that define the domains, or service instances, that this account is permitted to use.
      *
      * @param \Psr\Http\Message\UriInterface[]
      */
@@ -229,7 +229,7 @@ class Account
     }
 
     /**
-     * Returns The id field values of the Role objects that define the features, or service types, that this account is permitted to use.
+     * Returns the id field values of the Role objects that define the features, or service types, that this account is permitted to use.
      *
      * @return \Psr\Http\Message\UriInterface[]
      */
@@ -239,7 +239,7 @@ class Account
     }
 
     /**
-     * Set The id field values of the Role objects that define the features, or service types, that this account is permitted to use.
+     * Set the id field values of the Role objects that define the features, or service types, that this account is permitted to use.
      *
      * @param \Psr\Http\Message\UriInterface[]
      */
@@ -269,7 +269,7 @@ class Account
     }
 
     /**
-     * Returns The globally unique URI of this object.
+     * Returns the globally unique URI of this object.
      *
      * @return \Psr\Http\Message\UriInterface
      */
@@ -279,7 +279,7 @@ class Account
     }
 
     /**
-     * Set The globally unique URI of this object.
+     * Set the globally unique URI of this object.
      *
      * @param \Psr\Http\Message\UriInterface|string
      */
@@ -312,7 +312,7 @@ class Account
     }
 
     /**
-     * Returns The id of the account that owns this account.
+     * Returns the id of the account that owns this account.
      *
      * @return \Psr\Http\Message\UriInterface
      */
@@ -322,7 +322,7 @@ class Account
     }
 
     /**
-     * Set The id of the account that owns this account.
+     * Set the id of the account that owns this account.
      *
      * @param \Psr\Http\Message\UriInterface
      */
@@ -358,7 +358,7 @@ class Account
     }
 
     /**
-     * Returns The account's region.
+     * Returns the account's region.
      *
      * @return string
      */
@@ -368,7 +368,7 @@ class Account
     }
 
     /**
-     * Set The account's region.
+     * Set the account's region.
      *
      * @param string
      */
@@ -378,7 +378,7 @@ class Account
     }
 
     /**
-     * Returns The name of this object.
+     * Returns the title of this object.
      *
      * @return string
      */
@@ -388,7 +388,7 @@ class Account
     }
 
     /**
-     * Set The name of this object.
+     * Set the title of this object.
      *
      * @param string
      */
@@ -405,7 +405,7 @@ class Account
     }
 
     /**
-     * Returns The date and time this object was last modified.
+     * Returns the date and time this object was last modified.
      *
      * @return \DateTime
      */
@@ -415,7 +415,7 @@ class Account
     }
 
     /**
-     * Set The date and time this object was last modified.
+     * Set the date and time this object was last modified.
      *
      * @param \DateTime
      */
@@ -425,7 +425,7 @@ class Account
     }
 
     /**
-     * Returns The id of the user that last modified this object.
+     * Returns the id of the user that last modified this object.
      *
      * @return \Psr\Http\Message\UriInterface
      */
@@ -435,7 +435,7 @@ class Account
     }
 
     /**
-     * Set The id of the user that last modified this object.
+     * Set the id of the user that last modified this object.
      *
      * @param \Psr\Http\Message\UriInterface
      */
@@ -445,7 +445,7 @@ class Account
     }
 
     /**
-     * Returns This object's modification version.
+     * Returns this object's modification version.
      *
      * @return int
      */
@@ -455,7 +455,7 @@ class Account
     }
 
     /**
-     * Set This object's modification version.
+     * Set this object's modification version.
      *
      * @param int
      */

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lullabot\Mpx\DataService\Account;
+namespace Lullabot\Mpx\DataService\Access;
 
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;

--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Annotation;
+
+/**
+ * @Annotation
+ *
+ * Each MPX data service exposes one or more objects. We require annotations
+ * on object implementations so calling code can discover what services are
+ * currently implemented. In general, there should only be one implementation
+ * of a given (path, service, schema) triple.
+ *
+ * @todo Use symfony validation to assert requirements.
+ * @todo Mark the required values with @Required
+ * @todo Rename to DataServiceObject
+ * @todo Can we infer /data/ from path and assume it's always consistent?
+ *
+ * @see http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html
+ */
+class DataService
+{
+    /**
+     * The name of the service, such as 'Media Data Service'.
+     *
+     * @var string
+     */
+    public $service;
+
+    /**
+     * The relative path of the data service, such as '/data/Media'.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * The schema version this class implements, such as '1.10'.
+     *
+     * @var string
+     */
+    public $schemaVersion;
+
+    /**
+     * If the service supports an account context.
+     *
+     * @todo Should this be optional with a default to false?
+     *
+     * @var bool
+     */
+    public $hasAccountContext;
+
+    /**
+     * The base URI of the service, for when the service registry cannot be used.
+     *
+     * @var string
+     */
+    public $baseUri;
+
+    /**
+     * Return the service of the data object, such as 'Media Data Service'.
+     *
+     * @return string
+     */
+    public function getService(): string
+    {
+        return $this->service;
+    }
+
+    /**
+     * Return the relative path of the data service, such as '/data/Media'.
+     *
+     * @see https://docs.theplatform.com/help/wsf-how-to-find-the-url-of-a-service-in-the-service-registry
+     *
+     * @return string
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Return the schema version this class implements, such as '1.10'.
+     *
+     * @return string
+     */
+    public function getSchemaVersion(): string
+    {
+        return $this->schemaVersion;
+    }
+
+    /**
+     * Return if the service supports an account context.
+     *
+     * @return bool
+     */
+    public function isHasAccountContext(): bool
+    {
+        return $this->hasAccountContext;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBaseUri(): string
+    {
+        return !empty($this->baseUri) ? $this->baseUri : '';
+    }
+
+    public function hasBaseUri(): bool
+    {
+        return (bool) $this->baseUri;
+    }
+}

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\Service\AccessManagement\ResolveDomain;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Factory to construct new data service objects from MPX.
+ *
+ * @todo link to generic upstream docs.
+ */
+class DataObjectFactory
+{
+    /**
+     * The resolver for MPX services.
+     *
+     * @var \Lullabot\Mpx\Service\AccessManagement\ResolveDomain
+     */
+    protected $resolveDomain;
+
+    /**
+     * The class and annotation to load data objects into.
+     *
+     * @var array
+     */
+    protected $description;
+
+    /**
+     * The user session to use when loading from MPX.
+     *
+     * @var \Lullabot\Mpx\Service\IdentityManagement\UserSession
+     */
+    protected $userSession;
+
+    /**
+     * The manager used to load implementation classes of data objects.
+     *
+     * @var \Lullabot\Mpx\DataService\DataServiceManager
+     */
+    protected $manager;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * DataObjectFactory constructor.
+     *
+     * @todo Merge manager and service parameters?
+     * @todo Inject the resolveDomain() instead of constructing?
+     *
+     * @param \Lullabot\Mpx\DataService\DataServiceManager         $manager
+     * @param \Lullabot\Mpx\Service\IdentityManagement\UserSession $userSession
+     * @param string                                               $service
+     */
+    public function __construct(DataServiceManager $manager, UserSession $userSession, string $service, string $path)
+    {
+        $this->userSession = $userSession;
+        $this->resolveDomain = new ResolveDomain($this->userSession);
+        $this->manager = $manager;
+        $this->description = $manager->getDataService($service, $path);
+        $this->path = $path;
+    }
+
+    /**
+     * Load a data object from MPX, returning a promise to it.
+     *
+     * @todo Add a load that takes a full URL?
+     *
+     * @param int                                      $id      The numeric ID to load.
+     * @param \Lullabot\Mpx\DataService\Access\Account $account
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    public function load(int $id, Account $account = null)
+    {
+        /** @var \Lullabot\Mpx\DataService\Annotation\DataService $annotation */
+        $annotation = $this->description['annotation'];
+
+        // Accounts are optional as you need to be able to load an account
+        // before you can resolve services.
+        // @todo Can we do this by calling ResolveAllUrls?
+        if (!($base = $annotation->getBaseUri())) {
+            $resolved = $this->resolveDomain->resolve($account);
+            $base = $resolved->getUrl($annotation->getService()).$annotation->getPath();
+        }
+        $uri = $base.'/'.$id;
+
+        $options = [
+            'query' => [
+                'schema' => $annotation->getSchemaVersion(),
+                'form' => 'cjson',
+            ],
+        ];
+
+        $response = $this->userSession->requestAsync('GET', $uri, $options)->then(function (ResponseInterface $response) {
+            return $this->deserialize($this->description['class'], $response->getBody());
+        });
+
+        return $response;
+    }
+
+    /**
+     * Deserialize a JSON string into a class.
+     *
+     * @todo Inject the serializer in the constructor?
+     *
+     * @param string $class The full class name to create.
+     * @param string $data  The JSON string to deserialize.
+     *
+     * @return object
+     */
+    public function deserialize(string $class, $data)
+    {
+        $encoders = [new JsonEncoder()];
+        $normalizers = [new ObjectNormalizer()];
+        $serializer = new Serializer($normalizers, $encoders);
+
+        return $serializer->deserialize($data, $class, 'json');
+    }
+}

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Doctrine\Common\Annotations\Reader;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Class to discover Data Service implementations.
+ */
+class DataServiceDiscovery
+{
+    /**
+     * The namespace to search within, such as '\Lullabot\Mpx'.
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * The root directory of the namespace, such as 'src'.
+     *
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * The class to use for reading annotations.
+     *
+     * @var \Doctrine\Common\Annotations\Reader
+     */
+    private $annotationReader;
+
+    /**
+     * The root directory to discover from, containing the namespace directory.
+     *
+     * @var string
+     */
+    private $rootDir;
+
+    /**
+     * The array of discovered data services.
+     *
+     * @var array
+     */
+    private $dataServices = [];
+
+    /**
+     * DataServiceDiscovery constructor.
+     *
+     * @param string $namespace The namespace of the plugins.
+     * @param string $directory The directory of the plugins.
+     * @param $rootDir
+     * @param \Doctrine\Common\Annotations\Reader $annotationReader
+     */
+    public function __construct($namespace, $directory, $rootDir, Reader $annotationReader)
+    {
+        $this->namespace = $namespace;
+        $this->annotationReader = $annotationReader;
+        $this->directory = $directory;
+        $this->rootDir = $rootDir;
+    }
+
+    /**
+     * Returns all the data services.
+     */
+    public function getDataServices()
+    {
+        if (!$this->dataServices) {
+            $this->discoverDataServices();
+        }
+
+        return $this->dataServices;
+    }
+
+    /**
+     * Discovers data services.
+     *
+     * @todo Return a structured class?
+     */
+    private function discoverDataServices()
+    {
+        $path = $this->rootDir.'/'.$this->directory;
+        $finder = new Finder();
+        $finder->files()->in($path);
+
+        /** @var \Symfony\Component\Finder\SplFileInfo $file */
+        foreach ($finder as $file) {
+            $subnamespace = str_replace('/', '\\', $file->getRelativePath());
+            if (!empty($subnamespace)) {
+                $subnamespace .= '\\';
+            }
+            $class = $this->namespace.'\\'.$subnamespace.$file->getBasename('.php');
+            $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\DataService');
+            if (!$annotation) {
+                continue;
+            }
+
+            /* @var \Lullabot\Mpx\DataService\Annotation\DataService $annotation */
+            $this->dataServices[$annotation->getService()][$annotation->getPath()] = [
+                'class' => $class,
+                'annotation' => $annotation,
+            ];
+        }
+    }
+}

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+
+class DataServiceManager
+{
+    /**
+     * @var \Lullabot\Mpx\DataService\DataServiceDiscovery
+     */
+    private $discovery;
+
+    public function __construct(DataServiceDiscovery $discovery)
+    {
+        $this->discovery = $discovery;
+    }
+
+    /**
+     * Register our annotations, relative to this file.
+     *
+     * @return static
+     */
+    public static function basicDiscovery()
+    {
+        // @todo Check Drupal core for other tags to ignore?
+        AnnotationReader::addGlobalIgnoredName('class');
+        AnnotationRegistry::registerFile(__DIR__.'/Annotation/DataService.php');
+        $discovery = new DataServiceDiscovery('\\Lullabot\\Mpx', 'src', __DIR__.'/../..', new AnnotationReader());
+
+        return new static($discovery);
+    }
+
+    /**
+     * Returns a list of available data services.
+     *
+     * @return array
+     */
+    public function getDataServices()
+    {
+        return $this->discovery->getDataServices();
+    }
+
+    /**
+     * Returns one data service by service.
+     *
+     * @param string $name
+     * @param string $path
+     *
+     * @return array
+     */
+    public function getDataService(string $name, $path)
+    {
+        $services = $this->discovery->getDataServices();
+        if (isset($services[$name][$path])) {
+            return $services[$name][$path];
+        }
+
+        throw new \RuntimeException('Data service not found.');
+    }
+
+    /**
+     * Creates a data service.
+     *
+     * @param string $name
+     *
+     * @throws \RuntimeException
+     *
+     * @return object
+     */
+    public function create($name)
+    {
+        $services = $this->discovery->getDataServices();
+        if (array_key_exists($name, $services)) {
+            $class = $services[$name]['class'];
+            if (!class_exists($class)) {
+                throw new \RuntimeException('Data service class does not exist.');
+            }
+
+            return new $class();
+        }
+
+        throw new \RuntimeException('Data service does not exist.');
+    }
+}

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -3,12 +3,20 @@
 namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\CreateKeyInterface;
+use Lullabot\Mpx\DataService\Annotation\DataService;
 use Psr\Http\Message\UriInterface;
 
 /**
  * Implements the Media endpoint in the Media data service.
  *
  * @see https://docs.theplatform.com/help/media-media-object
+ *
+ * @DataService(
+ *   service="Media Data Service",
+ *   schemaVersion="1.10",
+ *   path="/data/Media",
+ *   hasAccountContext=true
+ * )
  */
 class Media implements CreateKeyInterface
 {

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -1,0 +1,1499 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Media;
+
+use Lullabot\Mpx\CreateKeyInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Implements the Media endpoint in the Media data service.
+ *
+ * @see https://docs.theplatform.com/help/media-media-object
+ */
+class Media implements CreateKeyInterface
+{
+    /**
+     * The id of the AdPolicy associated with this content.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $adPolicyId;
+
+    /**
+     * The date and time that this object was created.
+     *
+     * @var \DateTime
+     */
+    protected $added;
+
+    /**
+     * The id of the user that created this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $addedByUserId;
+
+    /**
+     * The administrative workflow tags for this object.
+     *
+     * @var string[]
+     */
+    protected $adminTags;
+
+    /**
+     * Whether this content is approved for playback.
+     *
+     * @var bool
+     */
+    protected $approved;
+
+    /**
+     * The creator of this content.
+     *
+     * @var string
+     */
+    protected $author;
+
+    /**
+     * A map that contains localized versions of this object's author value.
+     *
+     * @var array
+     */
+    protected $authorLocalized;
+
+    /**
+     * The computed availability of the media for playback.
+     *
+     * @var AvailabilityState
+     */
+    protected $availabilityState;
+
+    /**
+     * The playback availability tags for this media.
+     *
+     * @var string[]
+     */
+    protected $availabilityTags;
+
+    /**
+     * An array of distinct time frames that identify the playback availability for this media.
+     *
+     * @var AvailabilityWindow[]
+     */
+    protected $availabilityWindows;
+
+    /**
+     * The date that this content becomes available for playback.
+     *
+     * @var \DateTime
+     */
+    protected $availableDate;
+
+    /**
+     * The Category objects that this object is associated with, represented as CategoryInfo objects.
+     *
+     * @var CategoryInfo[]
+     */
+    protected $categories;
+
+    /**
+     * The id values of the Category objects that this object is associated with.
+     *
+     * @var \Psr\Http\Message\UriInterface[]
+     */
+    protected $categoryIds;
+
+    /**
+     * Chapter information for this content.
+     *
+     * @var Chapter[]
+     */
+    protected $chapters;
+
+    /**
+     * The content MediaFile objects that this object is associated with.
+     *
+     * @var MediaFile[]
+     */
+    //protected $content;
+
+    /**
+     * The copyright holder of this content.
+     *
+     * @var string
+     */
+    protected $copyright;
+
+    /**
+     * A map that contains localized versions of this object's copyright value.
+     *
+     * @var array
+     */
+    protected $copyrightLocalized;
+
+    /**
+     * The URL of a copyright statement or terms of use.
+     *
+     * @var string
+     */
+    protected $copyrightUrl;
+
+    /**
+     * A map that contains localized versions of this object's copyrightUrl value.
+     *
+     * @var array
+     */
+    protected $copyrightUrlLocalized;
+
+    /**
+     * The list of ISO 3166 country codes that geo-targeting restrictions apply to.
+     *
+     * @var string[]
+     */
+    protected $countries;
+
+    /**
+     * The creative credits for this content.
+     *
+     * @var Credit[]
+     */
+    protected $credits;
+
+    /**
+     * The streamingUrl of the default thumbnail for this Media.
+     *
+     * @var string
+     */
+    protected $defaultThumbnailUrl;
+
+    /**
+     * A description of this content.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * A map that contains localized versions of this object's description value.
+     *
+     * @var array
+     */
+    protected $descriptionLocalized;
+
+    /**
+     * Whether the specified countries are excluded from playing this content.
+     *
+     * @var bool
+     */
+    protected $excludeCountries;
+
+    /**
+     * The date that this content expires and is no longer available for playback.
+     *
+     * @var \DateTime
+     */
+    protected $expirationDate;
+
+    /**
+     * Reserved for future use.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $fileSourceMediaId;
+
+    /**
+     * An alternate identifier for this object that is unique within the owning account.
+     *
+     * @var string
+     */
+    protected $guid;
+
+    /**
+     * The globally unique URI of this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $id;
+
+    /**
+     * A list of internal keywords that describe this content.
+     *
+     * @var string
+     */
+    protected $keywords;
+
+    /**
+     * A map that contains localized versions of this object's keywords value.
+     *
+     * @var array
+     */
+    protected $keywordsLocalized;
+
+    /**
+     * A link to additional information related to this content.
+     *
+     * @var string
+     */
+    protected $link;
+
+    /**
+     * A map that contains localized versions of this object's link value.
+     *
+     * @var array
+     */
+    protected $linkLocalized;
+
+    /**
+     * Whether this object currently allows updates.
+     *
+     * @var bool
+     */
+    protected $locked;
+
+    /**
+     * The id values of the source Media objects that were shared to create this Media.
+     *
+     * @var \Psr\Http\Message\UriInterface[]
+     */
+    protected $originalMediaIds;
+
+    /**
+     * The id values of the accounts that shared this Media.
+     *
+     * @var \Psr\Http\Message\UriInterface[]
+     */
+    protected $originalOwnerIds;
+
+    /**
+     * The id of the account that owns this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $ownerId;
+
+    /**
+     * The globally unique public identifier for this media.
+     *
+     * @var string
+     */
+    protected $pid;
+
+    /**
+     * The ID of the Program that represents this media. The GUID URI is recommended.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $programId;
+
+    /**
+     * The title of the Provider that represents the account that shared this Media.
+     *
+     * @var string
+     */
+    protected $provider;
+
+    /**
+     * The id of the Provider that represents the account that shared this Media.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $providerId;
+
+    /**
+     * The original release date or airdate of this Media object's content.
+     *
+     * @var \DateTime
+     */
+    protected $pubDate;
+
+    /**
+     * The public URL for this media.
+     *
+     * @var string
+     */
+    protected $publicUrl;
+
+    /**
+     * The advisory ratings associated with this content.
+     *
+     * @var Rating[]
+     */
+    protected $ratings;
+
+    /**
+     * The id of the Restriction associated with this content.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $restrictionId;
+
+    /**
+     * The ID of the Program that represents the series to which this media belongs. The GUID URI is recommended.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $seriesId;
+
+    /**
+     * Text associated with this content.
+     *
+     * @var string
+     */
+    protected $text;
+
+    /**
+     * A map that contains localized versions of this object's text value.
+     *
+     * @var array
+     */
+    protected $textLocalized;
+
+    /**
+     * The thumbnail MediaFile objects that this object is associated with.
+     *
+     * @var MediaFile[]
+     */
+    protected $thumbnails;
+
+    /**
+     * The name of this object.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * A map that contains localized versions of this object's title value.
+     *
+     * @var array
+     */
+    protected $titleLocalized;
+
+    /**
+     * The date and time this object was last modified.
+     *
+     * @var \DateTime
+     */
+    protected $updated;
+
+    /**
+     * The id of the user that last modified this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $updatedByUserId;
+
+    /**
+     * This object's modification version, used for optimistic locking.
+     *
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * Returns the id of the AdPolicy associated with this content.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAdPolicyId(): UriInterface
+    {
+        return $this->adPolicyId;
+    }
+
+    /**
+     * Set the id of the AdPolicy associated with this content.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAdPolicyId($adPolicyId)
+    {
+        $this->adPolicyId = $adPolicyId;
+    }
+
+    /**
+     * Returns the date and time that this object was created.
+     *
+     * @return \DateTime
+     */
+    public function getAdded(): \DateTime
+    {
+        return $this->added;
+    }
+
+    /**
+     * Set the date and time that this object was created.
+     *
+     * @param \DateTime
+     */
+    public function setAdded($added)
+    {
+        $this->added = $added;
+    }
+
+    /**
+     * Returns the id of the user that created this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAddedByUserId(): UriInterface
+    {
+        return $this->addedByUserId;
+    }
+
+    /**
+     * Set the id of the user that created this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAddedByUserId($addedByUserId)
+    {
+        $this->addedByUserId = $addedByUserId;
+    }
+
+    /**
+     * Returns the administrative workflow tags for this object.
+     *
+     * @return string[]
+     */
+    public function getAdminTags(): array
+    {
+        return $this->adminTags;
+    }
+
+    /**
+     * Set the administrative workflow tags for this object.
+     *
+     * @param string[]
+     */
+    public function setAdminTags($adminTags)
+    {
+        $this->adminTags = $adminTags;
+    }
+
+    /**
+     * Returns Whether this content is approved for playback.
+     *
+     * @return bool
+     */
+    public function getApproved(): \boolean
+    {
+        return $this->approved;
+    }
+
+    /**
+     * Set Whether this content is approved for playback.
+     *
+     * @param bool
+     */
+    public function setApproved($approved)
+    {
+        $this->approved = $approved;
+    }
+
+    /**
+     * Returns the creator of this content.
+     *
+     * @return string
+     */
+    public function getAuthor(): string
+    {
+        return $this->author;
+    }
+
+    /**
+     * Set the creator of this content.
+     *
+     * @param string
+     */
+    public function setAuthor($author)
+    {
+        $this->author = $author;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's author value.
+     *
+     * @return array
+     */
+    public function getAuthorLocalized(): array
+    {
+        return $this->authorLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's author value.
+     *
+     * @param array
+     */
+    public function setAuthorLocalized($authorLocalized)
+    {
+        $this->authorLocalized = $authorLocalized;
+    }
+
+    /**
+     * Returns the computed availability of the media for playback.
+     *
+     * @return AvailabilityState
+     */
+    public function getAvailabilityState(): \AvailabilityState
+    {
+        return $this->availabilityState;
+    }
+
+    /**
+     * Set the computed availability of the media for playback.
+     *
+     * @param AvailabilityState
+     */
+    public function setAvailabilityState($availabilityState)
+    {
+        $this->availabilityState = $availabilityState;
+    }
+
+    /**
+     * Returns the playback availability tags for this media.
+     *
+     * @return string[]
+     */
+    public function getAvailabilityTags(): array
+    {
+        return $this->availabilityTags;
+    }
+
+    /**
+     * Set the playback availability tags for this media.
+     *
+     * @param string[]
+     */
+    public function setAvailabilityTags($availabilityTags)
+    {
+        $this->availabilityTags = $availabilityTags;
+    }
+
+    /**
+     * Returns An array of distinct time frames that identify the playback availability for this media.
+     *
+     * @return AvailabilityWindow[]
+     */
+    public function getAvailabilityWindows(): array
+    {
+        return $this->availabilityWindows;
+    }
+
+    /**
+     * Set An array of distinct time frames that identify the playback availability for this media.
+     *
+     * @param AvailabilityWindow[]
+     */
+    public function setAvailabilityWindows($availabilityWindows)
+    {
+        $this->availabilityWindows = $availabilityWindows;
+    }
+
+    /**
+     * Returns the date that this content becomes available for playback.
+     *
+     * @return \DateTime
+     */
+    public function getAvailableDate(): \DateTime
+    {
+        return $this->availableDate;
+    }
+
+    /**
+     * Set the date that this content becomes available for playback.
+     *
+     * @param \DateTime
+     */
+    public function setAvailableDate($availableDate)
+    {
+        $this->availableDate = $availableDate;
+    }
+
+    /**
+     * Returns the Category objects that this object is associated with, represented as CategoryInfo objects.
+     *
+     * @return CategoryInfo[]
+     */
+    public function getCategories(): array
+    {
+        return $this->categories;
+    }
+
+    /**
+     * Set the Category objects that this object is associated with, represented as CategoryInfo objects.
+     *
+     * @param CategoryInfo[]
+     */
+    public function setCategories($categories)
+    {
+        $this->categories = $categories;
+    }
+
+    /**
+     * Returns the id values of the Category objects that this object is associated with.
+     *
+     * @return \Psr\Http\Message\UriInterface[]
+     */
+    public function getCategoryIds(): array
+    {
+        return $this->categoryIds;
+    }
+
+    /**
+     * Set the id values of the Category objects that this object is associated with.
+     *
+     * @param \Psr\Http\Message\UriInterface[]
+     */
+    public function setCategoryIds($categoryIds)
+    {
+        $this->categoryIds = $categoryIds;
+    }
+
+    /**
+     * Returns Chapter information for this content.
+     *
+     * @return Chapter[]
+     */
+    public function getChapters(): array
+    {
+        return $this->chapters;
+    }
+
+    /**
+     * Set Chapter information for this content.
+     *
+     * @param Chapter[]
+     */
+    public function setChapters($chapters)
+    {
+        $this->chapters = $chapters;
+    }
+
+    /**
+     * Returns the content MediaFile objects that this object is associated with.
+     *
+     * @return MediaFile[]
+     */
+    public function getContent(): array
+    {
+        return $this->content;
+    }
+
+    /**
+     * Set the content MediaFile objects that this object is associated with.
+     *
+     * @param MediaFile[]
+     */
+    public function setzContent($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Returns the copyright holder of this content.
+     *
+     * @return string
+     */
+    public function getCopyright(): string
+    {
+        return $this->copyright;
+    }
+
+    /**
+     * Set the copyright holder of this content.
+     *
+     * @param string
+     */
+    public function setCopyright($copyright)
+    {
+        $this->copyright = $copyright;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's copyright value.
+     *
+     * @return array
+     */
+    public function getCopyrightLocalized(): array
+    {
+        return $this->copyrightLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's copyright value.
+     *
+     * @param array
+     */
+    public function setCopyrightLocalized($copyrightLocalized)
+    {
+        $this->copyrightLocalized = $copyrightLocalized;
+    }
+
+    /**
+     * Returns the URL of a copyright statement or terms of use.
+     *
+     * @return string
+     */
+    public function getCopyrightUrl(): string
+    {
+        return $this->copyrightUrl;
+    }
+
+    /**
+     * Set the URL of a copyright statement or terms of use.
+     *
+     * @param string
+     */
+    public function setCopyrightUrl($copyrightUrl)
+    {
+        $this->copyrightUrl = $copyrightUrl;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's copyrightUrl value.
+     *
+     * @return array
+     */
+    public function getCopyrightUrlLocalized(): array
+    {
+        return $this->copyrightUrlLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's copyrightUrl value.
+     *
+     * @param array
+     */
+    public function setCopyrightUrlLocalized($copyrightUrlLocalized)
+    {
+        $this->copyrightUrlLocalized = $copyrightUrlLocalized;
+    }
+
+    /**
+     * Returns the list of ISO 3166 country codes that geo-targeting restrictions apply to.
+     *
+     * @return string[]
+     */
+    public function getCountries(): array
+    {
+        return $this->countries;
+    }
+
+    /**
+     * Set the list of ISO 3166 country codes that geo-targeting restrictions apply to.
+     *
+     * @param string[]
+     */
+    public function setCountries($countries)
+    {
+        $this->countries = $countries;
+    }
+
+    /**
+     * Returns the creative credits for this content.
+     *
+     * @return Credit[]
+     */
+    public function getCredits(): array
+    {
+        return $this->credits;
+    }
+
+    /**
+     * Set the creative credits for this content.
+     *
+     * @param Credit[]
+     */
+    public function setCredits($credits)
+    {
+        $this->credits = $credits;
+    }
+
+    /**
+     * Returns the streamingUrl of the default thumbnail for this Media.
+     *
+     * @return string
+     */
+    public function getDefaultThumbnailUrl(): string
+    {
+        return $this->defaultThumbnailUrl;
+    }
+
+    /**
+     * Set the streamingUrl of the default thumbnail for this Media.
+     *
+     * @param string
+     */
+    public function setDefaultThumbnailUrl($defaultThumbnailUrl)
+    {
+        $this->defaultThumbnailUrl = $defaultThumbnailUrl;
+    }
+
+    /**
+     * Returns A description of this content.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set A description of this content.
+     *
+     * @param string
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's description value.
+     *
+     * @return array
+     */
+    public function getDescriptionLocalized(): array
+    {
+        return $this->descriptionLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's description value.
+     *
+     * @param array
+     */
+    public function setDescriptionLocalized($descriptionLocalized)
+    {
+        $this->descriptionLocalized = $descriptionLocalized;
+    }
+
+    /**
+     * Returns Whether the specified countries are excluded from playing this content.
+     *
+     * @return bool
+     */
+    public function getExcludeCountries(): \boolean
+    {
+        return $this->excludeCountries;
+    }
+
+    /**
+     * Set Whether the specified countries are excluded from playing this content.
+     *
+     * @param bool
+     */
+    public function setExcludeCountries($excludeCountries)
+    {
+        $this->excludeCountries = $excludeCountries;
+    }
+
+    /**
+     * Returns the date that this content expires and is no longer available for playback.
+     *
+     * @return \DateTime
+     */
+    public function getExpirationDate(): \DateTime
+    {
+        return $this->expirationDate;
+    }
+
+    /**
+     * Set the date that this content expires and is no longer available for playback.
+     *
+     * @param \DateTime
+     */
+    public function setExpirationDate($expirationDate)
+    {
+        $this->expirationDate = $expirationDate;
+    }
+
+    /**
+     * Returns Reserved for future use.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getFileSourceMediaId(): UriInterface
+    {
+        return $this->fileSourceMediaId;
+    }
+
+    /**
+     * Set Reserved for future use.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setFileSourceMediaId($fileSourceMediaId)
+    {
+        $this->fileSourceMediaId = $fileSourceMediaId;
+    }
+
+    /**
+     * Returns An alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    /**
+     * Set An alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string
+     */
+    public function setGuid($guid)
+    {
+        $this->guid = $guid;
+    }
+
+    /**
+     * Returns the globally unique URI of this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getId(): UriInterface
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set the globally unique URI of this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Returns A list of internal keywords that describe this content.
+     *
+     * @return string
+     */
+    public function getKeywords(): string
+    {
+        return $this->keywords;
+    }
+
+    /**
+     * Set A list of internal keywords that describe this content.
+     *
+     * @param string
+     */
+    public function setKeywords($keywords)
+    {
+        $this->keywords = $keywords;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's keywords value.
+     *
+     * @return array
+     */
+    public function getKeywordsLocalized(): array
+    {
+        return $this->keywordsLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's keywords value.
+     *
+     * @param array
+     */
+    public function setKeywordsLocalized($keywordsLocalized)
+    {
+        $this->keywordsLocalized = $keywordsLocalized;
+    }
+
+    /**
+     * Returns A link to additional information related to this content.
+     *
+     * @return string
+     */
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    /**
+     * Set A link to additional information related to this content.
+     *
+     * @param string
+     */
+    public function setLink($link)
+    {
+        $this->link = $link;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's link value.
+     *
+     * @return array
+     */
+    public function getLinkLocalized(): array
+    {
+        return $this->linkLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's link value.
+     *
+     * @param array
+     */
+    public function setLinkLocalized($linkLocalized)
+    {
+        $this->linkLocalized = $linkLocalized;
+    }
+
+    /**
+     * Returns Whether this object currently allows updates.
+     *
+     * @return bool
+     */
+    public function getLocked(): \boolean
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Set Whether this object currently allows updates.
+     *
+     * @param bool
+     */
+    public function setLocked($locked)
+    {
+        $this->locked = $locked;
+    }
+
+    /**
+     * Returns the id values of the source Media objects that were shared to create this Media.
+     *
+     * @return \Psr\Http\Message\UriInterface[]
+     */
+    public function getOriginalMediaIds(): array
+    {
+        return $this->originalMediaIds;
+    }
+
+    /**
+     * Set the id values of the source Media objects that were shared to create this Media.
+     *
+     * @param \Psr\Http\Message\UriInterface[]
+     */
+    public function setOriginalMediaIds($originalMediaIds)
+    {
+        $this->originalMediaIds = $originalMediaIds;
+    }
+
+    /**
+     * Returns the id values of the accounts that shared this Media.
+     *
+     * @return \Psr\Http\Message\UriInterface[]
+     */
+    public function getOriginalOwnerIds(): array
+    {
+        return $this->originalOwnerIds;
+    }
+
+    /**
+     * Set the id values of the accounts that shared this Media.
+     *
+     * @param \Psr\Http\Message\UriInterface[]
+     */
+    public function setOriginalOwnerIds($originalOwnerIds)
+    {
+        $this->originalOwnerIds = $originalOwnerIds;
+    }
+
+    /**
+     * Returns the id of the account that owns this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getOwnerId(): UriInterface
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * Set the id of the account that owns this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setOwnerId($ownerId)
+    {
+        $this->ownerId = $ownerId;
+    }
+
+    /**
+     * Returns the globally unique public identifier for this media.
+     *
+     * @return string
+     */
+    public function getPid(): string
+    {
+        return $this->pid;
+    }
+
+    /**
+     * Set the globally unique public identifier for this media.
+     *
+     * @param string
+     */
+    public function setPid($pid)
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * Returns the ID of the Program that represents this media. The GUID URI is recommended.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getProgramId(): UriInterface
+    {
+        return $this->programId;
+    }
+
+    /**
+     * Set the ID of the Program that represents this media. The GUID URI is recommended.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setProgramId($programId)
+    {
+        $this->programId = $programId;
+    }
+
+    /**
+     * Returns the title of the Provider that represents the account that shared this Media.
+     *
+     * @return string
+     */
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Set the title of the Provider that represents the account that shared this Media.
+     *
+     * @param string
+     */
+    public function setProvider($provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Returns the id of the Provider that represents the account that shared this Media.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getProviderId(): UriInterface
+    {
+        return $this->providerId;
+    }
+
+    /**
+     * Set the id of the Provider that represents the account that shared this Media.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setProviderId($providerId)
+    {
+        $this->providerId = $providerId;
+    }
+
+    /**
+     * Returns the original release date or airdate of this Media object's content.
+     *
+     * @return \DateTime
+     */
+    public function getPubDate(): \DateTime
+    {
+        return $this->pubDate;
+    }
+
+    /**
+     * Set the original release date or airdate of this Media object's content.
+     *
+     * @param \DateTime
+     */
+    public function setPubDate($pubDate)
+    {
+        $this->pubDate = $pubDate;
+    }
+
+    /**
+     * Returns the public URL for this media.
+     *
+     * @return string
+     */
+    public function getPublicUrl(): string
+    {
+        return $this->publicUrl;
+    }
+
+    /**
+     * Set the public URL for this media.
+     *
+     * @param string
+     */
+    public function setPublicUrl($publicUrl)
+    {
+        $this->publicUrl = $publicUrl;
+    }
+
+    /**
+     * Returns the advisory ratings associated with this content.
+     *
+     * @return Rating[]
+     */
+    public function getRatings(): array
+    {
+        return $this->ratings;
+    }
+
+    /**
+     * Set the advisory ratings associated with this content.
+     *
+     * @param Rating[]
+     */
+    public function setRatings($ratings)
+    {
+        $this->ratings = $ratings;
+    }
+
+    /**
+     * Returns the id of the Restriction associated with this content.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getRestrictionId(): UriInterface
+    {
+        return $this->restrictionId;
+    }
+
+    /**
+     * Set the id of the Restriction associated with this content.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setRestrictionId($restrictionId)
+    {
+        $this->restrictionId = $restrictionId;
+    }
+
+    /**
+     * Returns the ID of the Program that represents the series to which this media belongs. The GUID URI is recommended.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getSeriesId(): UriInterface
+    {
+        return $this->seriesId;
+    }
+
+    /**
+     * Set the ID of the Program that represents the series to which this media belongs. The GUID URI is recommended.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setSeriesId($seriesId)
+    {
+        $this->seriesId = $seriesId;
+    }
+
+    /**
+     * Returns text associated with this content.
+     *
+     * @return string
+     */
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * Set text associated with this content.
+     *
+     * @param string
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's text value.
+     *
+     * @return array
+     */
+    public function getTextLocalized(): array
+    {
+        return $this->textLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's text value.
+     *
+     * @param array
+     */
+    public function setTextLocalized($textLocalized)
+    {
+        $this->textLocalized = $textLocalized;
+    }
+
+    /**
+     * Returns the thumbnail MediaFile objects that this object is associated with.
+     *
+     * @return MediaFile[]
+     */
+    public function getThumbnails(): array
+    {
+        return $this->thumbnails;
+    }
+
+    /**
+     * Set the thumbnail MediaFile objects that this object is associated with.
+     *
+     * @param MediaFile[]
+     */
+    public function setThumbnails($thumbnails)
+    {
+        $this->thumbnails = $thumbnails;
+    }
+
+    /**
+     * Returns the name of this object.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the name of this object.
+     *
+     * @param string
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Returns A map that contains localized versions of this object's title value.
+     *
+     * @return array
+     */
+    public function getTitleLocalized(): array
+    {
+        return $this->titleLocalized;
+    }
+
+    /**
+     * Set A map that contains localized versions of this object's title value.
+     *
+     * @param array
+     */
+    public function setTitleLocalized($titleLocalized)
+    {
+        $this->titleLocalized = $titleLocalized;
+    }
+
+    /**
+     * Returns the date and time this object was last modified.
+     *
+     * @return \DateTime
+     */
+    public function getUpdated(): \DateTime
+    {
+        return $this->updated;
+    }
+
+    /**
+     * Set the date and time this object was last modified.
+     *
+     * @param \DateTime
+     */
+    public function setUpdated($updated)
+    {
+        $this->updated = $updated;
+    }
+
+    /**
+     * Returns the id of the user that last modified this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getUpdatedByUserId(): UriInterface
+    {
+        return $this->updatedByUserId;
+    }
+
+    /**
+     * Set the id of the user that last modified this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setUpdatedByUserId($updatedByUserId)
+    {
+        $this->updatedByUserId = $updatedByUserId;
+    }
+
+    /**
+     * Returns this object's modification version, used for optimistic locking.
+     *
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * Set this object's modification version, used for optimistic locking.
+     *
+     * @param int
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdKey(): string
+    {
+        return 'id';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCompoundKeys(): array
+    {
+        return [
+            ['ownerId', 'guid'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomKeys(): array
+    {
+        // @todo Implement getCustomKeys() method.
+        return [];
+    }
+}

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -67,6 +67,14 @@ class ResolveAllUrls
         return $this->resolved;
     }
 
+    public function resolve(): string
+    {
+        // If multiple URLs are returned, any of them are usable, so we choose
+        // a random one.
+        // @todo Double check this assumption.
+        return $this->getResolved()[array_rand($this->getResolved())];
+    }
+
     /**
      * Return the service these URLs correspond to, such as 'Media Data Service'.
      *

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -31,9 +31,10 @@ class ResolveAllUrls
      * @todo Is there value in storing Responses in all classes?
      *
      * @param string $service
-     * @param array $data
+     * @param array  $data
      */
-    public function __construct(string $service, array $data) {
+    public function __construct(string $service, array $data)
+    {
         if (!isset($data['resolveAllUrlsResponse'])) {
             throw new \InvalidArgumentException();
         }
@@ -51,7 +52,7 @@ class ResolveAllUrls
             ],
         ];
 
-        return $userSession->requestAsync('GET', self::RESOLVE_ALL_URLS_URL, $options)->then(function(ResponseInterface $response) use ($service) {
+        return $userSession->requestAsync('GET', self::RESOLVE_ALL_URLS_URL, $options)->then(function (ResponseInterface $response) use ($service) {
             return new static($service, \GuzzleHttp\json_decode($response->getBody(), true));
         });
     }
@@ -61,7 +62,8 @@ class ResolveAllUrls
      *
      * @return string[]
      */
-    public function getResolved(): array {
+    public function getResolved(): array
+    {
         return $this->resolved;
     }
 
@@ -70,7 +72,8 @@ class ResolveAllUrls
      *
      * @return string
      */
-    public function getService(): string {
+    public function getService(): string
+    {
         return $this->service;
     }
 }

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Lullabot\Mpx\Service\AccessManagement;
+
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Psr\Http\Message\ResponseInterface;
+
+class ResolveAllUrls
+{
+    const SCHEMA_VERSION = '1.0';
+
+    const RESOLVE_ALL_URLS_URL = 'https://access.auth.theplatform.com/web/Registry/resolveAllUrls';
+
+    /**
+     * An array of resolved URLs for the service.
+     *
+     * @var array
+     */
+    protected $resolved;
+
+    /**
+     * The service these URLs correspond to, such as 'Media Data Service'.
+     *
+     * @var string
+     */
+    protected $service;
+
+    /**
+     * ResolveAllUrls constructor.
+     *
+     * @todo Is there value in storing Responses in all classes?
+     *
+     * @param string $service
+     * @param array $data
+     */
+    public function __construct(string $service, array $data) {
+        if (!isset($data['resolveAllUrlsResponse'])) {
+            throw new \InvalidArgumentException();
+        }
+
+        $this->resolved = $data['resolveAllUrlsResponse'];
+        $this->service = $service;
+    }
+
+    public static function load(UserSession $userSession, string $service)
+    {
+        $options = [
+            'query' => [
+                'schema' => static::SCHEMA_VERSION,
+                '_service' => $service,
+            ],
+        ];
+
+        return $userSession->requestAsync('GET', self::RESOLVE_ALL_URLS_URL, $options)->then(function(ResponseInterface $response) use ($service) {
+            return new static($service, \GuzzleHttp\json_decode($response->getBody(), true));
+        });
+    }
+
+    /**
+     * Return the resolved URLs for this service.
+     *
+     * @return string[]
+     */
+    public function getResolved(): array {
+        return $this->resolved;
+    }
+
+    /**
+     * Return the service these URLs correspond to, such as 'Media Data Service'.
+     *
+     * @return string
+     */
+    public function getService(): string {
+        return $this->service;
+    }
+}

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -2,7 +2,7 @@
 
 namespace Lullabot\Mpx\Service\AccessManagement;
 
-use Lullabot\Mpx\DataService\Account\Account;
+use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 
 class ResolveDomain
@@ -25,7 +25,7 @@ class ResolveDomain
     {
         $options = [
             'query' => [
-                'schema' => static::getSchemaVersion(),
+                'schema' => static::SCHEMA_VERSION,
                 '_accountId' => (string) $account->getId(),
                 'account' => (string) $account->getId(),
             ],

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lullabot\Mpx\Service\AccessManagement;
+
+use Lullabot\Mpx\DataService\Account\Account;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+
+class ResolveDomain
+{
+    const RESOLVE_DOMAIN_URL = 'https://access.auth.theplatform.com/web/Registry/resolveDomain';
+
+    const SCHEMA_VERSION = '1.0';
+
+    /**
+     * @var \Lullabot\Mpx\Service\IdentityManagement\UserSession
+     */
+    private $userSession;
+
+    public function __construct(UserSession $userSession)
+    {
+        $this->userSession = $userSession;
+    }
+
+    public function resolve(Account $account)
+    {
+        $options = [
+            'query' => [
+                'schema' => static::getSchemaVersion(),
+                '_accountId' => (string) $account->getId(),
+                'account' => (string) $account->getId(),
+            ],
+        ];
+
+        $data = \GuzzleHttp\json_decode($this->userSession->request('GET', static::RESOLVE_DOMAIN_URL, $options)->getBody(), true);
+
+        return new ResolveDomainResponse($data);
+    }
+}

--- a/src/Service/AccessManagement/ResolveDomainResponse.php
+++ b/src/Service/AccessManagement/ResolveDomainResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Lullabot\Mpx\Service\AccessManagement;
+
+class ResolveDomainResponse
+{
+    protected $resolved;
+
+    public function __construct(array $resolved)
+    {
+        $this->resolved = $resolved['resolveDomainResponse'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getResolved(): array
+    {
+        return $this->resolved;
+    }
+
+    public function getUrl(string $service): string
+    {
+        if (!isset($this->resolved[$service])) {
+            throw new \Exception();
+        }
+
+        return $this->resolved[$service];
+    }
+}


### PR DESCRIPTION
Depends on #42 .

This PR adds the proper annotations so we can load both accounts and media.

Testing instructions:

* You need your MPX username and password.
* You need an account ID.
* You need a media ID.

Place the following in the root of the repository as a PHP file like `test.php`:

```php
use Cache\Adapter\PHPArray\ArrayCachePool;
use Lullabot\Mpx\Client;
use Lullabot\Mpx\DataService\DataObjectFactory;
use Lullabot\Mpx\DataService\DataServiceManager;
use Lullabot\Mpx\Service\IdentityManagement\UserSession;
use Lullabot\Mpx\TokenCachePool;
use Lullabot\Mpx\User;
use Psr\Log\NullLogger;

require_once './vendor/autoload.php';

// Create a new MPX client with the default configuration.
$defaults = Client::getDefaultConfiguration();
$client = new Client(new GuzzleHttp\Client($defaults));

// Replace your username and password here. The username must begin with `mpx/`.
$user = new User('mpx/YOU@EXAMPLE.COM', 'secret');
$tokenCachePool = new TokenCachePool(new ArrayCachePool());
$session = new UserSession($client, $user, $tokenCachePool, new NullLogger());

// This registers the annotation loader. I suppose we could call this from DataObjectFactory to make it automatic?
$dataServiceManager = DataServiceManager::basicDiscovery();

$accountFactory = new DataObjectFactory($dataServiceManager, $session, 'Access Data Service', '/data/Account');

// Replace the ID with the account ID to load.
$account = $accountFactory->load(12345)
    ->wait();
print "The loaded account is:\n";
var_dump($account);

$mediaFactory = new DataObjectFactory($dataServiceManager, $session, 'Media Data Service', '/data/Media');

// Replace the ID to the media item to load. You can find it under "History -> ID" in the MPX console.
$media = $mediaFactory->load(12345, $account)
    ->wait();
print "The loaded media is:\n";
var_dump($media);
```