### PR TITLE
Media object tests

### DIFF
--- a/command/csv/player-object.csv
+++ b/command/csv/player-object.csv
@@ -1,0 +1,90 @@
+FIELD NAME,ATTRIBUTES,DATA TYPE,DESCRIPTION
+added,,DateTime,The date and time that this object was created
+addedByUserId,,URI,The id of the user that created this object
+adminTags,,String[],The administrative workflow tags for this object
+adPolicyId,,URI,the identifier for the advertising policy for this object
+allowEmail,,Boolean,Indicates whether the player will feature sharing via email
+allowEmbed,,Boolean,Indicates whether the player will provide an embed code for sharing on other sites
+allowFullScreen,,Boolean,Indicates whether the player will be allowed to play video in fullscreen mode
+allowGetLink,,Boolean,Indicates whether the player will make a shareable link available to users
+allowRss,,Boolean,Indicates whether the player will make an RSS link available to users
+allowSearch,,Boolean,Indicates whether to include the search component
+alwaysShowOverlay,,Boolean,Indicates whether the player should always display the play overlay
+aspectRatioHeight,,Integer,The value of the aspect ratio for the height of the media area
+aspectRatioWidth,,Integer,The value of the aspect ratio for the width of the media area
+autoPlay,,Boolean,Indicates whether the player will start playback on load
+autoInitialize,,Boolean,Indicates whether the player will self-initialize on load
+backgroundImageUrl,,String,URL for a custom background image
+colorSchemeId,,URI,Identifier for the color scheme assigned to this player
+columns,,Integer,The number of columns in the release list.
+compatibilityMode,,Boolean,Reserved for future use. The default value is false
+controlLayoutXml,,String,XML layout content for the player control rack
+controlRackHeight,,Integer,Height of the player control rack
+customCss,,String,Custom CSS content for the player
+customCssUrls,,String[],URLs to remote custom CSS content for the player
+customHtml,,String,Custom HTML content for the player (not currently used)
+customJavaScript,,String,Custom JavaScript content for the player
+customJavaScriptUrls,,String[],URLs to custom JavaScript content for the player
+customProperties,,"Map<String, String>",Additional attributes to include in the player HTML
+description,,String,The description of this object
+disabled,,Boolean,Whether is player is available for customer retrieval
+embedAdPolicyId,,URI,The identifier for the advertising policy to use when the player is embedded in another site
+embedAllowFullScreen,,Boolean,Indicates whether embedded players will be allowed to be viewed in fullscreen mode
+embedHeight,,Integer,The default height of the player when embedded in another site
+embedRestrictionId,,URI,The identifier for the restriction to apply to this player when embedded in another site
+embedWidth,,Integer,The default width of the player when embedded in another site
+enabledPlugIns,,PlugInInstance[],The set of plug-ins for this player
+enableExternalController,,Boolean,Indicates if the player responds to commands from an IFrame parent element
+endCardFeedUrl,,String,The URL of the feed that will populate the related items list end card
+failoverHtml,,String,The custom failover HTML
+fallbackPdk,,String,Reserved for future use. The default value is null.
+feedUrl,,String,The URL of the player's default feed
+feedUrlParams,,String,The request parameters to include in the feed request
+guid,,String,An alternate identifier for this object that is unique within the owning account
+headerImageHeight,,Integer,The height of the header image
+headerImageUrl,,String,The URL of the header image
+height,,Integer,The height of the player
+id,,URI,The globally unique URI of this object
+includeDefaultCss,,Boolean,Whether to include the default player CSS file in the player HTML page
+itemsPerPage,,Integer,The number of items to make visible in each page of the release list
+layoutId,,URI,The identifier for the layout assigned to this player
+limitToCategories,,String[],A list of categories that will appear in the category list
+linkUrl,,String,The destination URL for when a user clicks the player video area
+locked,,Boolean,Whether this object currently allows updates
+overlayImageUrl,,String,The URL of the player overlay image
+ownerId,,URI,The id of the account that owns this object
+paddingBottom,,Integer,The amount of padding to add to the bottom of the player host page
+paddingLeft,,Integer,The amount of padding to add to the left side of the player host page
+paddingRight,,Integer,The amount of padding to add to the right side of the player host page
+paddingTop,,Integer,The amount of padding to add to the top of the player host page
+pdk,,String,Reserved for future use. The default value is null.
+pid,,String,The public identifier for this player when requested through the Player Service
+playAll,,Boolean,Indicates if the player should automatically play the next release when one finishes
+playerUrl,,String,Player URL used in the sharing features
+posterImageDefaultHeight,,Integer,The default height to use for the poster image
+posterImageDefaultWidth,,Integer,The default width to use for the poster image
+posterImageMetaAssetType,,String,The meta asset type to use for the poster image
+posterImagePreviewAssetType,,String,The preview asset type to use for the poster image
+preferredFormats,,String[],The media formats meant for use in this player
+preferredRuntimes,,String[],The runtimes meant for use in the player
+regionHeights,,"Map<String, Integer>",Heights of the regions in the layout
+regionWidths,,"Map<String, Integer>",Widths of the regions in the layout
+releaseUrlParams,,String,URL parameters to add to Public URL requests
+restrictionId,,URI,The identifier of the restriction to apply to this player
+showAirDate,,Boolean,Indicates whether to display the air date in the release list component
+showAllChoice,,Boolean,Indicates whether to include the All option in the category list component
+showAuthor,,Boolean,Indicates whether to display the author in the release list and clip info components
+showBitrate,,Boolean,Indicates whether to display the media bitrate in the release list component
+showFullTime,,Boolean,Indicates whether to show the full video time in the player control rack
+showMostPopularChoice,,Boolean,Indicates whether to show the Most Popular option in the category list component
+showNav,,Boolean,Indicates whether to display the previous and next buttons in the player control rack
+shuffle,,Boolean,Indicates whether to randomize the contents of the release list
+skinId,,URI,Identifier for the skin object to apply this player
+thumbnailHeight,,Integer,The height of the thumbnail images in the release list
+thumbnailWidth,,Integer,The width of the thumbnail images in the release list
+title,,String,The name of this object
+updated,,DateTime,The date and time this object was last modified
+updatedByUserId,,URI,The id of the user that last modified this object
+useFloatingControls,,Boolean,Indicates whether to float the control rack over the media area of the player
+version,,Long,"This object's modification version, used for optimistic locking"
+width,,Integer,The width of the player

--- a/src/DataService/BaseDataTrait.php
+++ b/src/DataService/BaseDataTrait.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Trait to handle common properties to data across different services.
+ */
+trait BaseDataTrait
+{
+    use ConversionTrait;
+
+    /**
+     * The date and time that this object was created.
+     *
+     * @var \DateTime
+     */
+    protected $added;
+
+    /**
+     * The id of the user that created this object.
+     *
+     * @var UriInterface
+     */
+    protected $addedByUserId;
+
+    /**
+     * the identifier for the advertising policy for this object.
+     *
+     * @var UriInterface
+     */
+    protected $adPolicyId;
+
+    /**
+     * The globally unique URI of this object.
+     *
+     * @var UriInterface
+     */
+    protected $id;
+
+    /**
+     * The id of the account that owns this object.
+     *
+     * @var UriInterface
+     */
+    protected $ownerId;
+
+    /**
+     * Returns The date and time that this object was created.
+     *
+     * @return \DateTime
+     */
+    public function getAdded(): \DateTime
+    {
+        return $this->added;
+    }
+
+    /**
+     * Set The date and time that this object was created.
+     *
+     * @param \DateTime|int
+     */
+    public function setAdded($added)
+    {
+        $this->added = $this->convertDateTime($added);
+    }
+
+    /**
+     * Returns The id of the user that created this object.
+     *
+     * @return UriInterface
+     */
+    public function getAddedByUserId(): UriInterface
+    {
+        return $this->addedByUserId;
+    }
+
+    /**
+     * Set The id of the user that created this object.
+     *
+     * @param UriInterface|string
+     */
+    public function setAddedByUserId($addedByUserId)
+    {
+        $this->addedByUserId = $this->convertUri($addedByUserId);
+    }
+
+    /**
+     * Returns The globally unique URI of this object.
+     *
+     * @return UriInterface
+     */
+    public function getId(): UriInterface
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set The globally unique URI of this object.
+     *
+     * @param UriInterface
+     */
+    public function setId($id)
+    {
+        $this->id = $this->convertUri($id);
+    }
+
+    /**
+     * Returns The id of the account that owns this object.
+     *
+     * @return UriInterface
+     */
+    public function getOwnerId(): UriInterface
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * Set The id of the account that owns this object.
+     *
+     * @param UriInterface
+     */
+    public function setOwnerId($ownerId)
+    {
+        $this->ownerId = $this->convertUri($ownerId);
+    }
+}

--- a/src/DataService/ConversionTrait.php
+++ b/src/DataService/ConversionTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+trait ConversionTrait
+{
+    /**
+     * Convert a Unix timestamp in microseconds to a \DateTime, or returns an existing \DateTime.
+     *
+     * @param \DateTime|int $microseconds A date object, or the number of microseconds since the epoch.
+     *
+     * @return \DateTime The converted date.
+     */
+    protected function convertDateTime($microseconds): \DateTime
+    {
+        if (is_int($microseconds)) {
+            // It's simpler to treat the number a string, since we have to create from a format anyways.
+            $bySeconds = substr_replace($microseconds, '.', -3, 0);
+
+            return \DateTime::createFromFormat('U.u', $bySeconds);
+        }
+
+        return $microseconds;
+    }
+
+    /**
+     * Convert a string to a URI, if required.
+     *
+     * @param UriInterface|string $uri The URI to convert.
+     *
+     * @return UriInterface The converted URI.
+     */
+    protected function convertUri($uri): UriInterface
+    {
+        if (is_string($uri)) {
+            return new Uri($uri);
+        }
+
+        return $uri;
+    }
+}

--- a/src/DataService/ConversionTrait.php
+++ b/src/DataService/ConversionTrait.php
@@ -17,8 +17,9 @@ trait ConversionTrait
     protected function convertDateTime($microseconds): \DateTime
     {
         if (is_int($microseconds)) {
-            // It's simpler to treat the number a string, since we have to create from a format anyways.
-            $bySeconds = substr_replace($microseconds, '.', -3, 0);
+            $seconds = floor($microseconds / 1000);
+            $remainder = $microseconds % 1000;
+            $bySeconds = "$seconds.$remainder";
 
             return \DateTime::createFromFormat('U.u', $bySeconds);
         }

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -122,7 +122,7 @@ class DataObjectFactory
         // @todo This is a total hack as MPX returns JSON with null values. Replace by ommitting in the normalizer.
         $j = \GuzzleHttp\json_decode($data, true);
         array_filter($j, function ($value) {
-            return !is_null($value);
+            return null !== $value;
         });
         $data = json_encode($j);
         $encoders = [new JsonEncoder()];

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -119,6 +119,12 @@ class DataObjectFactory
      */
     public function deserialize(string $class, $data)
     {
+        // @todo This is a total hack as MPX returns JSON with null values. Replace by ommitting in the normalizer.
+        $j = \GuzzleHttp\json_decode($data, true);
+        array_filter($j, function ($value) {
+            return !is_null($value);
+        });
+        $data = json_encode($j);
         $encoders = [new JsonEncoder()];
         $normalizers = [new ObjectNormalizer()];
         $serializer = new Serializer($normalizers, $encoders);

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\CreateKeyInterface;
 use Lullabot\Mpx\DataService\Annotation\DataService;
+use Lullabot\Mpx\DataService\BaseDataTrait;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -20,26 +21,7 @@ use Psr\Http\Message\UriInterface;
  */
 class Media implements CreateKeyInterface
 {
-    /**
-     * The id of the AdPolicy associated with this content.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $adPolicyId;
-
-    /**
-     * The date and time that this object was created.
-     *
-     * @var \DateTime
-     */
-    protected $added;
-
-    /**
-     * The id of the user that created this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $addedByUserId;
+    use BaseDataTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -217,13 +199,6 @@ class Media implements CreateKeyInterface
     protected $guid;
 
     /**
-     * The globally unique URI of this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $id;
-
-    /**
      * A list of internal keywords that describe this content.
      *
      * @var string
@@ -271,13 +246,6 @@ class Media implements CreateKeyInterface
      * @var \Psr\Http\Message\UriInterface[]
      */
     protected $originalOwnerIds;
-
-    /**
-     * The id of the account that owns this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $ownerId;
 
     /**
      * The globally unique public identifier for this media.
@@ -411,51 +379,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the id of the AdPolicy associated with this content.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param \Psr\Http\Message\UriInterface|string
      */
     public function setAdPolicyId($adPolicyId)
     {
-        $this->adPolicyId = $adPolicyId;
-    }
-
-    /**
-     * Returns the date and time that this object was created.
-     *
-     * @return \DateTime
-     */
-    public function getAdded(): \DateTime
-    {
-        return $this->added;
-    }
-
-    /**
-     * Set the date and time that this object was created.
-     *
-     * @param \DateTime
-     */
-    public function setAdded($added)
-    {
-        $this->added = $added;
-    }
-
-    /**
-     * Returns the id of the user that created this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getAddedByUserId(): UriInterface
-    {
-        return $this->addedByUserId;
-    }
-
-    /**
-     * Set the id of the user that created this object.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setAddedByUserId($addedByUserId)
-    {
-        $this->addedByUserId = $addedByUserId;
+        $this->adPolicyId = $this->convertUri($adPolicyId);
     }
 
     /**
@@ -959,26 +887,6 @@ class Media implements CreateKeyInterface
     }
 
     /**
-     * Returns the globally unique URI of this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getId(): UriInterface
-    {
-        return $this->id;
-    }
-
-    /**
-     * Set the globally unique URI of this object.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
-    /**
      * Returns A list of internal keywords that describe this content.
      *
      * @return string
@@ -1116,26 +1024,6 @@ class Media implements CreateKeyInterface
     public function setOriginalOwnerIds($originalOwnerIds)
     {
         $this->originalOwnerIds = $originalOwnerIds;
-    }
-
-    /**
-     * Returns the id of the account that owns this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getOwnerId(): UriInterface
-    {
-        return $this->ownerId;
-    }
-
-    /**
-     * Set the id of the account that owns this object.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setOwnerId($ownerId)
-    {
-        $this->ownerId = $ownerId;
     }
 
     /**

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -411,7 +411,7 @@ class Media implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getApproved(): \boolean
+    public function getApproved(): bool
     {
         return $this->approved;
     }
@@ -471,7 +471,7 @@ class Media implements CreateKeyInterface
      *
      * @return AvailabilityState
      */
-    public function getAvailabilityState(): \AvailabilityState
+    public function getAvailabilityState()
     {
         return $this->availabilityState;
     }
@@ -539,11 +539,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the date that this content becomes available for playback.
      *
-     * @param \DateTime
+     * @param \DateTime|int
      */
     public function setAvailableDate($availableDate)
     {
-        $this->availableDate = $availableDate;
+        $this->availableDate = $this->convertDateTime($availableDate);
     }
 
     /**
@@ -811,7 +811,7 @@ class Media implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getExcludeCountries(): \boolean
+    public function getExcludeCountries(): bool
     {
         return $this->excludeCountries;
     }
@@ -839,11 +839,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the date that this content expires and is no longer available for playback.
      *
-     * @param \DateTime
+     * @param \DateTime|int
      */
     public function setExpirationDate($expirationDate)
     {
-        $this->expirationDate = $expirationDate;
+        $this->expirationDate = $this->convertDateTime($expirationDate);
     }
 
     /**
@@ -859,11 +859,11 @@ class Media implements CreateKeyInterface
     /**
      * Set Reserved for future use.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param \Psr\Http\Message\UriInterface|string
      */
     public function setFileSourceMediaId($fileSourceMediaId)
     {
-        $this->fileSourceMediaId = $fileSourceMediaId;
+        $this->fileSourceMediaId = $this->convertUri($fileSourceMediaId);
     }
 
     /**
@@ -971,7 +971,7 @@ class Media implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getLocked(): \boolean
+    public function getLocked(): bool
     {
         return $this->locked;
     }
@@ -1059,11 +1059,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the ID of the Program that represents this media. The GUID URI is recommended.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param \Psr\Http\Message\UriInterface|string
      */
     public function setProgramId($programId)
     {
-        $this->programId = $programId;
+        $this->programId = $this->convertUri($programId);
     }
 
     /**
@@ -1103,7 +1103,7 @@ class Media implements CreateKeyInterface
      */
     public function setProviderId($providerId)
     {
-        $this->providerId = $providerId;
+        $this->providerId = $this->convertUri($providerId);
     }
 
     /**
@@ -1119,11 +1119,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the original release date or airdate of this Media object's content.
      *
-     * @param \DateTime
+     * @param \DateTime|int
      */
     public function setPubDate($pubDate)
     {
-        $this->pubDate = $pubDate;
+        $this->pubDate = $this->convertDateTime($pubDate);
     }
 
     /**
@@ -1179,11 +1179,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the id of the Restriction associated with this content.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param \Psr\Http\Message\UriInterface|string
      */
     public function setRestrictionId($restrictionId)
     {
-        $this->restrictionId = $restrictionId;
+        $this->restrictionId = $this->convertUri($restrictionId);
     }
 
     /**
@@ -1199,11 +1199,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the ID of the Program that represents the series to which this media belongs. The GUID URI is recommended.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param \Psr\Http\Message\UriInterface|string
      */
     public function setSeriesId($seriesId)
     {
-        $this->seriesId = $seriesId;
+        $this->seriesId = $this->convertUri($seriesId);
     }
 
     /**
@@ -1319,11 +1319,11 @@ class Media implements CreateKeyInterface
     /**
      * Set the date and time this object was last modified.
      *
-     * @param \DateTime
+     * @param \DateTime|int
      */
     public function setUpdated($updated)
     {
-        $this->updated = $updated;
+        $this->updated = $this->convertDateTime($updated);
     }
 
     /**
@@ -1343,7 +1343,7 @@ class Media implements CreateKeyInterface
      */
     public function setUpdatedByUserId($updatedByUserId)
     {
-        $this->updatedByUserId = $updatedByUserId;
+        $this->updatedByUserId = $this->convertUri($updatedByUserId);
     }
 
     /**

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -3,7 +3,7 @@
 namespace Lullabot\Mpx\DataService\Player;
 
 use Lullabot\Mpx\CreateKeyInterface;
-use Lullabot\Mpx\DataService\ConversionTrait;
+use Lullabot\Mpx\DataService\BaseDataTrait;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -15,21 +15,7 @@ use Psr\Http\Message\UriInterface;
  */
 class Player implements CreateKeyInterface
 {
-    use ConversionTrait;
-
-    /**
-     * The date and time that this object was created.
-     *
-     * @var \DateTime
-     */
-    protected $added;
-
-    /**
-     * The id of the user that created this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $addedByUserId;
+    use BaseDataTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -37,13 +23,6 @@ class Player implements CreateKeyInterface
      * @var string[]
      */
     protected $adminTags;
-
-    /**
-     * the identifier for the advertising policy for this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $adPolicyId;
 
     /**
      * Indicates whether the player will feature sharing via email.
@@ -333,13 +312,6 @@ class Player implements CreateKeyInterface
     protected $height;
 
     /**
-     * The globally unique URI of this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $id;
-
-    /**
      * Whether to include the default player CSS file in the player HTML page.
      *
      * @var bool
@@ -387,13 +359,6 @@ class Player implements CreateKeyInterface
      * @var \Psr\Http\Message\UriInterface
      */
     protected $overlayImageUrl;
-
-    /**
-     * The id of the account that owns this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $ownerId;
 
     /**
      * The amount of padding to add to the bottom of the player host page.
@@ -639,46 +604,6 @@ class Player implements CreateKeyInterface
      * @var int
      */
     protected $width;
-
-    /**
-     * Returns The date and time that this object was created.
-     *
-     * @return \DateTime
-     */
-    public function getAdded(): \DateTime
-    {
-        return $this->added;
-    }
-
-    /**
-     * Set The date and time that this object was created.
-     *
-     * @param \DateTime|int
-     */
-    public function setAdded($added)
-    {
-        $this->added = $this->convertDateTime($added);
-    }
-
-    /**
-     * Returns The id of the user that created this object.
-     *
-     * @return UriInterface
-     */
-    public function getAddedByUserId(): UriInterface
-    {
-        return $this->addedByUserId;
-    }
-
-    /**
-     * Set The id of the user that created this object.
-     *
-     * @param UriInterface|string
-     */
-    public function setAddedByUserId($addedByUserId)
-    {
-        $this->addedByUserId = $this->convertUri($addedByUserId);
-    }
 
     /**
      * Returns The administrative workflow tags for this object.
@@ -1541,26 +1466,6 @@ class Player implements CreateKeyInterface
     }
 
     /**
-     * Returns The globally unique URI of this object.
-     *
-     * @return UriInterface
-     */
-    public function getId(): UriInterface
-    {
-        return $this->id;
-    }
-
-    /**
-     * Set The globally unique URI of this object.
-     *
-     * @param UriInterface
-     */
-    public function setId($id)
-    {
-        $this->id = $this->convertUri($id);
-    }
-
-    /**
      * Returns Whether to include the default player CSS file in the player HTML page.
      *
      * @return bool
@@ -1698,26 +1603,6 @@ class Player implements CreateKeyInterface
     public function setOverlayImageUrl($overlayImageUrl)
     {
         $this->overlayImageUrl = $this->convertUri($overlayImageUrl);
-    }
-
-    /**
-     * Returns The id of the account that owns this object.
-     *
-     * @return UriInterface
-     */
-    public function getOwnerId(): UriInterface
-    {
-        return $this->ownerId;
-    }
-
-    /**
-     * Set The id of the account that owns this object.
-     *
-     * @param UriInterface
-     */
-    public function setOwnerId($ownerId)
-    {
-        $this->ownerId = $this->convertUri($ownerId);
     }
 
     /**

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -3,9 +3,20 @@
 namespace Lullabot\Mpx\DataService\Player;
 
 use Lullabot\Mpx\CreateKeyInterface;
+use Lullabot\Mpx\DataService\ConversionTrait;
+use Psr\Http\Message\UriInterface;
 
+/**
+ * @\Lullabot\Mpx\DataService\Annotation\DataService(
+ *     service="Player Data Service",
+ *     path="/data/Player",
+ *     schemaVersion="1.6",
+ * )
+ */
 class Player implements CreateKeyInterface
 {
+    use ConversionTrait;
+
     /**
      * The date and time that this object was created.
      *
@@ -114,7 +125,7 @@ class Player implements CreateKeyInterface
     /**
      * URL for a custom background image.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $backgroundImageUrl;
 
@@ -163,7 +174,7 @@ class Player implements CreateKeyInterface
     /**
      * URLs to remote custom CSS content for the player.
      *
-     * @var string[]
+     * @var \Psr\Http\Message\UriInterface[]
      */
     protected $customCssUrls;
 
@@ -184,7 +195,7 @@ class Player implements CreateKeyInterface
     /**
      * URLs to custom JavaScript content for the player.
      *
-     * @var string[]
+     * @var \Psr\Http\Message\UriInterface[]
      */
     protected $customJavaScriptUrls;
 
@@ -261,7 +272,7 @@ class Player implements CreateKeyInterface
     /**
      * The URL of the feed that will populate the related items list end card.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $endCardFeedUrl;
 
@@ -282,7 +293,7 @@ class Player implements CreateKeyInterface
     /**
      * The URL of the player's default feed.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $feedUrl;
 
@@ -310,7 +321,7 @@ class Player implements CreateKeyInterface
     /**
      * The URL of the header image.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $headerImageUrl;
 
@@ -359,7 +370,7 @@ class Player implements CreateKeyInterface
     /**
      * The destination URL for when a user clicks the player video area.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $linkUrl;
 
@@ -373,7 +384,7 @@ class Player implements CreateKeyInterface
     /**
      * The URL of the player overlay image.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $overlayImageUrl;
 
@@ -436,7 +447,7 @@ class Player implements CreateKeyInterface
     /**
      * Player URL used in the sharing features.
      *
-     * @var string
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $playerUrl;
 
@@ -515,7 +526,7 @@ class Player implements CreateKeyInterface
      *
      * @var bool
      */
-    protected $showAirDate;
+    protected $showAirdate;
 
     /**
      * Indicates whether to include the All option in the category list component.
@@ -642,19 +653,19 @@ class Player implements CreateKeyInterface
     /**
      * Set The date and time that this object was created.
      *
-     * @param \DateTime
+     * @param \DateTime|int
      */
     public function setAdded($added)
     {
-        $this->added = $added;
+        $this->added = $this->convertDateTime($added);
     }
 
     /**
      * Returns The id of the user that created this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getAddedByUserId(): \Psr\Http\Message\UriInterface
+    public function getAddedByUserId(): UriInterface
     {
         return $this->addedByUserId;
     }
@@ -662,11 +673,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The id of the user that created this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface|string
      */
     public function setAddedByUserId($addedByUserId)
     {
-        $this->addedByUserId = $addedByUserId;
+        $this->addedByUserId = $this->convertUri($addedByUserId);
     }
 
     /**
@@ -692,9 +703,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns the identifier for the advertising policy for this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getAdPolicyId(): \Psr\Http\Message\UriInterface
+    public function getAdPolicyId(): UriInterface
     {
         return $this->adPolicyId;
     }
@@ -702,11 +713,11 @@ class Player implements CreateKeyInterface
     /**
      * Set the identifier for the advertising policy for this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setAdPolicyId($adPolicyId)
     {
-        $this->adPolicyId = $adPolicyId;
+        $this->adPolicyId = $this->convertUri($adPolicyId);
     }
 
     /**
@@ -714,7 +725,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowEmail(): \boolean
+    public function getAllowEmail(): bool
     {
         return $this->allowEmail;
     }
@@ -734,7 +745,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowEmbed(): \boolean
+    public function getAllowEmbed(): bool
     {
         return $this->allowEmbed;
     }
@@ -754,7 +765,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowFullScreen(): \boolean
+    public function getAllowFullScreen(): bool
     {
         return $this->allowFullScreen;
     }
@@ -774,7 +785,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowGetLink(): \boolean
+    public function getAllowGetLink(): bool
     {
         return $this->allowGetLink;
     }
@@ -794,7 +805,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowRss(): \boolean
+    public function getAllowRss(): bool
     {
         return $this->allowRss;
     }
@@ -814,7 +825,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAllowSearch(): \boolean
+    public function getAllowSearch(): bool
     {
         return $this->allowSearch;
     }
@@ -834,7 +845,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAlwaysShowOverlay(): \boolean
+    public function getAlwaysShowOverlay(): bool
     {
         return $this->alwaysShowOverlay;
     }
@@ -854,7 +865,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getAspectRatioHeight(): \Integer
+    public function getAspectRatioHeight(): int
     {
         return $this->aspectRatioHeight;
     }
@@ -874,7 +885,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getAspectRatioWidth(): \Integer
+    public function getAspectRatioWidth(): int
     {
         return $this->aspectRatioWidth;
     }
@@ -894,7 +905,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAutoPlay(): \boolean
+    public function getAutoPlay(): bool
     {
         return $this->autoPlay;
     }
@@ -914,7 +925,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getAutoInitialize(): \boolean
+    public function getAutoInitialize(): bool
     {
         return $this->autoInitialize;
     }
@@ -946,15 +957,15 @@ class Player implements CreateKeyInterface
      */
     public function setBackgroundImageUrl($backgroundImageUrl)
     {
-        $this->backgroundImageUrl = $backgroundImageUrl;
+        $this->backgroundImageUrl = $this->convertUri($backgroundImageUrl);
     }
 
     /**
      * Returns Identifier for the color scheme assigned to this player.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getColorSchemeId(): \Psr\Http\Message\UriInterface
+    public function getColorSchemeId(): UriInterface
     {
         return $this->colorSchemeId;
     }
@@ -962,11 +973,11 @@ class Player implements CreateKeyInterface
     /**
      * Set Identifier for the color scheme assigned to this player.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setColorSchemeId($colorSchemeId)
     {
-        $this->colorSchemeId = $colorSchemeId;
+        $this->colorSchemeId = $this->convertUri($colorSchemeId);
     }
 
     /**
@@ -974,7 +985,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getColumns(): \Integer
+    public function getColumns(): int
     {
         return $this->columns;
     }
@@ -994,7 +1005,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getCompatibilityMode(): \boolean
+    public function getCompatibilityMode(): bool
     {
         return $this->compatibilityMode;
     }
@@ -1034,7 +1045,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getControlRackHeight(): \Integer
+    public function getControlRackHeight(): int
     {
         return $this->controlRackHeight;
     }
@@ -1194,7 +1205,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getDisabled(): \boolean
+    public function getDisabled(): bool
     {
         return $this->disabled;
     }
@@ -1212,9 +1223,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The identifier for the advertising policy to use when the player is embedded in another site.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getEmbedAdPolicyId(): \Psr\Http\Message\UriInterface
+    public function getEmbedAdPolicyId(): UriInterface
     {
         return $this->embedAdPolicyId;
     }
@@ -1222,11 +1233,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The identifier for the advertising policy to use when the player is embedded in another site.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setEmbedAdPolicyId($embedAdPolicyId)
     {
-        $this->embedAdPolicyId = $embedAdPolicyId;
+        $this->embedAdPolicyId = $this->convertUri($embedAdPolicyId);
     }
 
     /**
@@ -1234,7 +1245,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getEmbedAllowFullScreen(): \boolean
+    public function getEmbedAllowFullScreen(): bool
     {
         return $this->embedAllowFullScreen;
     }
@@ -1254,7 +1265,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getEmbedHeight(): \Integer
+    public function getEmbedHeight(): int
     {
         return $this->embedHeight;
     }
@@ -1272,9 +1283,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The identifier for the restriction to apply to this player when embedded in another site.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getEmbedRestrictionId(): \Psr\Http\Message\UriInterface
+    public function getEmbedRestrictionId(): UriInterface
     {
         return $this->embedRestrictionId;
     }
@@ -1282,11 +1293,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The identifier for the restriction to apply to this player when embedded in another site.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setEmbedRestrictionId($embedRestrictionId)
     {
-        $this->embedRestrictionId = $embedRestrictionId;
+        $this->embedRestrictionId = $this->convertUri($embedRestrictionId);
     }
 
     /**
@@ -1294,7 +1305,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getEmbedWidth(): \Integer
+    public function getEmbedWidth(): int
     {
         return $this->embedWidth;
     }
@@ -1334,7 +1345,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getEnableExternalController(): \boolean
+    public function getEnableExternalController(): bool
     {
         return $this->enableExternalController;
     }
@@ -1366,7 +1377,7 @@ class Player implements CreateKeyInterface
      */
     public function setEndCardFeedUrl($endCardFeedUrl)
     {
-        $this->endCardFeedUrl = $endCardFeedUrl;
+        $this->endCardFeedUrl = $this->convertUri($endCardFeedUrl);
     }
 
     /**
@@ -1426,7 +1437,7 @@ class Player implements CreateKeyInterface
      */
     public function setFeedUrl($feedUrl)
     {
-        $this->feedUrl = $feedUrl;
+        $this->feedUrl = $this->convertUri($feedUrl);
     }
 
     /**
@@ -1474,7 +1485,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getHeaderImageHeight(): \Integer
+    public function getHeaderImageHeight(): int
     {
         return $this->headerImageHeight;
     }
@@ -1506,7 +1517,7 @@ class Player implements CreateKeyInterface
      */
     public function setHeaderImageUrl($headerImageUrl)
     {
-        $this->headerImageUrl = $headerImageUrl;
+        $this->headerImageUrl = $this->convertUri($headerImageUrl);
     }
 
     /**
@@ -1514,7 +1525,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getHeight(): \Integer
+    public function getHeight(): int
     {
         return $this->height;
     }
@@ -1532,9 +1543,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The globally unique URI of this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getId(): \Psr\Http\Message\UriInterface
+    public function getId(): UriInterface
     {
         return $this->id;
     }
@@ -1542,11 +1553,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The globally unique URI of this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setId($id)
     {
-        $this->id = $id;
+        $this->id = $this->convertUri($id);
     }
 
     /**
@@ -1554,7 +1565,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getIncludeDefaultCss(): \boolean
+    public function getIncludeDefaultCss(): bool
     {
         return $this->includeDefaultCss;
     }
@@ -1574,7 +1585,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getItemsPerPage(): \Integer
+    public function getItemsPerPage(): int
     {
         return $this->itemsPerPage;
     }
@@ -1592,9 +1603,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The identifier for the layout assigned to this player.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getLayoutId(): \Psr\Http\Message\UriInterface
+    public function getLayoutId(): UriInterface
     {
         return $this->layoutId;
     }
@@ -1602,11 +1613,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The identifier for the layout assigned to this player.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setLayoutId($layoutId)
     {
-        $this->layoutId = $layoutId;
+        $this->layoutId = $this->convertUri($layoutId);
     }
 
     /**
@@ -1632,9 +1643,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The destination URL for when a user clicks the player video area.
      *
-     * @return string
+     * @return \Psr\Http\Message\UriInterface
      */
-    public function getLinkUrl(): string
+    public function getLinkUrl(): UriInterface
     {
         return $this->linkUrl;
     }
@@ -1646,7 +1657,7 @@ class Player implements CreateKeyInterface
      */
     public function setLinkUrl($linkUrl)
     {
-        $this->linkUrl = $linkUrl;
+        $this->linkUrl = $this->convertUri($linkUrl);
     }
 
     /**
@@ -1654,7 +1665,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getLocked(): \boolean
+    public function getLocked(): bool
     {
         return $this->locked;
     }
@@ -1672,9 +1683,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The URL of the player overlay image.
      *
-     * @return string
+     * @return \Psr\Http\Message\UriInterface
      */
-    public function getOverlayImageUrl(): string
+    public function getOverlayImageUrl(): UriInterface
     {
         return $this->overlayImageUrl;
     }
@@ -1686,15 +1697,15 @@ class Player implements CreateKeyInterface
      */
     public function setOverlayImageUrl($overlayImageUrl)
     {
-        $this->overlayImageUrl = $overlayImageUrl;
+        $this->overlayImageUrl = $this->convertUri($overlayImageUrl);
     }
 
     /**
      * Returns The id of the account that owns this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getOwnerId(): \Psr\Http\Message\UriInterface
+    public function getOwnerId(): UriInterface
     {
         return $this->ownerId;
     }
@@ -1702,11 +1713,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The id of the account that owns this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setOwnerId($ownerId)
     {
-        $this->ownerId = $ownerId;
+        $this->ownerId = $this->convertUri($ownerId);
     }
 
     /**
@@ -1714,7 +1725,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPaddingBottom(): \Integer
+    public function getPaddingBottom(): int
     {
         return $this->paddingBottom;
     }
@@ -1734,7 +1745,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPaddingLeft(): \Integer
+    public function getPaddingLeft(): int
     {
         return $this->paddingLeft;
     }
@@ -1754,7 +1765,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPaddingRight(): \Integer
+    public function getPaddingRight(): int
     {
         return $this->paddingRight;
     }
@@ -1774,7 +1785,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPaddingTop(): \Integer
+    public function getPaddingTop(): int
     {
         return $this->paddingTop;
     }
@@ -1834,7 +1845,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getPlayAll(): \boolean
+    public function getPlayAll(): bool
     {
         return $this->playAll;
     }
@@ -1874,7 +1885,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPosterImageDefaultHeight(): \Integer
+    public function getPosterImageDefaultHeight(): int
     {
         return $this->posterImageDefaultHeight;
     }
@@ -1894,7 +1905,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getPosterImageDefaultWidth(): \Integer
+    public function getPosterImageDefaultWidth(): int
     {
         return $this->posterImageDefaultWidth;
     }
@@ -2052,9 +2063,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns The identifier of the restriction to apply to this player.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getRestrictionId(): \Psr\Http\Message\UriInterface
+    public function getRestrictionId(): UriInterface
     {
         return $this->restrictionId;
     }
@@ -2062,11 +2073,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The identifier of the restriction to apply to this player.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setRestrictionId($restrictionId)
     {
-        $this->restrictionId = $restrictionId;
+        $this->restrictionId = $this->convertUri($restrictionId);
     }
 
     /**
@@ -2074,9 +2085,9 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowAirDate(): \boolean
+    public function getShowAirdate(): bool
     {
-        return $this->showAirDate;
+        return $this->showAirdate;
     }
 
     /**
@@ -2084,9 +2095,9 @@ class Player implements CreateKeyInterface
      *
      * @param bool
      */
-    public function setShowAirDate($showAirDate)
+    public function setShowAirdate($showAirdate)
     {
-        $this->showAirDate = $showAirDate;
+        $this->showAirdate = $showAirdate;
     }
 
     /**
@@ -2094,7 +2105,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowAllChoice(): \boolean
+    public function getShowAllChoice(): bool
     {
         return $this->showAllChoice;
     }
@@ -2114,7 +2125,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowAuthor(): \boolean
+    public function getShowAuthor(): bool
     {
         return $this->showAuthor;
     }
@@ -2134,7 +2145,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowBitrate(): \boolean
+    public function getShowBitrate(): bool
     {
         return $this->showBitrate;
     }
@@ -2154,7 +2165,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowFullTime(): \boolean
+    public function getShowFullTime(): bool
     {
         return $this->showFullTime;
     }
@@ -2174,7 +2185,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowMostPopularChoice(): \boolean
+    public function getShowMostPopularChoice(): bool
     {
         return $this->showMostPopularChoice;
     }
@@ -2194,7 +2205,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShowNav(): \boolean
+    public function getShowNav(): bool
     {
         return $this->showNav;
     }
@@ -2214,7 +2225,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getShuffle(): \boolean
+    public function getShuffle(): bool
     {
         return $this->shuffle;
     }
@@ -2232,9 +2243,9 @@ class Player implements CreateKeyInterface
     /**
      * Returns Identifier for the skin object to apply this player.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getSkinId(): \Psr\Http\Message\UriInterface
+    public function getSkinId(): UriInterface
     {
         return $this->skinId;
     }
@@ -2242,11 +2253,11 @@ class Player implements CreateKeyInterface
     /**
      * Set Identifier for the skin object to apply this player.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setSkinId($skinId)
     {
-        $this->skinId = $skinId;
+        $this->skinId = $this->convertUri($skinId);
     }
 
     /**
@@ -2254,7 +2265,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getThumbnailHeight(): \Integer
+    public function getThumbnailHeight(): int
     {
         return $this->thumbnailHeight;
     }
@@ -2274,7 +2285,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getThumbnailWidth(): \Integer
+    public function getThumbnailWidth(): int
     {
         return $this->thumbnailWidth;
     }
@@ -2322,19 +2333,19 @@ class Player implements CreateKeyInterface
     /**
      * Set The date and time this object was last modified.
      *
-     * @param \DateTime
+     * @param int
      */
     public function setUpdated($updated)
     {
-        $this->updated = $updated;
+        $this->updated = $this->convertDateTime($updated);
     }
 
     /**
      * Returns The id of the user that last modified this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    public function getUpdatedByUserId(): UriInterface
     {
         return $this->updatedByUserId;
     }
@@ -2342,11 +2353,11 @@ class Player implements CreateKeyInterface
     /**
      * Set The id of the user that last modified this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setUpdatedByUserId($updatedByUserId)
     {
-        $this->updatedByUserId = $updatedByUserId;
+        $this->updatedByUserId = $this->convertUri($updatedByUserId);
     }
 
     /**
@@ -2354,7 +2365,7 @@ class Player implements CreateKeyInterface
      *
      * @return bool
      */
-    public function getUseFloatingControls(): \boolean
+    public function getUseFloatingControls(): bool
     {
         return $this->useFloatingControls;
     }
@@ -2394,7 +2405,7 @@ class Player implements CreateKeyInterface
      *
      * @return int
      */
-    public function getWidth(): \Integer
+    public function getWidth(): int
     {
         return $this->width;
     }

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -1,0 +1,2449 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Player;
+
+use Lullabot\Mpx\CreateKeyInterface;
+
+class Player implements CreateKeyInterface
+{
+    /**
+     * The date and time that this object was created.
+     *
+     * @var \DateTime
+     */
+    protected $added;
+
+    /**
+     * The id of the user that created this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $addedByUserId;
+
+    /**
+     * The administrative workflow tags for this object.
+     *
+     * @var string[]
+     */
+    protected $adminTags;
+
+    /**
+     * the identifier for the advertising policy for this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $adPolicyId;
+
+    /**
+     * Indicates whether the player will feature sharing via email.
+     *
+     * @var bool
+     */
+    protected $allowEmail;
+
+    /**
+     * Indicates whether the player will provide an embed code for sharing on other sites.
+     *
+     * @var bool
+     */
+    protected $allowEmbed;
+
+    /**
+     * Indicates whether the player will be allowed to play video in fullscreen mode.
+     *
+     * @var bool
+     */
+    protected $allowFullScreen;
+
+    /**
+     * Indicates whether the player will make a shareable link available to users.
+     *
+     * @var bool
+     */
+    protected $allowGetLink;
+
+    /**
+     * Indicates whether the player will make an RSS link available to users.
+     *
+     * @var bool
+     */
+    protected $allowRss;
+
+    /**
+     * Indicates whether to include the search component.
+     *
+     * @var bool
+     */
+    protected $allowSearch;
+
+    /**
+     * Indicates whether the player should always display the play overlay.
+     *
+     * @var bool
+     */
+    protected $alwaysShowOverlay;
+
+    /**
+     * The value of the aspect ratio for the height of the media area.
+     *
+     * @var int
+     */
+    protected $aspectRatioHeight;
+
+    /**
+     * The value of the aspect ratio for the width of the media area.
+     *
+     * @var int
+     */
+    protected $aspectRatioWidth;
+
+    /**
+     * Indicates whether the player will start playback on load.
+     *
+     * @var bool
+     */
+    protected $autoPlay;
+
+    /**
+     * Indicates whether the player will self-initialize on load.
+     *
+     * @var bool
+     */
+    protected $autoInitialize;
+
+    /**
+     * URL for a custom background image.
+     *
+     * @var string
+     */
+    protected $backgroundImageUrl;
+
+    /**
+     * Identifier for the color scheme assigned to this player.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $colorSchemeId;
+
+    /**
+     * The number of columns in the release list.
+     *
+     * @var int
+     */
+    protected $columns;
+
+    /**
+     * Reserved for future use. The default value is false.
+     *
+     * @var bool
+     */
+    protected $compatibilityMode;
+
+    /**
+     * XML layout content for the player control rack.
+     *
+     * @var string
+     */
+    protected $controlLayoutXml;
+
+    /**
+     * Height of the player control rack.
+     *
+     * @var int
+     */
+    protected $controlRackHeight;
+
+    /**
+     * Custom CSS content for the player.
+     *
+     * @var string
+     */
+    protected $customCss;
+
+    /**
+     * URLs to remote custom CSS content for the player.
+     *
+     * @var string[]
+     */
+    protected $customCssUrls;
+
+    /**
+     * Custom HTML content for the player (not currently used).
+     *
+     * @var string
+     */
+    protected $customHtml;
+
+    /**
+     * Custom JavaScript content for the player.
+     *
+     * @var string
+     */
+    protected $customJavaScript;
+
+    /**
+     * URLs to custom JavaScript content for the player.
+     *
+     * @var string[]
+     */
+    protected $customJavaScriptUrls;
+
+    /**
+     * Additional attributes to include in the player HTML.
+     *
+     * @var array<string, string>
+     */
+    protected $customProperties;
+
+    /**
+     * The description of this object.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * Whether is player is available for customer retrieval.
+     *
+     * @var bool
+     */
+    protected $disabled;
+
+    /**
+     * The identifier for the advertising policy to use when the player is embedded in another site.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $embedAdPolicyId;
+
+    /**
+     * Indicates whether embedded players will be allowed to be viewed in fullscreen mode.
+     *
+     * @var bool
+     */
+    protected $embedAllowFullScreen;
+
+    /**
+     * The default height of the player when embedded in another site.
+     *
+     * @var int
+     */
+    protected $embedHeight;
+
+    /**
+     * The identifier for the restriction to apply to this player when embedded in another site.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $embedRestrictionId;
+
+    /**
+     * The default width of the player when embedded in another site.
+     *
+     * @var int
+     */
+    protected $embedWidth;
+
+    /**
+     * The set of plug-ins for this player.
+     *
+     * @var PlugInInstance[]
+     */
+    protected $enabledPlugIns;
+
+    /**
+     * Indicates if the player responds to commands from an IFrame parent element.
+     *
+     * @var bool
+     */
+    protected $enableExternalController;
+
+    /**
+     * The URL of the feed that will populate the related items list end card.
+     *
+     * @var string
+     */
+    protected $endCardFeedUrl;
+
+    /**
+     * The custom failover HTML.
+     *
+     * @var string
+     */
+    protected $failoverHtml;
+
+    /**
+     * Reserved for future use. The default value is null.
+     *
+     * @var string
+     */
+    protected $fallbackPdk;
+
+    /**
+     * The URL of the player's default feed.
+     *
+     * @var string
+     */
+    protected $feedUrl;
+
+    /**
+     * The request parameters to include in the feed request.
+     *
+     * @var string
+     */
+    protected $feedUrlParams;
+
+    /**
+     * An alternate identifier for this object that is unique within the owning account.
+     *
+     * @var string
+     */
+    protected $guid;
+
+    /**
+     * The height of the header image.
+     *
+     * @var int
+     */
+    protected $headerImageHeight;
+
+    /**
+     * The URL of the header image.
+     *
+     * @var string
+     */
+    protected $headerImageUrl;
+
+    /**
+     * The height of the player.
+     *
+     * @var int
+     */
+    protected $height;
+
+    /**
+     * The globally unique URI of this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $id;
+
+    /**
+     * Whether to include the default player CSS file in the player HTML page.
+     *
+     * @var bool
+     */
+    protected $includeDefaultCss;
+
+    /**
+     * The number of items to make visible in each page of the release list.
+     *
+     * @var int
+     */
+    protected $itemsPerPage;
+
+    /**
+     * The identifier for the layout assigned to this player.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $layoutId;
+
+    /**
+     * A list of categories that will appear in the category list.
+     *
+     * @var string[]
+     */
+    protected $limitToCategories;
+
+    /**
+     * The destination URL for when a user clicks the player video area.
+     *
+     * @var string
+     */
+    protected $linkUrl;
+
+    /**
+     * Whether this object currently allows updates.
+     *
+     * @var bool
+     */
+    protected $locked;
+
+    /**
+     * The URL of the player overlay image.
+     *
+     * @var string
+     */
+    protected $overlayImageUrl;
+
+    /**
+     * The id of the account that owns this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $ownerId;
+
+    /**
+     * The amount of padding to add to the bottom of the player host page.
+     *
+     * @var int
+     */
+    protected $paddingBottom;
+
+    /**
+     * The amount of padding to add to the left side of the player host page.
+     *
+     * @var int
+     */
+    protected $paddingLeft;
+
+    /**
+     * The amount of padding to add to the right side of the player host page.
+     *
+     * @var int
+     */
+    protected $paddingRight;
+
+    /**
+     * The amount of padding to add to the top of the player host page.
+     *
+     * @var int
+     */
+    protected $paddingTop;
+
+    /**
+     * Reserved for future use. The default value is null.
+     *
+     * @var string
+     */
+    protected $pdk;
+
+    /**
+     * The public identifier for this player when requested through the Player Service.
+     *
+     * @var string
+     */
+    protected $pid;
+
+    /**
+     * Indicates if the player should automatically play the next release when one finishes.
+     *
+     * @var bool
+     */
+    protected $playAll;
+
+    /**
+     * Player URL used in the sharing features.
+     *
+     * @var string
+     */
+    protected $playerUrl;
+
+    /**
+     * The default height to use for the poster image.
+     *
+     * @var int
+     */
+    protected $posterImageDefaultHeight;
+
+    /**
+     * The default width to use for the poster image.
+     *
+     * @var int
+     */
+    protected $posterImageDefaultWidth;
+
+    /**
+     * The meta asset type to use for the poster image.
+     *
+     * @var string
+     */
+    protected $posterImageMetaAssetType;
+
+    /**
+     * The preview asset type to use for the poster image.
+     *
+     * @var string
+     */
+    protected $posterImagePreviewAssetType;
+
+    /**
+     * The media formats meant for use in this player.
+     *
+     * @var string[]
+     */
+    protected $preferredFormats;
+
+    /**
+     * The runtimes meant for use in the player.
+     *
+     * @var string[]
+     */
+    protected $preferredRuntimes;
+
+    /**
+     * Heights of the regions in the layout.
+     *
+     * @var array<string, Integer>
+     */
+    protected $regionHeights;
+
+    /**
+     * Widths of the regions in the layout.
+     *
+     * @var array<string, Integer>
+     */
+    protected $regionWidths;
+
+    /**
+     * URL parameters to add to Public URL requests.
+     *
+     * @var string
+     */
+    protected $releaseUrlParams;
+
+    /**
+     * The identifier of the restriction to apply to this player.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $restrictionId;
+
+    /**
+     * Indicates whether to display the air date in the release list component.
+     *
+     * @var bool
+     */
+    protected $showAirDate;
+
+    /**
+     * Indicates whether to include the All option in the category list component.
+     *
+     * @var bool
+     */
+    protected $showAllChoice;
+
+    /**
+     * Indicates whether to display the author in the release list and clip info components.
+     *
+     * @var bool
+     */
+    protected $showAuthor;
+
+    /**
+     * Indicates whether to display the media bitrate in the release list component.
+     *
+     * @var bool
+     */
+    protected $showBitrate;
+
+    /**
+     * Indicates whether to show the full video time in the player control rack.
+     *
+     * @var bool
+     */
+    protected $showFullTime;
+
+    /**
+     * Indicates whether to show the Most Popular option in the category list component.
+     *
+     * @var bool
+     */
+    protected $showMostPopularChoice;
+
+    /**
+     * Indicates whether to display the previous and next buttons in the player control rack.
+     *
+     * @var bool
+     */
+    protected $showNav;
+
+    /**
+     * Indicates whether to randomize the contents of the release list.
+     *
+     * @var bool
+     */
+    protected $shuffle;
+
+    /**
+     * Identifier for the skin object to apply this player.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $skinId;
+
+    /**
+     * The height of the thumbnail images in the release list.
+     *
+     * @var int
+     */
+    protected $thumbnailHeight;
+
+    /**
+     * The width of the thumbnail images in the release list.
+     *
+     * @var int
+     */
+    protected $thumbnailWidth;
+
+    /**
+     * The name of this object.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The date and time this object was last modified.
+     *
+     * @var \DateTime
+     */
+    protected $updated;
+
+    /**
+     * The id of the user that last modified this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $updatedByUserId;
+
+    /**
+     * Indicates whether to float the control rack over the media area of the player.
+     *
+     * @var bool
+     */
+    protected $useFloatingControls;
+
+    /**
+     * This object's modification version, used for optimistic locking.
+     *
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * The width of the player.
+     *
+     * @var int
+     */
+    protected $width;
+
+    /**
+     * Returns The date and time that this object was created.
+     *
+     * @return \DateTime
+     */
+    public function getAdded(): \DateTime
+    {
+        return $this->added;
+    }
+
+    /**
+     * Set The date and time that this object was created.
+     *
+     * @param \DateTime
+     */
+    public function setAdded($added)
+    {
+        $this->added = $added;
+    }
+
+    /**
+     * Returns The id of the user that created this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAddedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->addedByUserId;
+    }
+
+    /**
+     * Set The id of the user that created this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAddedByUserId($addedByUserId)
+    {
+        $this->addedByUserId = $addedByUserId;
+    }
+
+    /**
+     * Returns The administrative workflow tags for this object.
+     *
+     * @return string[]
+     */
+    public function getAdminTags(): array
+    {
+        return $this->adminTags;
+    }
+
+    /**
+     * Set The administrative workflow tags for this object.
+     *
+     * @param string[]
+     */
+    public function setAdminTags($adminTags)
+    {
+        $this->adminTags = $adminTags;
+    }
+
+    /**
+     * Returns the identifier for the advertising policy for this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAdPolicyId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->adPolicyId;
+    }
+
+    /**
+     * Set the identifier for the advertising policy for this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAdPolicyId($adPolicyId)
+    {
+        $this->adPolicyId = $adPolicyId;
+    }
+
+    /**
+     * Returns Indicates whether the player will feature sharing via email.
+     *
+     * @return bool
+     */
+    public function getAllowEmail(): \boolean
+    {
+        return $this->allowEmail;
+    }
+
+    /**
+     * Set Indicates whether the player will feature sharing via email.
+     *
+     * @param bool
+     */
+    public function setAllowEmail($allowEmail)
+    {
+        $this->allowEmail = $allowEmail;
+    }
+
+    /**
+     * Returns Indicates whether the player will provide an embed code for sharing on other sites.
+     *
+     * @return bool
+     */
+    public function getAllowEmbed(): \boolean
+    {
+        return $this->allowEmbed;
+    }
+
+    /**
+     * Set Indicates whether the player will provide an embed code for sharing on other sites.
+     *
+     * @param bool
+     */
+    public function setAllowEmbed($allowEmbed)
+    {
+        $this->allowEmbed = $allowEmbed;
+    }
+
+    /**
+     * Returns Indicates whether the player will be allowed to play video in fullscreen mode.
+     *
+     * @return bool
+     */
+    public function getAllowFullScreen(): \boolean
+    {
+        return $this->allowFullScreen;
+    }
+
+    /**
+     * Set Indicates whether the player will be allowed to play video in fullscreen mode.
+     *
+     * @param bool
+     */
+    public function setAllowFullScreen($allowFullScreen)
+    {
+        $this->allowFullScreen = $allowFullScreen;
+    }
+
+    /**
+     * Returns Indicates whether the player will make a shareable link available to users.
+     *
+     * @return bool
+     */
+    public function getAllowGetLink(): \boolean
+    {
+        return $this->allowGetLink;
+    }
+
+    /**
+     * Set Indicates whether the player will make a shareable link available to users.
+     *
+     * @param bool
+     */
+    public function setAllowGetLink($allowGetLink)
+    {
+        $this->allowGetLink = $allowGetLink;
+    }
+
+    /**
+     * Returns Indicates whether the player will make an RSS link available to users.
+     *
+     * @return bool
+     */
+    public function getAllowRss(): \boolean
+    {
+        return $this->allowRss;
+    }
+
+    /**
+     * Set Indicates whether the player will make an RSS link available to users.
+     *
+     * @param bool
+     */
+    public function setAllowRss($allowRss)
+    {
+        $this->allowRss = $allowRss;
+    }
+
+    /**
+     * Returns Indicates whether to include the search component.
+     *
+     * @return bool
+     */
+    public function getAllowSearch(): \boolean
+    {
+        return $this->allowSearch;
+    }
+
+    /**
+     * Set Indicates whether to include the search component.
+     *
+     * @param bool
+     */
+    public function setAllowSearch($allowSearch)
+    {
+        $this->allowSearch = $allowSearch;
+    }
+
+    /**
+     * Returns Indicates whether the player should always display the play overlay.
+     *
+     * @return bool
+     */
+    public function getAlwaysShowOverlay(): \boolean
+    {
+        return $this->alwaysShowOverlay;
+    }
+
+    /**
+     * Set Indicates whether the player should always display the play overlay.
+     *
+     * @param bool
+     */
+    public function setAlwaysShowOverlay($alwaysShowOverlay)
+    {
+        $this->alwaysShowOverlay = $alwaysShowOverlay;
+    }
+
+    /**
+     * Returns The value of the aspect ratio for the height of the media area.
+     *
+     * @return int
+     */
+    public function getAspectRatioHeight(): \Integer
+    {
+        return $this->aspectRatioHeight;
+    }
+
+    /**
+     * Set The value of the aspect ratio for the height of the media area.
+     *
+     * @param int
+     */
+    public function setAspectRatioHeight($aspectRatioHeight)
+    {
+        $this->aspectRatioHeight = $aspectRatioHeight;
+    }
+
+    /**
+     * Returns The value of the aspect ratio for the width of the media area.
+     *
+     * @return int
+     */
+    public function getAspectRatioWidth(): \Integer
+    {
+        return $this->aspectRatioWidth;
+    }
+
+    /**
+     * Set The value of the aspect ratio for the width of the media area.
+     *
+     * @param int
+     */
+    public function setAspectRatioWidth($aspectRatioWidth)
+    {
+        $this->aspectRatioWidth = $aspectRatioWidth;
+    }
+
+    /**
+     * Returns Indicates whether the player will start playback on load.
+     *
+     * @return bool
+     */
+    public function getAutoPlay(): \boolean
+    {
+        return $this->autoPlay;
+    }
+
+    /**
+     * Set Indicates whether the player will start playback on load.
+     *
+     * @param bool
+     */
+    public function setAutoPlay($autoPlay)
+    {
+        $this->autoPlay = $autoPlay;
+    }
+
+    /**
+     * Returns Indicates whether the player will self-initialize on load.
+     *
+     * @return bool
+     */
+    public function getAutoInitialize(): \boolean
+    {
+        return $this->autoInitialize;
+    }
+
+    /**
+     * Set Indicates whether the player will self-initialize on load.
+     *
+     * @param bool
+     */
+    public function setAutoInitialize($autoInitialize)
+    {
+        $this->autoInitialize = $autoInitialize;
+    }
+
+    /**
+     * Returns URL for a custom background image.
+     *
+     * @return string
+     */
+    public function getBackgroundImageUrl(): string
+    {
+        return $this->backgroundImageUrl;
+    }
+
+    /**
+     * Set URL for a custom background image.
+     *
+     * @param string
+     */
+    public function setBackgroundImageUrl($backgroundImageUrl)
+    {
+        $this->backgroundImageUrl = $backgroundImageUrl;
+    }
+
+    /**
+     * Returns Identifier for the color scheme assigned to this player.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getColorSchemeId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->colorSchemeId;
+    }
+
+    /**
+     * Set Identifier for the color scheme assigned to this player.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setColorSchemeId($colorSchemeId)
+    {
+        $this->colorSchemeId = $colorSchemeId;
+    }
+
+    /**
+     * Returns The number of columns in the release list.
+     *
+     * @return int
+     */
+    public function getColumns(): \Integer
+    {
+        return $this->columns;
+    }
+
+    /**
+     * Set The number of columns in the release list.
+     *
+     * @param int
+     */
+    public function setColumns($columns)
+    {
+        $this->columns = $columns;
+    }
+
+    /**
+     * Returns Reserved for future use. The default value is false.
+     *
+     * @return bool
+     */
+    public function getCompatibilityMode(): \boolean
+    {
+        return $this->compatibilityMode;
+    }
+
+    /**
+     * Set Reserved for future use. The default value is false.
+     *
+     * @param bool
+     */
+    public function setCompatibilityMode($compatibilityMode)
+    {
+        $this->compatibilityMode = $compatibilityMode;
+    }
+
+    /**
+     * Returns XML layout content for the player control rack.
+     *
+     * @return string
+     */
+    public function getControlLayoutXml(): string
+    {
+        return $this->controlLayoutXml;
+    }
+
+    /**
+     * Set XML layout content for the player control rack.
+     *
+     * @param string
+     */
+    public function setControlLayoutXml($controlLayoutXml)
+    {
+        $this->controlLayoutXml = $controlLayoutXml;
+    }
+
+    /**
+     * Returns Height of the player control rack.
+     *
+     * @return int
+     */
+    public function getControlRackHeight(): \Integer
+    {
+        return $this->controlRackHeight;
+    }
+
+    /**
+     * Set Height of the player control rack.
+     *
+     * @param int
+     */
+    public function setControlRackHeight($controlRackHeight)
+    {
+        $this->controlRackHeight = $controlRackHeight;
+    }
+
+    /**
+     * Returns Custom CSS content for the player.
+     *
+     * @return string
+     */
+    public function getCustomCss(): string
+    {
+        return $this->customCss;
+    }
+
+    /**
+     * Set Custom CSS content for the player.
+     *
+     * @param string
+     */
+    public function setCustomCss($customCss)
+    {
+        $this->customCss = $customCss;
+    }
+
+    /**
+     * Returns URLs to remote custom CSS content for the player.
+     *
+     * @return string[]
+     */
+    public function getCustomCssUrls(): array
+    {
+        return $this->customCssUrls;
+    }
+
+    /**
+     * Set URLs to remote custom CSS content for the player.
+     *
+     * @param string[]
+     */
+    public function setCustomCssUrls($customCssUrls)
+    {
+        $this->customCssUrls = $customCssUrls;
+    }
+
+    /**
+     * Returns Custom HTML content for the player (not currently used).
+     *
+     * @return string
+     */
+    public function getCustomHtml(): string
+    {
+        return $this->customHtml;
+    }
+
+    /**
+     * Set Custom HTML content for the player (not currently used).
+     *
+     * @param string
+     */
+    public function setCustomHtml($customHtml)
+    {
+        $this->customHtml = $customHtml;
+    }
+
+    /**
+     * Returns Custom JavaScript content for the player.
+     *
+     * @return string
+     */
+    public function getCustomJavaScript(): string
+    {
+        return $this->customJavaScript;
+    }
+
+    /**
+     * Set Custom JavaScript content for the player.
+     *
+     * @param string
+     */
+    public function setCustomJavaScript($customJavaScript)
+    {
+        $this->customJavaScript = $customJavaScript;
+    }
+
+    /**
+     * Returns URLs to custom JavaScript content for the player.
+     *
+     * @return string[]
+     */
+    public function getCustomJavaScriptUrls(): array
+    {
+        return $this->customJavaScriptUrls;
+    }
+
+    /**
+     * Set URLs to custom JavaScript content for the player.
+     *
+     * @param string[]
+     */
+    public function setCustomJavaScriptUrls($customJavaScriptUrls)
+    {
+        $this->customJavaScriptUrls = $customJavaScriptUrls;
+    }
+
+    /**
+     * Returns Additional attributes to include in the player HTML.
+     *
+     * @return string[]
+     */
+    public function getCustomProperties(): array
+    {
+        return $this->customProperties;
+    }
+
+    /**
+     * Set Additional attributes to include in the player HTML.
+     *
+     * @param array<string, string>
+     */
+    public function setCustomProperties($customProperties)
+    {
+        $this->customProperties = $customProperties;
+    }
+
+    /**
+     * Returns The description of this object.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set The description of this object.
+     *
+     * @param string
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Returns Whether is player is available for customer retrieval.
+     *
+     * @return bool
+     */
+    public function getDisabled(): \boolean
+    {
+        return $this->disabled;
+    }
+
+    /**
+     * Set Whether is player is available for customer retrieval.
+     *
+     * @param bool
+     */
+    public function setDisabled($disabled)
+    {
+        $this->disabled = $disabled;
+    }
+
+    /**
+     * Returns The identifier for the advertising policy to use when the player is embedded in another site.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getEmbedAdPolicyId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->embedAdPolicyId;
+    }
+
+    /**
+     * Set The identifier for the advertising policy to use when the player is embedded in another site.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setEmbedAdPolicyId($embedAdPolicyId)
+    {
+        $this->embedAdPolicyId = $embedAdPolicyId;
+    }
+
+    /**
+     * Returns Indicates whether embedded players will be allowed to be viewed in fullscreen mode.
+     *
+     * @return bool
+     */
+    public function getEmbedAllowFullScreen(): \boolean
+    {
+        return $this->embedAllowFullScreen;
+    }
+
+    /**
+     * Set Indicates whether embedded players will be allowed to be viewed in fullscreen mode.
+     *
+     * @param bool
+     */
+    public function setEmbedAllowFullScreen($embedAllowFullScreen)
+    {
+        $this->embedAllowFullScreen = $embedAllowFullScreen;
+    }
+
+    /**
+     * Returns The default height of the player when embedded in another site.
+     *
+     * @return int
+     */
+    public function getEmbedHeight(): \Integer
+    {
+        return $this->embedHeight;
+    }
+
+    /**
+     * Set The default height of the player when embedded in another site.
+     *
+     * @param int
+     */
+    public function setEmbedHeight($embedHeight)
+    {
+        $this->embedHeight = $embedHeight;
+    }
+
+    /**
+     * Returns The identifier for the restriction to apply to this player when embedded in another site.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getEmbedRestrictionId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->embedRestrictionId;
+    }
+
+    /**
+     * Set The identifier for the restriction to apply to this player when embedded in another site.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setEmbedRestrictionId($embedRestrictionId)
+    {
+        $this->embedRestrictionId = $embedRestrictionId;
+    }
+
+    /**
+     * Returns The default width of the player when embedded in another site.
+     *
+     * @return int
+     */
+    public function getEmbedWidth(): \Integer
+    {
+        return $this->embedWidth;
+    }
+
+    /**
+     * Set The default width of the player when embedded in another site.
+     *
+     * @param int
+     */
+    public function setEmbedWidth($embedWidth)
+    {
+        $this->embedWidth = $embedWidth;
+    }
+
+    /**
+     * Returns The set of plug-ins for this player.
+     *
+     * @return PlugInInstance[]
+     */
+    public function getEnabledPlugIns(): array
+    {
+        return $this->enabledPlugIns;
+    }
+
+    /**
+     * Set The set of plug-ins for this player.
+     *
+     * @param PlugInInstance[]
+     */
+    public function setEnabledPlugIns($enabledPlugIns)
+    {
+        $this->enabledPlugIns = $enabledPlugIns;
+    }
+
+    /**
+     * Returns Indicates if the player responds to commands from an IFrame parent element.
+     *
+     * @return bool
+     */
+    public function getEnableExternalController(): \boolean
+    {
+        return $this->enableExternalController;
+    }
+
+    /**
+     * Set Indicates if the player responds to commands from an IFrame parent element.
+     *
+     * @param bool
+     */
+    public function setEnableExternalController($enableExternalController)
+    {
+        $this->enableExternalController = $enableExternalController;
+    }
+
+    /**
+     * Returns The URL of the feed that will populate the related items list end card.
+     *
+     * @return string
+     */
+    public function getEndCardFeedUrl(): string
+    {
+        return $this->endCardFeedUrl;
+    }
+
+    /**
+     * Set The URL of the feed that will populate the related items list end card.
+     *
+     * @param string
+     */
+    public function setEndCardFeedUrl($endCardFeedUrl)
+    {
+        $this->endCardFeedUrl = $endCardFeedUrl;
+    }
+
+    /**
+     * Returns The custom failover HTML.
+     *
+     * @return string
+     */
+    public function getFailoverHtml(): string
+    {
+        return $this->failoverHtml;
+    }
+
+    /**
+     * Set The custom failover HTML.
+     *
+     * @param string
+     */
+    public function setFailoverHtml($failoverHtml)
+    {
+        $this->failoverHtml = $failoverHtml;
+    }
+
+    /**
+     * Returns Reserved for future use. The default value is null.
+     *
+     * @return string
+     */
+    public function getFallbackPdk(): string
+    {
+        return $this->fallbackPdk;
+    }
+
+    /**
+     * Set Reserved for future use. The default value is null.
+     *
+     * @param string
+     */
+    public function setFallbackPdk($fallbackPdk)
+    {
+        $this->fallbackPdk = $fallbackPdk;
+    }
+
+    /**
+     * Returns The URL of the player's default feed.
+     *
+     * @return string
+     */
+    public function getFeedUrl(): string
+    {
+        return $this->feedUrl;
+    }
+
+    /**
+     * Set The URL of the player's default feed.
+     *
+     * @param string
+     */
+    public function setFeedUrl($feedUrl)
+    {
+        $this->feedUrl = $feedUrl;
+    }
+
+    /**
+     * Returns The request parameters to include in the feed request.
+     *
+     * @return string
+     */
+    public function getFeedUrlParams(): string
+    {
+        return $this->feedUrlParams;
+    }
+
+    /**
+     * Set The request parameters to include in the feed request.
+     *
+     * @param string
+     */
+    public function setFeedUrlParams($feedUrlParams)
+    {
+        $this->feedUrlParams = $feedUrlParams;
+    }
+
+    /**
+     * Returns An alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    /**
+     * Set An alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string
+     */
+    public function setGuid($guid)
+    {
+        $this->guid = $guid;
+    }
+
+    /**
+     * Returns The height of the header image.
+     *
+     * @return int
+     */
+    public function getHeaderImageHeight(): \Integer
+    {
+        return $this->headerImageHeight;
+    }
+
+    /**
+     * Set The height of the header image.
+     *
+     * @param int
+     */
+    public function setHeaderImageHeight($headerImageHeight)
+    {
+        $this->headerImageHeight = $headerImageHeight;
+    }
+
+    /**
+     * Returns The URL of the header image.
+     *
+     * @return string
+     */
+    public function getHeaderImageUrl(): string
+    {
+        return $this->headerImageUrl;
+    }
+
+    /**
+     * Set The URL of the header image.
+     *
+     * @param string
+     */
+    public function setHeaderImageUrl($headerImageUrl)
+    {
+        $this->headerImageUrl = $headerImageUrl;
+    }
+
+    /**
+     * Returns The height of the player.
+     *
+     * @return int
+     */
+    public function getHeight(): \Integer
+    {
+        return $this->height;
+    }
+
+    /**
+     * Set The height of the player.
+     *
+     * @param int
+     */
+    public function setHeight($height)
+    {
+        $this->height = $height;
+    }
+
+    /**
+     * Returns The globally unique URI of this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set The globally unique URI of this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Returns Whether to include the default player CSS file in the player HTML page.
+     *
+     * @return bool
+     */
+    public function getIncludeDefaultCss(): \boolean
+    {
+        return $this->includeDefaultCss;
+    }
+
+    /**
+     * Set Whether to include the default player CSS file in the player HTML page.
+     *
+     * @param bool
+     */
+    public function setIncludeDefaultCss($includeDefaultCss)
+    {
+        $this->includeDefaultCss = $includeDefaultCss;
+    }
+
+    /**
+     * Returns The number of items to make visible in each page of the release list.
+     *
+     * @return int
+     */
+    public function getItemsPerPage(): \Integer
+    {
+        return $this->itemsPerPage;
+    }
+
+    /**
+     * Set The number of items to make visible in each page of the release list.
+     *
+     * @param int
+     */
+    public function setItemsPerPage($itemsPerPage)
+    {
+        $this->itemsPerPage = $itemsPerPage;
+    }
+
+    /**
+     * Returns The identifier for the layout assigned to this player.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getLayoutId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->layoutId;
+    }
+
+    /**
+     * Set The identifier for the layout assigned to this player.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setLayoutId($layoutId)
+    {
+        $this->layoutId = $layoutId;
+    }
+
+    /**
+     * Returns A list of categories that will appear in the category list.
+     *
+     * @return string[]
+     */
+    public function getLimitToCategories(): array
+    {
+        return $this->limitToCategories;
+    }
+
+    /**
+     * Set A list of categories that will appear in the category list.
+     *
+     * @param string[]
+     */
+    public function setLimitToCategories($limitToCategories)
+    {
+        $this->limitToCategories = $limitToCategories;
+    }
+
+    /**
+     * Returns The destination URL for when a user clicks the player video area.
+     *
+     * @return string
+     */
+    public function getLinkUrl(): string
+    {
+        return $this->linkUrl;
+    }
+
+    /**
+     * Set The destination URL for when a user clicks the player video area.
+     *
+     * @param string
+     */
+    public function setLinkUrl($linkUrl)
+    {
+        $this->linkUrl = $linkUrl;
+    }
+
+    /**
+     * Returns Whether this object currently allows updates.
+     *
+     * @return bool
+     */
+    public function getLocked(): \boolean
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Set Whether this object currently allows updates.
+     *
+     * @param bool
+     */
+    public function setLocked($locked)
+    {
+        $this->locked = $locked;
+    }
+
+    /**
+     * Returns The URL of the player overlay image.
+     *
+     * @return string
+     */
+    public function getOverlayImageUrl(): string
+    {
+        return $this->overlayImageUrl;
+    }
+
+    /**
+     * Set The URL of the player overlay image.
+     *
+     * @param string
+     */
+    public function setOverlayImageUrl($overlayImageUrl)
+    {
+        $this->overlayImageUrl = $overlayImageUrl;
+    }
+
+    /**
+     * Returns The id of the account that owns this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getOwnerId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * Set The id of the account that owns this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setOwnerId($ownerId)
+    {
+        $this->ownerId = $ownerId;
+    }
+
+    /**
+     * Returns The amount of padding to add to the bottom of the player host page.
+     *
+     * @return int
+     */
+    public function getPaddingBottom(): \Integer
+    {
+        return $this->paddingBottom;
+    }
+
+    /**
+     * Set The amount of padding to add to the bottom of the player host page.
+     *
+     * @param int
+     */
+    public function setPaddingBottom($paddingBottom)
+    {
+        $this->paddingBottom = $paddingBottom;
+    }
+
+    /**
+     * Returns The amount of padding to add to the left side of the player host page.
+     *
+     * @return int
+     */
+    public function getPaddingLeft(): \Integer
+    {
+        return $this->paddingLeft;
+    }
+
+    /**
+     * Set The amount of padding to add to the left side of the player host page.
+     *
+     * @param int
+     */
+    public function setPaddingLeft($paddingLeft)
+    {
+        $this->paddingLeft = $paddingLeft;
+    }
+
+    /**
+     * Returns The amount of padding to add to the right side of the player host page.
+     *
+     * @return int
+     */
+    public function getPaddingRight(): \Integer
+    {
+        return $this->paddingRight;
+    }
+
+    /**
+     * Set The amount of padding to add to the right side of the player host page.
+     *
+     * @param int
+     */
+    public function setPaddingRight($paddingRight)
+    {
+        $this->paddingRight = $paddingRight;
+    }
+
+    /**
+     * Returns The amount of padding to add to the top of the player host page.
+     *
+     * @return int
+     */
+    public function getPaddingTop(): \Integer
+    {
+        return $this->paddingTop;
+    }
+
+    /**
+     * Set The amount of padding to add to the top of the player host page.
+     *
+     * @param int
+     */
+    public function setPaddingTop($paddingTop)
+    {
+        $this->paddingTop = $paddingTop;
+    }
+
+    /**
+     * Returns Reserved for future use. The default value is null.
+     *
+     * @return string
+     */
+    public function getPdk(): string
+    {
+        return $this->pdk;
+    }
+
+    /**
+     * Set Reserved for future use. The default value is null.
+     *
+     * @param string
+     */
+    public function setPdk($pdk)
+    {
+        $this->pdk = $pdk;
+    }
+
+    /**
+     * Returns The public identifier for this player when requested through the Player Service.
+     *
+     * @return string
+     */
+    public function getPid(): string
+    {
+        return $this->pid;
+    }
+
+    /**
+     * Set The public identifier for this player when requested through the Player Service.
+     *
+     * @param string
+     */
+    public function setPid($pid)
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * Returns Indicates if the player should automatically play the next release when one finishes.
+     *
+     * @return bool
+     */
+    public function getPlayAll(): \boolean
+    {
+        return $this->playAll;
+    }
+
+    /**
+     * Set Indicates if the player should automatically play the next release when one finishes.
+     *
+     * @param bool
+     */
+    public function setPlayAll($playAll)
+    {
+        $this->playAll = $playAll;
+    }
+
+    /**
+     * Returns Player URL used in the sharing features.
+     *
+     * @return string
+     */
+    public function getPlayerUrl(): string
+    {
+        return $this->playerUrl;
+    }
+
+    /**
+     * Set Player URL used in the sharing features.
+     *
+     * @param string
+     */
+    public function setPlayerUrl($playerUrl)
+    {
+        $this->playerUrl = $playerUrl;
+    }
+
+    /**
+     * Returns The default height to use for the poster image.
+     *
+     * @return int
+     */
+    public function getPosterImageDefaultHeight(): \Integer
+    {
+        return $this->posterImageDefaultHeight;
+    }
+
+    /**
+     * Set The default height to use for the poster image.
+     *
+     * @param int
+     */
+    public function setPosterImageDefaultHeight($posterImageDefaultHeight)
+    {
+        $this->posterImageDefaultHeight = $posterImageDefaultHeight;
+    }
+
+    /**
+     * Returns The default width to use for the poster image.
+     *
+     * @return int
+     */
+    public function getPosterImageDefaultWidth(): \Integer
+    {
+        return $this->posterImageDefaultWidth;
+    }
+
+    /**
+     * Set The default width to use for the poster image.
+     *
+     * @param int
+     */
+    public function setPosterImageDefaultWidth($posterImageDefaultWidth)
+    {
+        $this->posterImageDefaultWidth = $posterImageDefaultWidth;
+    }
+
+    /**
+     * Returns The meta asset type to use for the poster image.
+     *
+     * @return string
+     */
+    public function getPosterImageMetaAssetType(): string
+    {
+        return $this->posterImageMetaAssetType;
+    }
+
+    /**
+     * Set The meta asset type to use for the poster image.
+     *
+     * @param string
+     */
+    public function setPosterImageMetaAssetType($posterImageMetaAssetType)
+    {
+        $this->posterImageMetaAssetType = $posterImageMetaAssetType;
+    }
+
+    /**
+     * Returns The preview asset type to use for the poster image.
+     *
+     * @return string
+     */
+    public function getPosterImagePreviewAssetType(): string
+    {
+        return $this->posterImagePreviewAssetType;
+    }
+
+    /**
+     * Set The preview asset type to use for the poster image.
+     *
+     * @param string
+     */
+    public function setPosterImagePreviewAssetType($posterImagePreviewAssetType)
+    {
+        $this->posterImagePreviewAssetType = $posterImagePreviewAssetType;
+    }
+
+    /**
+     * Returns The media formats meant for use in this player.
+     *
+     * @return string[]
+     */
+    public function getPreferredFormats(): array
+    {
+        return $this->preferredFormats;
+    }
+
+    /**
+     * Set The media formats meant for use in this player.
+     *
+     * @param string[]
+     */
+    public function setPreferredFormats($preferredFormats)
+    {
+        $this->preferredFormats = $preferredFormats;
+    }
+
+    /**
+     * Returns The runtimes meant for use in the player.
+     *
+     * @return string[]
+     */
+    public function getPreferredRuntimes(): array
+    {
+        return $this->preferredRuntimes;
+    }
+
+    /**
+     * Set The runtimes meant for use in the player.
+     *
+     * @param string[]
+     */
+    public function setPreferredRuntimes($preferredRuntimes)
+    {
+        $this->preferredRuntimes = $preferredRuntimes;
+    }
+
+    /**
+     * Returns Heights of the regions in the layout.
+     *
+     * @return int[]
+     */
+    public function getRegionHeights(): array
+    {
+        return $this->regionHeights;
+    }
+
+    /**
+     * Set Heights of the regions in the layout.
+     *
+     * @param array<string, Integer>
+     */
+    public function setRegionHeights($regionHeights)
+    {
+        $this->regionHeights = $regionHeights;
+    }
+
+    /**
+     * Returns Widths of the regions in the layout.
+     *
+     * @return int[]
+     */
+    public function getRegionWidths(): array
+    {
+        return $this->regionWidths;
+    }
+
+    /**
+     * Set Widths of the regions in the layout.
+     *
+     * @param array<string, Integer>
+     */
+    public function setRegionWidths($regionWidths)
+    {
+        $this->regionWidths = $regionWidths;
+    }
+
+    /**
+     * Returns URL parameters to add to Public URL requests.
+     *
+     * @return string
+     */
+    public function getReleaseUrlParams(): string
+    {
+        return $this->releaseUrlParams;
+    }
+
+    /**
+     * Set URL parameters to add to Public URL requests.
+     *
+     * @param string
+     */
+    public function setReleaseUrlParams($releaseUrlParams)
+    {
+        $this->releaseUrlParams = $releaseUrlParams;
+    }
+
+    /**
+     * Returns The identifier of the restriction to apply to this player.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getRestrictionId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->restrictionId;
+    }
+
+    /**
+     * Set The identifier of the restriction to apply to this player.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setRestrictionId($restrictionId)
+    {
+        $this->restrictionId = $restrictionId;
+    }
+
+    /**
+     * Returns Indicates whether to display the air date in the release list component.
+     *
+     * @return bool
+     */
+    public function getShowAirDate(): \boolean
+    {
+        return $this->showAirDate;
+    }
+
+    /**
+     * Set Indicates whether to display the air date in the release list component.
+     *
+     * @param bool
+     */
+    public function setShowAirDate($showAirDate)
+    {
+        $this->showAirDate = $showAirDate;
+    }
+
+    /**
+     * Returns Indicates whether to include the All option in the category list component.
+     *
+     * @return bool
+     */
+    public function getShowAllChoice(): \boolean
+    {
+        return $this->showAllChoice;
+    }
+
+    /**
+     * Set Indicates whether to include the All option in the category list component.
+     *
+     * @param bool
+     */
+    public function setShowAllChoice($showAllChoice)
+    {
+        $this->showAllChoice = $showAllChoice;
+    }
+
+    /**
+     * Returns Indicates whether to display the author in the release list and clip info components.
+     *
+     * @return bool
+     */
+    public function getShowAuthor(): \boolean
+    {
+        return $this->showAuthor;
+    }
+
+    /**
+     * Set Indicates whether to display the author in the release list and clip info components.
+     *
+     * @param bool
+     */
+    public function setShowAuthor($showAuthor)
+    {
+        $this->showAuthor = $showAuthor;
+    }
+
+    /**
+     * Returns Indicates whether to display the media bitrate in the release list component.
+     *
+     * @return bool
+     */
+    public function getShowBitrate(): \boolean
+    {
+        return $this->showBitrate;
+    }
+
+    /**
+     * Set Indicates whether to display the media bitrate in the release list component.
+     *
+     * @param bool
+     */
+    public function setShowBitrate($showBitrate)
+    {
+        $this->showBitrate = $showBitrate;
+    }
+
+    /**
+     * Returns Indicates whether to show the full video time in the player control rack.
+     *
+     * @return bool
+     */
+    public function getShowFullTime(): \boolean
+    {
+        return $this->showFullTime;
+    }
+
+    /**
+     * Set Indicates whether to show the full video time in the player control rack.
+     *
+     * @param bool
+     */
+    public function setShowFullTime($showFullTime)
+    {
+        $this->showFullTime = $showFullTime;
+    }
+
+    /**
+     * Returns Indicates whether to show the Most Popular option in the category list component.
+     *
+     * @return bool
+     */
+    public function getShowMostPopularChoice(): \boolean
+    {
+        return $this->showMostPopularChoice;
+    }
+
+    /**
+     * Set Indicates whether to show the Most Popular option in the category list component.
+     *
+     * @param bool
+     */
+    public function setShowMostPopularChoice($showMostPopularChoice)
+    {
+        $this->showMostPopularChoice = $showMostPopularChoice;
+    }
+
+    /**
+     * Returns Indicates whether to display the previous and next buttons in the player control rack.
+     *
+     * @return bool
+     */
+    public function getShowNav(): \boolean
+    {
+        return $this->showNav;
+    }
+
+    /**
+     * Set Indicates whether to display the previous and next buttons in the player control rack.
+     *
+     * @param bool
+     */
+    public function setShowNav($showNav)
+    {
+        $this->showNav = $showNav;
+    }
+
+    /**
+     * Returns Indicates whether to randomize the contents of the release list.
+     *
+     * @return bool
+     */
+    public function getShuffle(): \boolean
+    {
+        return $this->shuffle;
+    }
+
+    /**
+     * Set Indicates whether to randomize the contents of the release list.
+     *
+     * @param bool
+     */
+    public function setShuffle($shuffle)
+    {
+        $this->shuffle = $shuffle;
+    }
+
+    /**
+     * Returns Identifier for the skin object to apply this player.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getSkinId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->skinId;
+    }
+
+    /**
+     * Set Identifier for the skin object to apply this player.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setSkinId($skinId)
+    {
+        $this->skinId = $skinId;
+    }
+
+    /**
+     * Returns The height of the thumbnail images in the release list.
+     *
+     * @return int
+     */
+    public function getThumbnailHeight(): \Integer
+    {
+        return $this->thumbnailHeight;
+    }
+
+    /**
+     * Set The height of the thumbnail images in the release list.
+     *
+     * @param int
+     */
+    public function setThumbnailHeight($thumbnailHeight)
+    {
+        $this->thumbnailHeight = $thumbnailHeight;
+    }
+
+    /**
+     * Returns The width of the thumbnail images in the release list.
+     *
+     * @return int
+     */
+    public function getThumbnailWidth(): \Integer
+    {
+        return $this->thumbnailWidth;
+    }
+
+    /**
+     * Set The width of the thumbnail images in the release list.
+     *
+     * @param int
+     */
+    public function setThumbnailWidth($thumbnailWidth)
+    {
+        $this->thumbnailWidth = $thumbnailWidth;
+    }
+
+    /**
+     * Returns The name of this object.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set The name of this object.
+     *
+     * @param string
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Returns The date and time this object was last modified.
+     *
+     * @return \DateTime
+     */
+    public function getUpdated(): \DateTime
+    {
+        return $this->updated;
+    }
+
+    /**
+     * Set The date and time this object was last modified.
+     *
+     * @param \DateTime
+     */
+    public function setUpdated($updated)
+    {
+        $this->updated = $updated;
+    }
+
+    /**
+     * Returns The id of the user that last modified this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->updatedByUserId;
+    }
+
+    /**
+     * Set The id of the user that last modified this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setUpdatedByUserId($updatedByUserId)
+    {
+        $this->updatedByUserId = $updatedByUserId;
+    }
+
+    /**
+     * Returns Indicates whether to float the control rack over the media area of the player.
+     *
+     * @return bool
+     */
+    public function getUseFloatingControls(): \boolean
+    {
+        return $this->useFloatingControls;
+    }
+
+    /**
+     * Set Indicates whether to float the control rack over the media area of the player.
+     *
+     * @param bool
+     */
+    public function setUseFloatingControls($useFloatingControls)
+    {
+        $this->useFloatingControls = $useFloatingControls;
+    }
+
+    /**
+     * Returns This object's modification version, used for optimistic locking.
+     *
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * Set This object's modification version, used for optimistic locking.
+     *
+     * @param int
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+    }
+
+    /**
+     * Returns The width of the player.
+     *
+     * @return int
+     */
+    public function getWidth(): \Integer
+    {
+        return $this->width;
+    }
+
+    /**
+     * Set The width of the player.
+     *
+     * @param int
+     */
+    public function setWidth($width)
+    {
+        $this->width = $width;
+    }
+
+    /**
+     * Returns the name of the field containing the canonical identifier, such as 'id'.
+     *
+     * @return string The ID key.
+     */
+    public function getIdKey(): string
+    {
+        return 'id';
+    }
+
+    /**
+     * Returns an array of all defined compound keys.
+     *
+     * For example, a Media object would return @code [['ownerId', 'guid']] @endcode.
+     *
+     * @see https://docs.theplatform.com/help/media-media-object
+     *
+     * @return array[] An array of compound keys, each compound key as an array.
+     */
+    public function getCompoundKeys(): array
+    {
+        return [];
+    }
+
+    /**
+     * Returns an array of all custom keys.
+     *
+     * Typically, such keys are created by setting isUnique on the field.
+     *
+     * @see https://docs.theplatform.com/help/wsf-working-with-custom-fields#Workingwithcustomfields-Uniquecustomvalues
+     *
+     * @return string[] An array of custom keys.
+     */
+    public function getCustomKeys(): array
+    {
+        // TODO: Implement getCustomKeys() method.
+    }
+}

--- a/tests/fixtures/media-object.json
+++ b/tests/fixtures/media-object.json
@@ -1,0 +1,353 @@
+{
+  "id": "http://data.media.theplatform.com/media/data/Media/2602559",
+  "guid": "zYO7XMrWyix_9UCMurLYEWJPrWYHavMM",
+  "title": "thePlatform's History",
+  "author": "thePlatform",
+  "description": "Our CEO Ian Blaine discusses a bit of thePlatform's history",
+  "added": 1299622592000,
+  "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+  "updated": 1299624648000,
+  "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/58590342",
+  "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/58590342",
+  "version": 0,
+  "locked": false,
+  "availableDate": 1230796800000,
+  "expirationDate": 1609401600000,
+  "categories": [
+    {
+      "name": "thePlatform/Ian Blaine",
+      "scheme": "thePlatform",
+      "label": ""
+    },
+    {
+      "name": "Technology",
+      "scheme": "urn:cat-scheme",
+      "label": ""
+    }
+  ],
+  "copyright": "thePlatform",
+  "copyrightUrl": "http://theplatform.com/about/terms_of_service",
+  "credits": [
+    {
+      "role": "producer",
+      "scheme": "urn:ebu",
+      "value": "thePlatform"
+    },
+    {
+      "role": "director",
+      "scheme": "urn:ebu",
+      "value": "Steve Mack"
+    },
+    {
+      "role": "actor",
+      "scheme": "urn:ebu",
+      "value": "Ian Blaine"
+    },
+    {
+      "role": "author",
+      "scheme": "urn:ebu",
+      "value": "Melissa Tennant"
+    }
+  ],
+  "keywords": "thePlatform",
+  "ratings": [
+    {
+      "scheme": "urn:simple",
+      "rating": "non-adult"
+    }
+  ],
+  "countries": [
+    "cx"
+  ],
+  "excludeCountries": true,
+  "text": "",
+  "content": [
+    {
+      "audioChannels": 0,
+      "audioSampleRate": 0,
+      "bitrate": 30307523,
+      "checksums": {
+        "md5": "e2cac7082f0afc5f008c64a039880d27"
+      },
+      "contentType": "video",
+      "duration": 55.289,
+      "expression": "full",
+      "fileSize": 210243584,
+      "frameRate": 29.97,
+      "format": "AVI",
+      "height": 480,
+      "isDefault": false,
+      "language": "en",
+      "sourceTime": 0.0,
+      "url": "ftp://storage.theplatform.com/content/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+      "width": 720,
+      "id": "http://data.media.theplatform.com/media/data/MediaFile/2602561",
+      "guid": "qK6s9oXNUNkp7UP41_IV_QK5P2xmV3ml",
+      "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+      "added": 1299623075000,
+      "updated": 1299623887000,
+      "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "version": 1,
+      "locked": false,
+      "description": "",
+      "title": "ian_1_flexible_544309.avi",
+      "allowRelease": true,
+      "assetTypeIds": [
+        "http://data.media.theplatform.com/media/data/AssetType/2128951"
+      ],
+      "assetTypes": [
+        "mezzanine"
+      ],
+      "audioCodec": "",
+      "audioSampleSize": 0,
+      "downloadUrl": "",
+      "exists": true,
+      "failoverStreamingUrl": "",
+      "failoverSourceUrl": "",
+      "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+      "isProtected": false,
+      "isThumbnail": false,
+      "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+      "protectionKey": "",
+      "releases": [
+
+      ],
+      "serverId": "http://data.media.theplatform.com/media/data/Server/2600877",
+      "sourceMediaFileId": "",
+      "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/16/897/ian_1_flexible_544309.avi",
+      "storageUrl": "ftp://storage.theplatform.com/content/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+      "streamingUrl": "",
+      "transformId": "",
+      "videoCodec": "",
+      "approved": true,
+      "protectionScheme": "",
+      "aspectRatio": 1.5,
+      "previousLocations": [
+
+      ]
+    },
+    {
+      "audioChannels": 0,
+      "audioSampleRate": 0,
+      "bitrate": 600000,
+      "checksums": {
+        "md5": "26ac0a3e10717af6e7e881bddf73eef2"
+      },
+      "contentType": "video",
+      "duration": 55.333,
+      "expression": "full",
+      "fileSize": 4843251,
+      "frameRate": 0.0,
+      "format": "FLV",
+      "height": 420,
+      "isDefault": false,
+      "language": "en",
+      "sourceTime": 0.0,
+      "url": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+      "width": 560,
+      "id": "http://data.media.theplatform.com/media/data/MediaFile/2602603",
+      "guid": "d5xGaKF2JxmLf53QSL99DW4O6C8U6oni",
+      "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+      "added": 1299623178000,
+      "updated": 1299624648000,
+      "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "version": 1,
+      "locked": false,
+      "description": "",
+      "title": "ian_1_flexible.flv",
+      "allowRelease": true,
+      "assetTypeIds": [
+        "http://data.media.theplatform.com/media/data/AssetType/2128950"
+      ],
+      "assetTypes": [
+        "video"
+      ],
+      "audioCodec": "",
+      "audioSampleSize": 0,
+      "downloadUrl": "",
+      "exists": true,
+      "failoverStreamingUrl": "",
+      "failoverSourceUrl": "",
+      "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+      "isProtected": false,
+      "isThumbnail": false,
+      "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+      "protectionKey": "",
+      "releases": [
+        {
+          "id": "http://data.media.theplatform.com/media/data/Release/2602609",
+          "guid": "ZYmP6QQgCLz0OpNSoiJqnmNDmU_0nTyj",
+          "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+          "added": 1299624648000,
+          "updated": 1299624648000,
+          "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/9320345",
+          "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/9320345",
+          "version": 0,
+          "locked": false,
+          "description": "",
+          "approved": true,
+          "delivery": "streaming",
+          "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+          "fileId": "http://data.media.theplatform.com/media/data/MediaFile/2602603",
+          "pid": "UIYsTlf6Susa",
+          "parameters": "",
+          "url": "http://link.theplatform.com/s/MTYzMzY5NDE3/UIYsTlf6Susa",
+          "restrictionId": "",
+          "adPolicyId": ""
+        }
+      ],
+      "serverId": "http://data.media.theplatform.com/media/data/Server/2602560",
+      "sourceMediaFileId": "",
+      "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/226/426/ian_1_flexible.flv",
+      "storageUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+      "streamingUrl": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+      "transformId": "",
+      "videoCodec": "",
+      "approved": true,
+      "protectionScheme": "",
+      "aspectRatio": 1.33,
+      "previousLocations": [
+
+      ]
+    }
+  ],
+  "thumbnails": [
+    {
+      "audioChannels": 0,
+      "audioSampleRate": 0,
+      "bitrate": 0,
+      "checksums": {
+        "md5": "a9b5fdea0070fcabf0bbbabfd96f9036"
+      },
+      "contentType": "image",
+      "duration": 0.0,
+      "expression": "full",
+      "fileSize": 25819,
+      "frameRate": 0.0,
+      "format": "JPEG",
+      "height": 240,
+      "isDefault": true,
+      "language": "",
+      "sourceTime": 0.0,
+      "url": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+      "width": 320,
+      "id": "http://data.media.theplatform.com/media/data/MediaFile/2602653",
+      "guid": "D5JgEa2oXlnAdZ8jsKEpLXmYoRll8NV0",
+      "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+      "added": 1299623213000,
+      "updated": 1299624193000,
+      "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+      "version": 1,
+      "locked": false,
+      "description": "",
+      "title": "ian_1_flexible_320x240.jpg",
+      "allowRelease": true,
+      "assetTypeIds": [
+        "http://data.media.theplatform.com/media/data/AssetType/2128952"
+      ],
+      "assetTypes": [
+        "thumbnail"
+      ],
+      "audioCodec": "",
+      "audioSampleSize": 0,
+      "downloadUrl": "",
+      "exists": true,
+      "failoverStreamingUrl": "",
+      "failoverSourceUrl": "",
+      "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+      "isProtected": false,
+      "isThumbnail": true,
+      "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+      "protectionKey": "",
+      "releases": [
+
+      ],
+      "serverId": "http://data.media.theplatform.com/media/data/Server/2602560",
+      "sourceMediaFileId": "",
+      "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/226/426/ian_1_flexible_320x240.jpg",
+      "storageUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+      "streamingUrl": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+      "transformId": "",
+      "videoCodec": "",
+      "approved": true,
+      "protectionScheme": "",
+      "aspectRatio": 1.33,
+      "previousLocations": [
+
+      ]
+    }
+  ],
+  "adminTags": [
+    "corp site content"
+  ],
+  "approved": true,
+  "categoryIds": [
+    "http://data.media.theplatform.com/media/data/Category/2127592",
+    "http://data.media.theplatform.com/media/data/Category/2127590"
+  ],
+  "chapters": [
+    {
+      "startTime": 0.0,
+      "endTime": 21.8,
+      "title": "Chapter 1",
+      "thumbnailUrl": ""
+    },
+    {
+      "startTime": 21.9,
+      "endTime": 55.0,
+      "title": "Chapter 2",
+      "thumbnailUrl": ""
+    }
+  ],
+  "link": "http://www.theplatform.com/about/",
+  "pubDate": 1256661120000,
+  "titleLocalized": {
+    "en-us": "thePlatform's History",
+    "es-mx": "Historia de thePlatform"
+  },
+  "descriptionLocalized": {
+
+  },
+  "authorLocalized": {
+
+  },
+  "copyrightLocalized": {
+
+  },
+  "copyrightUrlLocalized": {
+
+  },
+  "keywordsLocalized": {
+
+  },
+  "linkLocalized": {
+
+  },
+  "textLocalized": {
+
+  },
+  "defaultThumbnailUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+  "originalOwnerIds": [
+
+  ],
+  "provider": "",
+  "providerId": "",
+  "restrictionId": "",
+  "adPolicyId": "",
+  "programId": "",
+  "seriesId": "",
+  "availabilityState": "available",
+  "pid": "Zy1n9JQPy6hw",
+  "publicUrl": "",
+  "availabilityTags": [
+  ],
+  "availabilityWindows": [
+  ],
+  "fileSourceMediaId": "http://example.com/reserved-for-future-use",
+  "originalMediaIds": [
+    "http://example.com/media-url"
+  ]
+}

--- a/tests/fixtures/player-object.json
+++ b/tests/fixtures/player-object.json
@@ -1,0 +1,203 @@
+{
+  "id": "http://data.player.theplatform.com/player/data/Player/34928",
+  "guid": "yahtocha4aiP2aiVah4Jee7ahkohK2qu",
+  "updated": 1479405200000,
+  "title": "MPX Production Player",
+  "description": "Universal player used by the Production environment.",
+  "added": 1464885946000,
+  "ownerId": "http://access.auth.theplatform.com/data/Account/1",
+  "addedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mpx/1",
+  "updatedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mpx/1",
+  "version": 16,
+  "locked": false,
+  "paddingLeft": -1,
+  "paddingTop": -1,
+  "paddingRight": -1,
+  "paddingBottom": -1,
+  "height": 0,
+  "width": 0,
+  "allowFullScreen": true,
+  "backgroundImageUrl": "",
+  "colorSchemeId": "http://data.player.theplatform.com/player/data/ColorScheme/",
+  "columns": 0,
+  "disabled": false,
+  "headerImageHeight": 0,
+  "headerImageUrl": "",
+  "itemsPerPage": 0,
+  "layoutId": "http://data.player.theplatform.com/player/data/Layout/1",
+  "limitToCategories": [],
+  "overlayImageUrl": "",
+  "feedUrl": "https://feed.theplatform.com/f/jei1iS/Ohy1tahcoo1y",
+  "feedUrlParams": "",
+  "releaseUrlParams": "",
+  "skinId": "http://data.player.theplatform.com/player/data/Skin/1",
+  "showAirdate": false,
+  "showAuthor": false,
+  "showBitrate": false,
+  "thumbnailHeight": 0,
+  "thumbnailWidth": 0,
+  "allowSearch": true,
+  "allowEmail": true,
+  "allowGetLink": true,
+  "allowEmbed": true,
+  "alwaysShowOverlay": true,
+  "autoPlay": true,
+  "controlRackHeight": 0,
+  "embedAllowFullScreen": true,
+  "embedHeight": 387,
+  "embedWidth": 688,
+  "playAll": true,
+  "playerUrl": "",
+  "linkUrl": "",
+  "endCardFeedUrl": "",
+  "showAllChoice": false,
+  "showFullTime": true,
+  "showMostPopularChoice": false,
+  "showNav": false,
+  "shuffle": false,
+  "useFloatingControls": true,
+  "restrictionId": null,
+  "embedRestrictionId": null,
+  "adPolicyId": null,
+  "embedAdPolicyId": null,
+  "preferredRuntimes": [
+    "universal",
+    "flash",
+    "html5"
+  ],
+  "preferredFormats": [
+    "F4M",
+    "M3U",
+    "MPEG4"
+  ],
+  "aspectRatioWidth": 16,
+  "aspectRatioHeight": 9,
+  "controlLayoutXml": "",
+  "customHtml": "",
+  "customCss": "html, body {\n\t\t\tmargin: 0;\n\t\t\tpadding: 0;\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\toverflow: hidden;\n\t\t\tborder: 0;\n\t\t}\n\t\t.tpLayout {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t}\n\t\t.tpMessage {\n\t\t\tfont-size: 14px;\n\t\t\tcolor: #bebebe;\n\t\t\tbackground: #131313;\n\t\t}\n\t\t#player {\n\t\t\tmargin: 0;\n\t\t\tpadding: 0;\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t}\n\t\t.tpBackground {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tpadding:0px;\n\t\t}\n\t\t.tpContainer {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tpadding:0px;\n\t\t}\n\n.tpPlayerCard.tpSubtitleStylesCard\n{\n\toverflow: auto;\n}\n\n.tpPlayerCard .tpSubtitlesForm\n{\n\tfont-size: 14px;\n}\n.tpPlayerCard .tpFontColor, .tpPlayerCard .tpFontBackgroundColor, .tpPlayerCard .tpFontEdgeColor {\n\twidth: 15px;\n\theight: 15px;\n\tfloat: left;\n\tcursor: hand;\n\tborder-style: solid;\n\tborder-width: 1px;\n\tmargin-right: 4px;\n\ttext-align: center;\n\tcursor: pointer;\n}\n\n.tpPlayerCard select {\n\tcolor: #FFFFFF;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard .tpCardClose .tpButton\n{\n\tfloat: right;\n\tmargin-right: 4px;\n\twidth: 120px;\n\theight: 34px;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard .tpFormActions .tpButton\n{\n\tfloat: right;\n\tmargin-right: 4px;\n\twidth: 120px;\n\theight: 34px;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard input\n{\n\theight: auto;\n}",
+  "customJavaScript": "$pdk.env.Detect.getInstance().addToConfigSet(\"flashblacklist\", \"\");\n\nif ($(window).width() < 450) {\n  $pdk.controller.setPlayerLayoutUrl(\"https://bravo-video.nbcuni.com/up/PDK/metalayout/smallMetaLayout.xml\");\n}else{\n  $pdk.controller.setPlayerLayoutUrl(\"https://bravo-video.nbcuni.com/up/PDK/metalayout/normalMetaLayout-univ.xml\");\n}\n\nNBCUOmniture.initialize(null);\n\nfunction tpExtCompanionAdScriptCallback(htmlAdContent, deprecatedParam, height, width, mimeType, slotCustomId) {\nconsole.log(\"INSIDE tpExtCompanionAdScriptCallback\");\n  var companionAdEventObj = {\n    id: slotCustomId,\n    mime: mimeType,\n    html: htmlAdContent,\n    width: width,\n    height: height\n  };\n  $pdk.controller.dispatchEvent(\"onCompanionAd\", companionAdEventObj);\n}\n\n$('document').ready( function() {\n  if (fw.gup('m') !== '1') {\n    $('body').append(fw.slot(728, 90));\n    $('body').append(fw.slot(300, 60));\n    $('body').append(fw.slot(300, 250));\n  }\n  $('.controlsLayer').css('visibility','hidden');\n});",
+  "includeDefaultCss": true,
+  "regionWidths": {
+    "player": 688
+  },
+  "regionHeights": {
+    "player": 387
+  },
+  "customProperties": {
+    "endCard": "none",
+    "allowBandwidth": "false"
+  },
+  "enabledPlugIns": [
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/1",
+      "regionName": "player",
+      "params": {
+        "persistentlabels": "c1=2,ns_site=tpf,tp_cid=CUST,tp_type=production",
+        "timinglabel": "tp_st_ps",
+        "labelmapping": "ns_st_cl=clip.length,ns_st_pl=playlist.title,ns_st_pr=playlist.feed,ns_st_ep=playlist.title,tp_aid=playlist.accountID,tp_st_cat=content.baseclip.categories,tp_st_mp=playlist.player,tp_st_guid=content.baseclip.guid",
+        "sendErrors": "true",
+        "sendload": "true",
+        "priority": "1",
+        "c2": "9924155"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/2",
+      "regionName": "player",
+      "params": {
+        "visitorNamespace": "visitor",
+        "trackVars": "eVar4,eVar7,eVar9,eVar11,eVar12,eVar13,eVar14,eVar27,eVar32,eVar36,eVar37,eVar38,eVar39,eVar40,eVar41,eVar42,eVar44,eVar45,eVar47,eVar48,eVar49,eVar50,eVar75,prop2,prop8,prop9,prop20,prop42,prop43,prop44,prop45,prop46,prop50,products,events",
+        "host": "oimg.nbcuni.com",
+        "secureHost": "osimg.nbcuni.com",
+        "trackEvents": "event20,event21,event22,event23,event24,event25,event26,event27,event28,event29,event30,event31,event81,event82,event70,event71,event72,event73,event74,event75,event76,event77,event78,event79,event80",
+        "priority": "1",
+        "account": "nbcuglobal",
+        "dc": "112",
+        "frequency": "25%"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/3",
+      "regionName": "player",
+      "params": {
+        "path": "https://example.com/PDK/img/ratings/",
+        "enableAgeVerification": "false",
+        "delay": "10",
+        "reminder": "20",
+        "showRatings": "true",
+        "priority": "1"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/4",
+      "regionName": "player",
+      "params": {
+        "bufferProfile": "livestable",
+        "manifest": "true",
+        "videoLayer": "akamaihd",
+        "priority": "1",
+        "fallback": "switch=progressive"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/4",
+      "regionName": "player",
+      "params": {
+        "enablecustomparse": "true",
+        "DPR": "true",
+        "apid": "P11111111-2222-3333-4444-555555555555",
+        "sfcode": "us",
+        "lfappend": "true",
+        "priority": "1",
+        "apn": "Production Player"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/6",
+      "regionName": "player",
+      "params": {
+        "labelmapping": "c3=\"bravo\",c4=\"*null\",c6=content.baseclip.categories",
+        "priority": "1",
+        "c2": "3000039"
+      }
+    },
+    {
+      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/5",
+      "regionName": "player",
+      "params": {
+        "pemURLs": "http://example.com/p/AnalyticsExtension.swf",
+        "playerProfile": "live_profile",
+        "siteSectionId": "cable_default",
+        "adManagerUrl": "http://adm.example.com/p/AdManager.{ext}",
+        "priority": "1",
+        "customVideoAssetIdField": "externalAdvertiserId",
+        "isLive": "false",
+        "exitFullscreenOnPause": "true",
+        "serverUrl": "http://example.com",
+        "playerProfileHTML5": "live_jsam",
+        "networkId": "12345",
+        "requestTimeout": "5",
+        "pemURLsSeparator": ","
+      }
+    }
+  ],
+  "adminTags": [],
+  "enableExternalController": true,
+  "autoInitialize": true,
+  "allowRss": true,
+  "customCssUrls": [
+    "//example.com/PDK/card/ui-7.css"
+  ],
+  "customJavaScriptUrls": [
+    "https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"
+  ],
+  "posterImagePreviewAssetType": null,
+  "posterImageMetaAssetType": null,
+  "posterImageDefaultWidth": -1,
+  "posterImageDefaultHeight": -1,
+  "failoverHtml": null,
+  "compatibilityMode": false,
+  "fallbackPdk": null,
+  "pdk": null,
+  "pid": "production"
+}

--- a/tests/fixtures/player-object.json
+++ b/tests/fixtures/player-object.json
@@ -1,203 +1,122 @@
 {
-  "id": "http://data.player.theplatform.com/player/data/Player/34928",
-  "guid": "yahtocha4aiP2aiVah4Jee7ahkohK2qu",
-  "updated": 1479405200000,
-  "title": "MPX Production Player",
-  "description": "Universal player used by the Production environment.",
-  "added": 1464885946000,
-  "ownerId": "http://access.auth.theplatform.com/data/Account/1",
-  "addedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mpx/1",
-  "updatedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mpx/1",
-  "version": 16,
-  "locked": false,
-  "paddingLeft": -1,
-  "paddingTop": -1,
-  "paddingRight": -1,
-  "paddingBottom": -1,
-  "height": 0,
-  "width": 0,
-  "allowFullScreen": true,
-  "backgroundImageUrl": "",
-  "colorSchemeId": "http://data.player.theplatform.com/player/data/ColorScheme/",
-  "columns": 0,
-  "disabled": false,
-  "headerImageHeight": 0,
-  "headerImageUrl": "",
-  "itemsPerPage": 0,
-  "layoutId": "http://data.player.theplatform.com/player/data/Layout/1",
-  "limitToCategories": [],
-  "overlayImageUrl": "",
-  "feedUrl": "https://feed.theplatform.com/f/jei1iS/Ohy1tahcoo1y",
-  "feedUrlParams": "",
-  "releaseUrlParams": "",
-  "skinId": "http://data.player.theplatform.com/player/data/Skin/1",
-  "showAirdate": false,
-  "showAuthor": false,
-  "showBitrate": false,
-  "thumbnailHeight": 0,
-  "thumbnailWidth": 0,
-  "allowSearch": true,
-  "allowEmail": true,
-  "allowGetLink": true,
-  "allowEmbed": true,
-  "alwaysShowOverlay": true,
-  "autoPlay": true,
-  "controlRackHeight": 0,
-  "embedAllowFullScreen": true,
-  "embedHeight": 387,
-  "embedWidth": 688,
-  "playAll": true,
-  "playerUrl": "",
-  "linkUrl": "",
-  "endCardFeedUrl": "",
-  "showAllChoice": false,
-  "showFullTime": true,
-  "showMostPopularChoice": false,
-  "showNav": false,
-  "shuffle": false,
-  "useFloatingControls": true,
-  "restrictionId": null,
-  "embedRestrictionId": null,
-  "adPolicyId": null,
-  "embedAdPolicyId": null,
-  "preferredRuntimes": [
-    "universal",
-    "flash",
-    "html5"
-  ],
-  "preferredFormats": [
-    "F4M",
-    "M3U",
-    "MPEG4"
-  ],
-  "aspectRatioWidth": 16,
-  "aspectRatioHeight": 9,
-  "controlLayoutXml": "",
-  "customHtml": "",
-  "customCss": "html, body {\n\t\t\tmargin: 0;\n\t\t\tpadding: 0;\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\toverflow: hidden;\n\t\t\tborder: 0;\n\t\t}\n\t\t.tpLayout {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t}\n\t\t.tpMessage {\n\t\t\tfont-size: 14px;\n\t\t\tcolor: #bebebe;\n\t\t\tbackground: #131313;\n\t\t}\n\t\t#player {\n\t\t\tmargin: 0;\n\t\t\tpadding: 0;\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t}\n\t\t.tpBackground {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tpadding:0px;\n\t\t}\n\t\t.tpContainer {\n\t\t\twidth: 100%;\n\t\t\theight: 100%;\n\t\t\tpadding:0px;\n\t\t}\n\n.tpPlayerCard.tpSubtitleStylesCard\n{\n\toverflow: auto;\n}\n\n.tpPlayerCard .tpSubtitlesForm\n{\n\tfont-size: 14px;\n}\n.tpPlayerCard .tpFontColor, .tpPlayerCard .tpFontBackgroundColor, .tpPlayerCard .tpFontEdgeColor {\n\twidth: 15px;\n\theight: 15px;\n\tfloat: left;\n\tcursor: hand;\n\tborder-style: solid;\n\tborder-width: 1px;\n\tmargin-right: 4px;\n\ttext-align: center;\n\tcursor: pointer;\n}\n\n.tpPlayerCard select {\n\tcolor: #FFFFFF;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard .tpCardClose .tpButton\n{\n\tfloat: right;\n\tmargin-right: 4px;\n\twidth: 120px;\n\theight: 34px;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard .tpFormActions .tpButton\n{\n\tfloat: right;\n\tmargin-right: 4px;\n\twidth: 120px;\n\theight: 34px;\n}\n\n.tpPlayerCard.tpSubtitleStylesCard input\n{\n\theight: auto;\n}",
-  "customJavaScript": "$pdk.env.Detect.getInstance().addToConfigSet(\"flashblacklist\", \"\");\n\nif ($(window).width() < 450) {\n  $pdk.controller.setPlayerLayoutUrl(\"https://bravo-video.nbcuni.com/up/PDK/metalayout/smallMetaLayout.xml\");\n}else{\n  $pdk.controller.setPlayerLayoutUrl(\"https://bravo-video.nbcuni.com/up/PDK/metalayout/normalMetaLayout-univ.xml\");\n}\n\nNBCUOmniture.initialize(null);\n\nfunction tpExtCompanionAdScriptCallback(htmlAdContent, deprecatedParam, height, width, mimeType, slotCustomId) {\nconsole.log(\"INSIDE tpExtCompanionAdScriptCallback\");\n  var companionAdEventObj = {\n    id: slotCustomId,\n    mime: mimeType,\n    html: htmlAdContent,\n    width: width,\n    height: height\n  };\n  $pdk.controller.dispatchEvent(\"onCompanionAd\", companionAdEventObj);\n}\n\n$('document').ready( function() {\n  if (fw.gup('m') !== '1') {\n    $('body').append(fw.slot(728, 90));\n    $('body').append(fw.slot(300, 60));\n    $('body').append(fw.slot(300, 250));\n  }\n  $('.controlsLayer').css('visibility','hidden');\n});",
-  "includeDefaultCss": true,
-  "regionWidths": {
-    "player": 688
-  },
-  "regionHeights": {
-    "player": 387
-  },
-  "customProperties": {
-    "endCard": "none",
-    "allowBandwidth": "false"
-  },
-  "enabledPlugIns": [
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/1",
-      "regionName": "player",
-      "params": {
-        "persistentlabels": "c1=2,ns_site=tpf,tp_cid=CUST,tp_type=production",
-        "timinglabel": "tp_st_ps",
-        "labelmapping": "ns_st_cl=clip.length,ns_st_pl=playlist.title,ns_st_pr=playlist.feed,ns_st_ep=playlist.title,tp_aid=playlist.accountID,tp_st_cat=content.baseclip.categories,tp_st_mp=playlist.player,tp_st_guid=content.baseclip.guid",
-        "sendErrors": "true",
-        "sendload": "true",
-        "priority": "1",
-        "c2": "9924155"
-      }
+    "id": "http://data.player.test.corp.theplatform.com/player/data/Player/1424281",
+    "guid": "V2ePA6WcdF0y29G1Y3wUcoqm_RiIM6Pu",
+    "updated": 1335378125000,
+    "title": "Fancy new player",
+    "description": "To be used on our main site",
+    "added": 1335377369000,
+    "ownerId": "http://access.auth.theplatform.com/data/Account/165515816",
+    "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/5",
+    "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/5",
+    "version": 1,
+    "locked": false,
+    "paddingLeft": -1,
+    "paddingTop": -1,
+    "paddingRight": -1,
+    "paddingBottom": -1,
+    "height": 0,
+    "width": 0,
+    "pid": "2qDVKDWgwe_g",
+    "allowFullScreen": true,
+    "backgroundImageUrl": "http://example.org/images/sample.png",
+    "colorSchemeId": "http://data.player.theplatform.com/player/data/ColorScheme/1314564",
+    "columns": 0,
+    "disabled": false,
+    "headerImageHeight": 0,
+    "headerImageUrl": "http://example.org/images/background.png",
+    "itemsPerPage": 0,
+    "layoutId": "http://data.player.theplatform.com/player/data/Layout/210951",
+    "limitToCategories": [
+        "Sports",
+        "News"
+    ],
+    "overlayImageUrl": "http://example.org/images/overlay.png",
+    "feedUrl": "http://feed.media.theplatform.com/f/cons/Spq1ms2pbT1l",
+    "feedUrlParams": "count=true",
+    "releaseUrlParams": "mbr=true",
+    "skinId": "http://data.player.theplatform.com/player/data/Skin/1038",
+    "showAirdate": false,
+    "showAuthor": false,
+    "showBitrate": false,
+    "thumbnailHeight": 0,
+    "thumbnailWidth": 0,
+    "allowSearch": true,
+    "allowEmail": true,
+    "allowGetLink": true,
+    "allowEmbed": true,
+    "alwaysShowOverlay": false,
+    "autoPlay": false,
+    "controlRackHeight": 0,
+    "embedAllowFullScreen": true,
+    "embedHeight": 0,
+    "embedWidth": 0,
+    "playAll": false,
+    "playerUrl": "http://player.theplatform.com/p/customer/mainplayer",
+    "linkUrl": "http://example.org",
+    "endCardFeedUrl": "http://feed.media.theplatform.com/f/cons/5rfyyRD30",
+    "showAllChoice": true,
+    "showFullTime": false,
+    "showMostPopularChoice": false,
+    "showNav": false,
+    "shuffle": false,
+    "useFloatingControls": true,
+    "restrictionId": "http://data.delivery.theplatform.com/delivery/data/Restriction/644",
+    "embedRestrictionId": "http://data.delivery.theplatform.com/delivery/data/Restriction/645",
+    "adPolicyId": "http://data.delivery.theplatform.com/delivery/data/AdPolicy/1601",
+    "embedAdPolicyId": "http://data.delivery.theplatform.com/delivery/data/AdPolicy/1602",
+    "preferredRuntimes": [
+        "Flash",
+        "HTML5"
+    ],
+    "preferredFormats": [
+        "mpeg4",
+        "webm"
+    ],
+    "aspectRatioWidth": 0,
+    "aspectRatioHeight": 0,
+    "controlLayoutXml": "<controls> <region /> </controls>",
+    "customHtml": "<html><head>...",
+    "customCss": ".body {margin: auto}...",
+    "customJavaScript": "function s(){...",
+    "includeDefaultCss": true,
+    "regionWidths": {
+        "player": 1024
     },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/2",
-      "regionName": "player",
-      "params": {
-        "visitorNamespace": "visitor",
-        "trackVars": "eVar4,eVar7,eVar9,eVar11,eVar12,eVar13,eVar14,eVar27,eVar32,eVar36,eVar37,eVar38,eVar39,eVar40,eVar41,eVar42,eVar44,eVar45,eVar47,eVar48,eVar49,eVar50,eVar75,prop2,prop8,prop9,prop20,prop42,prop43,prop44,prop45,prop46,prop50,products,events",
-        "host": "oimg.nbcuni.com",
-        "secureHost": "osimg.nbcuni.com",
-        "trackEvents": "event20,event21,event22,event23,event24,event25,event26,event27,event28,event29,event30,event31,event81,event82,event70,event71,event72,event73,event74,event75,event76,event77,event78,event79,event80",
-        "priority": "1",
-        "account": "nbcuglobal",
-        "dc": "112",
-        "frequency": "25%"
-      }
+    "regionHeights": {
+        "player": 768
     },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/3",
-      "regionName": "player",
-      "params": {
-        "path": "https://example.com/PDK/img/ratings/",
-        "enableAgeVerification": "false",
-        "delay": "10",
-        "reminder": "20",
-        "showRatings": "true",
-        "priority": "1"
-      }
+    "customProperties": {
+        "endCard": "tpMenuCard",
+        "overrideNativeControls": "true"
     },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/4",
-      "regionName": "player",
-      "params": {
-        "bufferProfile": "livestable",
-        "manifest": "true",
-        "videoLayer": "akamaihd",
-        "priority": "1",
-        "fallback": "switch=progressive"
-      }
-    },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/4",
-      "regionName": "player",
-      "params": {
-        "enablecustomparse": "true",
-        "DPR": "true",
-        "apid": "P11111111-2222-3333-4444-555555555555",
-        "sfcode": "us",
-        "lfappend": "true",
-        "priority": "1",
-        "apn": "Production Player"
-      }
-    },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/6",
-      "regionName": "player",
-      "params": {
-        "labelmapping": "c3=\"bravo\",c4=\"*null\",c6=content.baseclip.categories",
-        "priority": "1",
-        "c2": "3000039"
-      }
-    },
-    {
-      "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/5",
-      "regionName": "player",
-      "params": {
-        "pemURLs": "http://example.com/p/AnalyticsExtension.swf",
-        "playerProfile": "live_profile",
-        "siteSectionId": "cable_default",
-        "adManagerUrl": "http://adm.example.com/p/AdManager.{ext}",
-        "priority": "1",
-        "customVideoAssetIdField": "externalAdvertiserId",
-        "isLive": "false",
-        "exitFullscreenOnPause": "true",
-        "serverUrl": "http://example.com",
-        "playerProfileHTML5": "live_jsam",
-        "networkId": "12345",
-        "requestTimeout": "5",
-        "pemURLsSeparator": ","
-      }
-    }
-  ],
-  "adminTags": [],
-  "enableExternalController": true,
-  "autoInitialize": true,
-  "allowRss": true,
-  "customCssUrls": [
-    "//example.com/PDK/card/ui-7.css"
-  ],
-  "customJavaScriptUrls": [
-    "https://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"
-  ],
-  "posterImagePreviewAssetType": null,
-  "posterImageMetaAssetType": null,
-  "posterImageDefaultWidth": -1,
-  "posterImageDefaultHeight": -1,
-  "failoverHtml": null,
-  "compatibilityMode": false,
-  "fallbackPdk": null,
-  "pdk": null,
-  "pid": "production"
+    "enabledPlugIns": [
+         {
+            "plugInId": "http://data.player.theplatform.com/player/data/PlugIn/5555",
+            "regionName": "player",
+            "params": {
+                "priority": "1"
+            }
+        }
+    ],
+    "adminTags": [
+        "workflow_main"
+    ],
+    "enableExternalController": true,
+    "autoInitialize": true,
+    "allowRss": true,
+    "customCssUrls": [
+
+    ],
+    "customJavaScriptUrls": [
+
+    ],
+    "posterImagePreviewAssetType" : null,
+    "posterImageMetaAssetType": null,
+    "posterImageDefaultWidth": -1,
+    "posterImageDefaultHeight": -1,
+    "failoverHtml": null,
+    "compatibilityMode": false,
+    "fallbackPdk": null,
+    "pdk": null,
+    "pid": "DemoPlayer"
 }

--- a/tests/fixtures/player-object.json
+++ b/tests/fixtures/player-object.json
@@ -110,13 +110,13 @@
     "customJavaScriptUrls": [
 
     ],
-    "posterImagePreviewAssetType" : null,
-    "posterImageMetaAssetType": null,
+    "posterImagePreviewAssetType" : "asset-type",
+    "posterImageMetaAssetType": "asset-type",
     "posterImageDefaultWidth": -1,
     "posterImageDefaultHeight": -1,
-    "failoverHtml": null,
+    "failoverHtml": "<p>failover</p>",
     "compatibilityMode": false,
-    "fallbackPdk": null,
-    "pdk": null,
+    "fallbackPdk": "reserved",
+    "pdk": "reserved",
     "pid": "DemoPlayer"
 }

--- a/tests/src/Unit/DataService/Media/MediaTest.php
+++ b/tests/src/Unit/DataService/Media/MediaTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Media;
+
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+
+/**
+ * Test the Media data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Media\Media
+ */
+class MediaTest extends ObjectTestBase
+{
+    protected $class = Media::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->loadFixture('media-object.json');
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return array
+     */
+    public function getSetMethods()
+    {
+        $tests = parent::getSetMethods();
+        $tests['added'] = ['added', \DateTime::createFromFormat('U.u', '1299622592.000')];
+        $tests['updated'] = ['updated', \DateTime::createFromFormat('U.u', '1299624648.000')];
+        $tests['availableDate'] = ['availableDate', \DateTime::createFromFormat('U.u', '1230796800.000')];
+        $tests['expirationDate'] = ['expirationDate', \DateTime::createFromFormat('U.u', '1609401600.000')];
+        $tests['pubDate'] = ['pubDate', \DateTime::createFromFormat('U.u', '1256661120.000')];
+
+        return $tests;
+    }
+}

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Base class for testing data objects from MPX.
+ */
+abstract class ObjectTestBase extends TestCase
+{
+    /**
+     * The class to test. All concrete implementations must set this property.
+     *
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * The serializer used to decode the data.
+     *
+     * @var Serializer
+     */
+    protected $serializer;
+
+    /**
+     * The decoded player object fixture.
+     *
+     * @var array
+     */
+    protected $decoded;
+
+    /**
+     * Return an array of methods to test.
+     *
+     * @return array The array of methods to test.
+     */
+    public function getSetMethods()
+    {
+        $r = new \ReflectionClass($this->class);
+        $tests = [];
+        foreach ($r->getProperties() as $property) {
+            $tests[$property->getName()] = [$property->getName()];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * @param $fixture
+     */
+    protected function loadFixture($fixture): void
+    {
+        $encoders = [new JsonEncoder()];
+        $normalizers = [new ObjectNormalizer()];
+        $this->serializer = new Serializer($normalizers, $encoders);
+
+        $data = file_get_contents(__DIR__."/../../../fixtures/$fixture");
+        $this->decoded = \GuzzleHttp\json_decode($data, true);
+    }
+
+    /**
+     * @param $class
+     * @param string $field
+     * @param $expected
+     */
+    protected function assertObjectClass($class, string $field, $expected)
+    {
+        // This significantly improves test performance as we only deserialize a single field at a time.
+        $filtered = [
+            $field => $this->decoded[$field],
+        ];
+
+        // @todo This is a total hack as MPX returns JSON with null values. Replace by omitting in the normalizer.
+        $filtered = array_filter(
+            $filtered,
+            function ($value) {
+                return null !== $value;
+            }
+        );
+        $data = json_encode($filtered);
+
+        $player = $this->serializer->deserialize($data, $class, 'json');
+
+        $method = 'get'.ucfirst($field);
+        if (!$expected) {
+            $expected = $filtered[$field];
+        }
+        $this->assertEquals($expected, $player->$method());
+    }
+}

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -52,7 +52,7 @@ abstract class ObjectTestBase extends TestCase
     /**
      * @param $fixture
      */
-    protected function loadFixture($fixture): void
+    protected function loadFixture($fixture)
     {
         $encoders = [new JsonEncoder()];
         $normalizers = [new ObjectNormalizer()];

--- a/tests/src/Unit/DataService/Player/PlayerTest.php
+++ b/tests/src/Unit/DataService/Player/PlayerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Player;
+
+use Lullabot\Mpx\DataService\Player\Player;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Tests the Player object.
+ *
+ * This class explicitly doesn't use method coverage markers because it would be hundreds of lines.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\DataService\Player\Player
+ */
+class PlayerTest extends TestCase
+{
+    /**
+     * The serializer used to decode the data.
+     *
+     * @var Serializer
+     */
+    protected $serializer;
+
+    /**
+     * The decoded player object fixture.
+     *
+     * @var array
+     */
+    protected $decoded;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $encoders = [new JsonEncoder()];
+        $normalizers = [new ObjectNormalizer()];
+        $this->serializer = new Serializer($normalizers, $encoders);
+
+        $data = file_get_contents(__DIR__.'/../../../../fixtures/player-object.json');
+        $this->decoded = \GuzzleHttp\json_decode($data, true);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        // This significantly improves test performance as we only deserialize a single field at a time.
+        $filtered = [
+            $field => $this->decoded[$field],
+        ];
+
+        // @todo This is a total hack as MPX returns JSON with null values. Replace by omitting in the normalizer.
+        $filtered = array_filter($filtered, function ($value) {
+            return null !== $value;
+        });
+        $data = json_encode($filtered);
+
+        $player = $this->serializer->deserialize($data, Player::class, 'json');
+        $data = json_decode($data, true);
+
+        $method = 'get'.ucfirst($field);
+        if (!$expected) {
+            $expected = $filtered[$field];
+        }
+        $this->assertEquals($expected, $player->$method());
+    }
+
+    /**
+     * Return an array of methods to test.
+     *
+     * @return array The array of methods to test.
+     */
+    public function getSetMethods()
+    {
+        $r = new \ReflectionClass(Player::class);
+        foreach ($r->getProperties() as $property) {
+            $tests[$property->getName()] = [$property->getName()];
+        }
+        $tests['added'] = ['added', \DateTime::createFromFormat('U.u', '1335377369.000')];
+        $tests['updated'] = ['updated', \DateTime::createFromFormat('U.u', '1335378125.000')];
+
+        return $tests;
+    }
+}

--- a/tests/src/Unit/DataService/Player/PlayerTest.php
+++ b/tests/src/Unit/DataService/Player/PlayerTest.php
@@ -3,10 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit\DataService\Player;
 
 use Lullabot\Mpx\DataService\Player\Player;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Encoder\JsonEncoder;
-use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
-use Symfony\Component\Serializer\Serializer;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
 
 /**
  * Tests the Player object.
@@ -15,21 +12,9 @@ use Symfony\Component\Serializer\Serializer;
  *
  * @coversDefaultClass \Lullabot\Mpx\DataService\Player\Player
  */
-class PlayerTest extends TestCase
+class PlayerTest extends ObjectTestBase
 {
-    /**
-     * The serializer used to decode the data.
-     *
-     * @var Serializer
-     */
-    protected $serializer;
-
-    /**
-     * The decoded player object fixture.
-     *
-     * @var array
-     */
-    protected $decoded;
+    protected $class = Player::class;
 
     /**
      * {@inheritdoc}
@@ -37,13 +22,7 @@ class PlayerTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-
-        $encoders = [new JsonEncoder()];
-        $normalizers = [new ObjectNormalizer()];
-        $this->serializer = new Serializer($normalizers, $encoders);
-
-        $data = file_get_contents(__DIR__.'/../../../../fixtures/player-object.json');
-        $this->decoded = \GuzzleHttp\json_decode($data, true);
+        $this->loadFixture('player-object.json');
     }
 
     /**
@@ -56,38 +35,17 @@ class PlayerTest extends TestCase
      */
     public function testGetSet(string $field, $expected = null)
     {
-        // This significantly improves test performance as we only deserialize a single field at a time.
-        $filtered = [
-            $field => $this->decoded[$field],
-        ];
-
-        // @todo This is a total hack as MPX returns JSON with null values. Replace by omitting in the normalizer.
-        $filtered = array_filter($filtered, function ($value) {
-            return null !== $value;
-        });
-        $data = json_encode($filtered);
-
-        $player = $this->serializer->deserialize($data, Player::class, 'json');
-        $data = json_decode($data, true);
-
-        $method = 'get'.ucfirst($field);
-        if (!$expected) {
-            $expected = $filtered[$field];
-        }
-        $this->assertEquals($expected, $player->$method());
+        $this->assertObjectClass($this->class, $field, $expected);
     }
 
     /**
-     * Return an array of methods to test.
+     * @param string $class
      *
-     * @return array The array of methods to test.
+     * @return array
      */
     public function getSetMethods()
     {
-        $r = new \ReflectionClass(Player::class);
-        foreach ($r->getProperties() as $property) {
-            $tests[$property->getName()] = [$property->getName()];
-        }
+        $tests = parent::getSetMethods();
         $tests['added'] = ['added', \DateTime::createFromFormat('U.u', '1335377369.000')];
         $tests['updated'] = ['updated', \DateTime::createFromFormat('U.u', '1335378125.000')];
 


### PR DESCRIPTION
Depends on #46 . [Here is the interdiff](https://github.com/Lullabot/mpx-php/compare/player-data...media-object-tests).

Highlights include:

* Sharing almost all of the test code between data objects.
* Addition of a `BaseDataTrait` to hold fields common across data services.
* More tests!