### PR TITLE
Add a functional test with logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ test: &test
       # run tests!
       - run: |
           mkdir -p build/logs
-          vendor/bin/phpunit
+          vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
           path: build/logs
@@ -98,7 +98,7 @@ test_and_cover: &test_and_cover
       - run: |
           mkdir -p build/logs
           ./cc-test-reporter before-build
-          vendor/bin/phpunit
+          vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
           path: build/logs

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "friendsofphp/php-cs-fixer": "^2.10",
     "nette/php-generator": "^3.0",
     "symfony/console": "^3.4",
-    "namshi/cuzzle": "^2.0"
+    "namshi/cuzzle": "^2.0",
+    "rtheunissen/guzzle-log-middleware": "^0.4.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "squizlabs/php_codesniffer": "^2.9",
     "friendsofphp/php-cs-fixer": "^2.10",
     "nette/php-generator": "^3.0",
-    "symfony/console": "^3.0"
+    "symfony/console": "^3.4",
+    "namshi/cuzzle": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,11 @@
         <!-- Specify your MPX username and password for testing. -->
         <env name="MPX_USERNAME" value="" />
         <env name="MPX_PASSWORD" value="" />
+
+        <!-- Set to 'true' to log all HTTP requests as curl commands.
+             Note this will EXPOSE PASSWORDS AND TOKENS in logs, so
+             this should only be enabled on local environments. -->
+        <env name="MPX_LOG_CURL" value="false" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,11 @@
          stopOnFailure="false">
 
     <php>
-        <!-- Specify your MPX username and password for testing. -->
+        <!-- Specify your MPX username and password for functional testing. -->
         <env name="MPX_USERNAME" value="" />
         <env name="MPX_PASSWORD" value="" />
+        <!-- Specify the MPX account URL to test with. -->
+        <env name="MPX_ACCOUNT" value="" />
 
         <!-- Set to 'true' to log all HTTP requests as curl commands.
              Note this will EXPOSE PASSWORDS AND TOKENS in logs, so

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Concat\Http\Middleware\Logger;
+use GuzzleHttp\MessageFormatter;
+use Lullabot\Mpx\Client;
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\TokenCachePool;
+use Lullabot\Mpx\User;
+use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+abstract class FunctionalTestBase extends TestCase
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * @var UserSession
+     */
+    protected $session;
+
+    /**
+     * The MPX account.
+     *
+     * @var Account
+     */
+    protected $account;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $username = getenv('MPX_USERNAME');
+        $password = getenv('MPX_PASSWORD');
+        $account = getenv('MPX_ACCOUNT');
+
+        if (empty($username) || empty($password) || empty($account)) {
+            $this->markTestSkipped(
+                'MPX_USER, MPX_PASSWORD, and MPX_ACCOUNT must be defined as environment variables or in phpunit.xml for functional tests.'
+            );
+        }
+
+        $config = Client::getDefaultConfiguration();
+
+        if (getenv('MPX_LOG_CURL')) {
+            $output = new ConsoleOutput();
+            $output->setVerbosity(ConsoleOutput::VERBOSITY_DEBUG);
+            $cl = new ConsoleLogger($output);
+            /** @var $handler \GuzzleHttp\HandlerStack */
+            $handler = $config['handler'];
+            $handler->after('cookies', new CurlFormatterMiddleware($cl));
+
+            $responseLogger = new Logger($cl);
+            $responseLogger->setLogLevel(\Psr\Log\LogLevel::DEBUG);
+            $responseLogger->setFormatter(new MessageFormatter(MessageFormatter::DEBUG));
+            $handler->after('cookies', $responseLogger);
+        }
+
+        $this->client = new Client(new \GuzzleHttp\Client($config));
+        $this->user = new User($username, $password);
+        $this->session = new UserSession(
+            $this->client,
+            $this->user,
+            new TokenCachePool(new ArrayCachePool()),
+            new NullLogger()
+        );
+
+        $this->account = new Account();
+        $this->account->setId($account);
+    }
+}

--- a/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -2,61 +2,21 @@
 
 namespace Lullabot\Mpx\Tests\Functional\Service\AccessManagement;
 
-use Cache\Adapter\PHPArray\ArrayCachePool;
-use Concat\Http\Middleware\Logger;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\MessageFormatter;
-use Lullabot\Mpx\Client;
 use Lullabot\Mpx\Service\AccessManagement\ResolveAllUrls;
-use Lullabot\Mpx\Service\IdentityManagement\UserSession;
-use Lullabot\Mpx\TokenCachePool;
-use Lullabot\Mpx\User;
-use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
-use PHPUnit\Framework\TestCase;
-use Psr\Log\LogLevel;
-use Psr\Log\NullLogger;
-use Symfony\Component\Console\Logger\ConsoleLogger;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
 
 /**
  * Test resolving URLs with a live API call.
  */
-class ResolveAllUrlsTest extends TestCase
+class ResolveAllUrlsTest extends FunctionalTestBase
 {
     /**
      * Execute a resolveAllUrls() call.
      */
     public function testResolve()
     {
-        $username = getenv('MPX_USERNAME');
-        $password = getenv('MPX_PASSWORD');
-
-        if (empty($username) || empty($password)) {
-            $this->markTestSkipped('MPX_USER and MPX_PASSWORD must be defined as environment variables or in phpunit.xml for functional tests.');
-        }
-
-        $config = Client::getDefaultConfiguration();
-
-        if (getenv('MPX_LOG_CURL')) {
-            $output = new ConsoleOutput();
-            $output->setVerbosity(ConsoleOutput::VERBOSITY_DEBUG);
-            $cl = new ConsoleLogger($output);
-            /** @var $handler \GuzzleHttp\HandlerStack */
-            $handler = $config['handler'];
-            $handler->after('cookies', new CurlFormatterMiddleware($cl));
-
-            $responseLogger = new Logger($cl);
-            $responseLogger->setLogLevel(LogLevel::DEBUG);
-            $responseLogger->setFormatter(new MessageFormatter(MessageFormatter::DEBUG));
-            $handler->after('cookies', $responseLogger);
-        }
-
-        $client = new Client(new GuzzleClient($config));
-        $user = new User($username, $password);
-        $session = new UserSession($client, $user, new TokenCachePool(new ArrayCachePool()), new NullLogger());
-
         /** @var ResolveAllUrls $resolved */
-        $resolved = ResolveAllUrls::load($session, 'Media Data Service')->wait();
+        $resolved = ResolveAllUrls::load($this->session, 'Media Data Service')->wait();
         $this->assertInternalType('string', $resolved->getService());
     }
 }

--- a/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\Service\AccessManagement;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use GuzzleHttp\Client as GuzzleClient;
+use Lullabot\Mpx\Client;
+use Lullabot\Mpx\Service\AccessManagement\ResolveAllUrls;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\TokenCachePool;
+use Lullabot\Mpx\User;
+use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class ResolveAllUrlsTest extends TestCase
+{
+
+    public function testResolve()
+    {
+        $username = getenv('MPX_USERNAME');
+        $password = getenv('MPX_PASSWORD');
+
+        if (empty($username) || empty($password)) {
+            $this->markTestSkipped('MPX_USER and MPX_PASSWORD must be defined as environment variables or in phpunit.xml for functional tests.');
+        }
+
+        $config = Client::getDefaultConfiguration();
+
+        if (getEnv('MPX_LOG_CURL')) {
+            $output = new ConsoleOutput();
+            $output->setVerbosity(ConsoleOutput::VERBOSITY_DEBUG);
+            $cl = new ConsoleLogger($output);
+            /** @var $handler \GuzzleHttp\HandlerStack */
+            $handler = $config['handler'];
+            $handler->after('cookies', new CurlFormatterMiddleware($cl));
+        }
+
+        $client = new Client(new GuzzleClient($config));
+        $user = new User($username, $password);
+        $session = new UserSession($client, $user, new TokenCachePool(new ArrayCachePool()), new NullLogger());
+
+        /** @var ResolveAllUrls $resolved */
+        $resolved = ResolveAllUrls::load($session, 'Media Data Service')->wait();
+        $this->assertInternalType('string', $resolved->getService());
+    }
+}

--- a/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
@@ -10,7 +10,6 @@ use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
  */
 class ResolveDomainTest extends FunctionalTestBase
 {
-
     /**
      * Tests that resolving domains returns an array.
      */

--- a/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\Service\AccessManagement;
+
+use Lullabot\Mpx\Service\AccessManagement\ResolveDomain;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+
+/**
+ * Test calling resolveDomain.
+ */
+class ResolveDomainTest extends FunctionalTestBase
+{
+
+    /**
+     * Tests that resolving domains returns an array.
+     */
+    public function testResolve()
+    {
+        $resolveDomain = new ResolveDomain($this->session);
+        $resolved = $resolveDomain->resolve($this->account)->getResolved();
+        $this->assertInternalType('array', $resolved);
+        $this->assertNotEmpty($resolved);
+    }
+}


### PR DESCRIPTION
I've been annoyed with having to manually set up a `test.php` file for hitting the live API, so I figured it was time to extend upon existing configs for MPX tests.

This PR:

* Adds one Guzzle middleware to log each HTTP request as a cURL command you can copy-paste out to your console.
* Adds an additional middleware to log the requests and responses.

To run the tests, you have to:

1. Set your `MPX_USERNAME` and `MPX_PASSWORD` in your local copy of `phpunit.xml`.
1. Set `MPX_LOG_CURL` to `true`, noting that the logs will contain sensitive passwords and tokens.
1. Run phpunit.

```
$ vendor/bin/phpunit --testsuite Functional
PHPUnit 6.5.7 by Sebastian Bergmann and contributors.

[debug] curl \
  'https://identity.auth.theplatform.com/idm/web/Authentication/signIn?schema=1.0&form=json&httpError=0' \
  -A 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.2.3' -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Basic REDACTED'
[debug] >>>>>>>>
GET /idm/web/Authentication/signIn?schema=1.0&form=json&httpError=0 HTTP/1.1
Accept: application/json
Content-Type: application/json
User-Agent: GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.2.3
Authorization: Basic REDACTED
Host: identity.auth.theplatform.com


<<<<<<<<
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Cache-Control: no-cache
Date: Fri, 23 Mar 2018 17:10:55 GMT
Content-Type: application/json;charset=UTF-8
Content-Length: 217
Server: Jetty(8.1.16.2)

{"signInResponse":{"duration":315360000000,"token":"REDACTED","idleTimeout":14400000,"userName":"REDACTED","userId":"https://identity.auth.theplatform.com/idm/data/User/mpx/1"}}
--------
NULL
[debug] curl \
  'https://access.auth.theplatform.com/web/Registry/resolveAllUrls?schema=1.0&_service=Media%20Data%20Service&token=REDACTED' \
  -A 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.2.3' -H 'Accept: application/json' \
  -H 'Content-Type: application/json'
[debug] >>>>>>>>
GET /web/Registry/resolveAllUrls?schema=1.0&_service=Media%20Data%20Service&token=REDACTED HTTP/1.1
Accept: application/json
Content-Type: application/json
User-Agent: GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.2.3
Host: access.auth.theplatform.com


<<<<<<<<
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Cache-Control: no-cache
Date: Fri, 23 Mar 2018 17:10:55 GMT
Content-Type: application/json;charset=UTF-8
Content-Length: 70
Server: Jetty(8.1.16.2)

{"resolveAllUrlsResponse":["http://data.media.theplatform.com/media"]}
--------
NULL
.                                                                   1 / 1 (100%)

Time: 1.42 seconds, Memory: 10.00MB

OK (1 test, 1 assertion)

Generating code coverage report in Clover XML format ... done
```