### PR TITLE
Support media and non-media notifications

### DIFF
--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\UriInterface;
  *   service="Access Data Service",
  *   baseUri="https://access.auth.theplatform.com/data/Account",
  *   schemaVersion="1.0",
- *   path="/data/Account"
+ *   objectType="Account"
  * )
  */
 class Account

--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -8,12 +8,11 @@ namespace Lullabot\Mpx\DataService\Annotation;
  * Each MPX data service exposes one or more objects. We require annotations
  * on object implementations so calling code can discover what services are
  * currently implemented. In general, there should only be one implementation
- * of a given (path, service, schema) triple.
+ * of a given (objectType, service, schema) triple.
  *
  * @todo Use symfony validation to assert requirements.
  * @todo Mark the required values with @Required
  * @todo Rename to DataServiceObject
- * @todo Can we infer /data/ from path and assume it's always consistent?
  *
  * @see http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html
  */
@@ -27,11 +26,11 @@ class DataService
     public $service;
 
     /**
-     * The relative path of the data service, such as '/data/Media'.
+     * The object type in the service, such as 'Media'.
      *
      * @var string
      */
-    public $path;
+    public $objectType;
 
     /**
      * The schema version this class implements, such as '1.10'.
@@ -64,15 +63,15 @@ class DataService
     }
 
     /**
-     * Return the relative path of the data service, such as '/data/Media'.
+     * Return the relative objectType of the data service, such as '/data/Media'.
      *
      * @see https://docs.theplatform.com/help/wsf-how-to-find-the-url-of-a-service-in-the-service-registry
      *
      * @return string
      */
-    public function getPath(): string
+    public function getObjectType(): string
     {
-        return $this->path;
+        return $this->objectType;
     }
 
     /**

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -189,7 +189,7 @@ class DataObjectFactory
         // @todo Can we do this by calling ResolveAllUrls?
         if (!($base = $annotation->getBaseUri())) {
             $resolved = $this->resolveDomain->resolve($account);
-            $base = $resolved->getUrl($annotation->getService($readonly)).$annotation->getPath();
+            $base = $resolved->getUrl($annotation->getService($readonly)).$annotation->getObjectType();
         }
 
         return $base;

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -65,7 +65,7 @@ class DataServiceDiscovery
     /**
      * Returns all the data services.
      *
-     * @return DiscoveredDataService[] An array of all discovered data services.
+     * @return DiscoveredDataService[] An array of all discovered data services, indexed by service name, object type, and schema version.
      */
     public function getDataServices(): array
     {

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -94,7 +94,7 @@ class DataServiceDiscovery
                 continue;
             }
 
-            $this->dataServices[$annotation->getService()][$annotation->getPath()][$annotation->getSchemaVersion()] = new DiscoveredDataService($class, $annotation);
+            $this->dataServices[$annotation->getService()][$annotation->getObjectType()][$annotation->getSchemaVersion()] = new DiscoveredDataService($class, $annotation);
         }
     }
 

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -42,7 +42,7 @@ class DataServiceDiscovery
     /**
      * The array of discovered data services.
      *
-     * @var array
+     * @var DiscoveredDataService[]
      */
     private $dataServices = [];
 
@@ -64,8 +64,10 @@ class DataServiceDiscovery
 
     /**
      * Returns all the data services.
+     *
+     * @return DiscoveredDataService[] An array of all discovered data services.
      */
-    public function getDataServices()
+    public function getDataServices(): array
     {
         if (!$this->dataServices) {
             $this->discoverDataServices();
@@ -76,8 +78,6 @@ class DataServiceDiscovery
 
     /**
      * Discovers data services.
-     *
-     * @todo Return a structured class?
      */
     private function discoverDataServices()
     {
@@ -88,16 +88,13 @@ class DataServiceDiscovery
         /** @var SplFileInfo $file */
         foreach ($finder as $file) {
             $class = $this->classForFile($file);
+            /* @var \Lullabot\Mpx\DataService\Annotation\DataService $annotation */
             $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\DataService');
             if (!$annotation) {
                 continue;
             }
 
-            /* @var \Lullabot\Mpx\DataService\Annotation\DataService $annotation */
-            $this->dataServices[$annotation->getService()][$annotation->getPath()] = [
-                'class' => $class,
-                'annotation' => $annotation,
-            ];
+            $this->dataServices[$annotation->getService()][$annotation->getPath()][$annotation->getSchemaVersion()] = new DiscoveredDataService($class, $annotation);
         }
     }
 

--- a/src/DataService/DataServiceExtractor.php
+++ b/src/DataService/DataServiceExtractor.php
@@ -32,7 +32,7 @@ class DataServiceExtractor extends ReflectionExtractor
      */
     public function getTypes($class, $property, array $context = [])
     {
-        if ('entries' != $property) {
+        if ('entries' !== $property) {
             return parent::getTypes($class, $property, $context);
         }
 

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -46,16 +46,16 @@ class DataServiceManager
      * Returns one data service by service.
      *
      * @param string $name
-     * @param string $path
+     * @param string $objectType
      * @param string $schema
      *
      * @return DiscoveredDataService
      */
-    public function getDataService(string $name, string $path, string $schema)
+    public function getDataService(string $name, string $objectType, string $schema)
     {
         $services = $this->discovery->getDataServices();
-        if (isset($services[$name][$path][$schema])) {
-            return $services[$name][$path][$schema];
+        if (isset($services[$name][$objectType][$schema])) {
+            return $services[$name][$objectType][$schema];
         }
 
         throw new \RuntimeException('Data service not found.');

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -35,7 +35,7 @@ class DataServiceManager
     /**
      * Returns a list of available data services.
      *
-     * @return array
+     * @return DiscoveredDataService[]
      */
     public function getDataServices()
     {
@@ -47,14 +47,15 @@ class DataServiceManager
      *
      * @param string $name
      * @param string $path
+     * @param string $schema
      *
-     * @return array
+     * @return DiscoveredDataService
      */
-    public function getDataService(string $name, string $path)
+    public function getDataService(string $name, string $path, string $schema)
     {
         $services = $this->discovery->getDataServices();
-        if (isset($services[$name][$path])) {
-            return $services[$name][$path];
+        if (isset($services[$name][$path][$schema])) {
+            return $services[$name][$path][$schema];
         }
 
         throw new \RuntimeException('Data service not found.');

--- a/src/DataService/DiscoveredDataService.php
+++ b/src/DataService/DiscoveredDataService.php
@@ -2,16 +2,21 @@
 
 namespace Lullabot\Mpx\DataService;
 
+use Lullabot\Mpx\DataService\Annotation\DataService;
+
 class DiscoveredDataService
 {
-
     /**
      * @var string
      */
     private $class;
+
+    /**
+     * @var DataService
+     */
     private $annotation;
 
-    public function __construct(string $class, $annotation)
+    public function __construct(string $class, DataService $annotation)
     {
         $this->class = $class;
         $this->annotation = $annotation;
@@ -26,7 +31,7 @@ class DiscoveredDataService
     }
 
     /**
-     * @return mixed
+     * @return DataService
      */
     public function getAnnotation()
     {

--- a/src/DataService/DiscoveredDataService.php
+++ b/src/DataService/DiscoveredDataService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+class DiscoveredDataService
+{
+
+    /**
+     * @var string
+     */
+    private $class;
+    private $annotation;
+
+    public function __construct(string $class, $annotation)
+    {
+        $this->class = $class;
+        $this->annotation = $annotation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAnnotation()
+    {
+        return $this->annotation;
+    }
+}

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\UriInterface;
  * @DataService(
  *   service="Media Data Service",
  *   schemaVersion="1.10",
- *   path="/data/Media",
+ *   objectType="Media",
  * )
  */
 class Media implements CreateKeyInterface

--- a/src/DataService/Notification.php
+++ b/src/DataService/Notification.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * @class   Notification
+ */
+class Notification
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $method;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var object
+     */
+    protected $entry;
+
+    /**
+     * @return object
+     */
+    public function getEntry(): object
+    {
+        return $this->entry;
+    }
+
+    /**
+     * @param object $entry
+     */
+    public function setEntry($entry)
+    {
+        $this->entry = $entry;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId(int $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @param string $method
+     */
+    public function setMethod(string $method)
+    {
+        $this->method = $method;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/DataService/Notification.php
+++ b/src/DataService/Notification.php
@@ -3,7 +3,9 @@
 namespace Lullabot\Mpx\DataService;
 
 /**
- * @class   Notification
+ * Represents an MPX notification.
+ *
+ * @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications
  */
 class Notification
 {
@@ -30,7 +32,7 @@ class Notification
     /**
      * @return object
      */
-    public function getEntry(): object
+    public function getEntry()
     {
         return $this->entry;
     }

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -99,8 +99,12 @@ class NotificationListener
     /**
      * Listen for notifications.
      *
+     * This method always filters to the object type defined in the discovered
+     * data service passed in the constructor, such as 'Media'.
+     *
+     * @see https://docs.theplatform.com/help/media-media-data-service-api-reference
+     *
      * @todo Add support for a configurable timeout?
-     * @todo Convert the return to an ObjectList.
      *
      * @see \Lullabot\Mpx\DataService\NotificationListener::sync
      *
@@ -117,6 +121,7 @@ class NotificationListener
                 'block' => 'true',
                 'form' => 'cjson',
                 'schema' => '1.10',
+                'filter' => $this->service->getAnnotation()->getObjectType(),
             ],
         ])->then(function (ResponseInterface $response) {
             $data = \GuzzleHttp\json_decode($response->getBody(), true);

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -58,7 +58,7 @@ class NotificationListener
      *
      * This method always uses the read-only version of a service.
      *
-     * @see https://docs.theplatform.com/help/wsf-subscribing- to -change-notifications#tp-toc2
+     * @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications#tp-toc2
      *
      * @param \Lullabot\Mpx\AuthenticatedClient $session  The client to use for authenticated requests.
      * @param DiscoveredDataService             $service  The name of the service to listen to notifications on, such as 'Media Data Service'.
@@ -116,7 +116,7 @@ class NotificationListener
      * @param int $since   The last sync ID.
      * @param int $maximum (optional) The maximum number of notifications to return. Defaults to 500.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface A promise returning an array of Notifications.
+     * @return \GuzzleHttp\Promise\PromiseInterface A promise returning an array of Notification objects.
      */
     public function listen(int $since, int $maximum = 500)
     {

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -106,18 +106,19 @@ class NotificationListener
      * This method always filters to the object type defined in the discovered
      * data service passed in the constructor, such as 'Media'.
      *
-     * @see https://docs.theplatform.com/help/media-media-data-service-api-reference
+     * @see  https://docs.theplatform.com/help/media-media-data-service-api-reference
      *
      * @todo Add support for a configurable timeout?
      *
-     * @see \Lullabot\Mpx\DataService\NotificationListener::sync
-     * @see \Lullabot\Mpx\DataService\Notification
+     * @see  \Lullabot\Mpx\DataService\NotificationListener::sync
+     * @see  \Lullabot\Mpx\DataService\Notification
      *
-     * @param int $since The last sync ID.
+     * @param int $since   The last sync ID.
+     * @param int $maximum (optional) The maximum number of notifications to return. Defaults to 500.
      *
      * @return \GuzzleHttp\Promise\PromiseInterface A promise returning an array of Notifications.
      */
-    public function listen(int $since)
+    public function listen(int $since, int $maximum = 500)
     {
         return $this->session->requestAsync('GET', $this->uri, [
             'query' => [
@@ -127,6 +128,7 @@ class NotificationListener
                 'form' => 'cjson',
                 'schema' => '1.10',
                 'filter' => $this->service->getAnnotation()->getObjectType(),
+                'size' => $maximum,
             ],
         ])->then(function (ResponseInterface $response) {
             // First, we need an encoder that filters out null values.

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -17,8 +17,6 @@ use Symfony\Component\Serializer\Serializer;
  * Listen to events from MPX.
  *
  * @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications
- *
- * @codeCoverageIgnore Until we refactor this to allow loading all objects.
  */
 class NotificationListener
 {
@@ -113,10 +111,11 @@ class NotificationListener
      * @todo Add support for a configurable timeout?
      *
      * @see \Lullabot\Mpx\DataService\NotificationListener::sync
+     * @see \Lullabot\Mpx\DataService\Notification
      *
      * @param int $since The last sync ID.
      *
-     * @return \GuzzleHttp\Promise\PromiseInterface A promise returning a list of notified objects.
+     * @return \GuzzleHttp\Promise\PromiseInterface A promise returning an array of Notifications.
      */
     public function listen(int $since)
     {

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -37,7 +37,7 @@ class NotificationTypeExtractor extends ReflectionExtractor
         }
 
         if (!isset($this->class)) {
-            throw new \UnexpectedValueException('setClass() must be called before using this extractor.');
+            throw new \LogicException('setClass() must be called before using this extractor.');
         }
 
         return [new Type('object', false, $this->class)];

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * A property extractor to extract the type from a notification entry.
+ */
+class NotificationTypeExtractor extends ReflectionExtractor
+{
+    /**
+     * The class each entry is, such as \Lullabot\Mpx\DataService\Media\Media.
+     *
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * Set the class that is being extracted, such as \Lullabot\Mpx\DataService\Media\Media.
+     *
+     * @param string $class The class being extracted.
+     */
+    public function setClass(string $class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypes($class, $property, array $context = [])
+    {
+        if ('entry' !== $property) {
+            return parent::getTypes($class, $property, $context);
+        }
+
+        if (!isset($this->class)) {
+            throw new \UnexpectedValueException('setClass() must be called before using this extractor.');
+        }
+
+        return [new Type('object', false, $this->class)];
+    }
+}

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Lullabot\Mpx\DataService\Access\Account;
 
 /**
- * An ObjectList represents a list of data service objects from a search query or a notification.
+ * An ObjectList represents a list of data service objects from a search query.
  *
  * @see https://docs.theplatform.com/help/wsf-retrieving-data-objects#tp-toc11
  * @see https://docs.theplatform.com/help/wsf-cjson-format#cJSONformat-cJSONobjectlistpayloads

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * @\Lullabot\Mpx\DataService\Annotation\DataService(
  *     service="Player Data Service",
- *     path="/data/Player",
+ *     objectType="Player",
  *     schemaVersion="1.6",
  * )
  */

--- a/tests/fixtures/notification.json
+++ b/tests/fixtures/notification.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": 1,
+    "method": "put",
+    "type": "Media",
+    "entry": {
+      "id": "http://data.media.theplatform.com/media/data/Media/1",
+      "updated": 1521790000000,
+      "ownerId": "http://access.auth.theplatform.com/data/Account/1",
+      "updatedByUserId": "https://identity.auth.theplatform.com/idm/data/User/service/1"
+    }
+  },
+  {
+    "id": 2,
+    "method": "post",
+    "type": "Media",
+    "entry": {
+      "id": "http://data.media.theplatform.com/media/data/Media/2",
+      "updated": 1521791000000,
+      "ownerId": "http://access.auth.theplatform.com/data/Account/2",
+      "updatedByUserId": "https://identity.auth.theplatform.com/idm/data/User/service/2"
+    }
+  }
+]

--- a/tests/src/Functional/DataService/NotificationListenerTest.php
+++ b/tests/src/Functional/DataService/NotificationListenerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\DataService;
+
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\NotificationListener;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+
+class NotificationListenerTest extends FunctionalTestBase
+{
+    /**
+     * Tests listening for two Media notifications.
+     */
+    public function testListen()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $listener = new NotificationListener($this->session, $service, 'lullabot/mpx-php');
+        /** @var \Lullabot\Mpx\DataService\Notification[] $notifications */
+        $notifications = $listener->listen(-1)->wait();
+        $this->assertNotEmpty($notifications);
+        foreach ($notifications as $notification) {
+            $this->assertInstanceOf(Media::class, $notification->getEntry());
+        }
+    }
+}

--- a/tests/src/Functional/DataService/NotificationListenerTest.php
+++ b/tests/src/Functional/DataService/NotificationListenerTest.php
@@ -18,8 +18,8 @@ class NotificationListenerTest extends FunctionalTestBase
         $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
         $listener = new NotificationListener($this->session, $service, 'lullabot/mpx-php');
         /** @var \Lullabot\Mpx\DataService\Notification[] $notifications */
-        $notifications = $listener->listen(-1)->wait();
-        $this->assertNotEmpty($notifications);
+        $notifications = $listener->listen(-1, 2)->wait();
+        $this->assertCount(2, $notifications);
         foreach ($notifications as $notification) {
             $this->assertInstanceOf(Media::class, $notification->getEntry());
         }

--- a/tests/src/JsonResponse.php
+++ b/tests/src/JsonResponse.php
@@ -15,9 +15,9 @@ class JsonResponse extends Response
     public function __construct($status = 200, array $headers = [], $body = null, $version = '1.1', $reason = null)
     {
         if (isset($body)) {
-            if (is_file($body)) {
+            if (is_string($body) && is_file($body)) {
                 $body = fopen($body, 'r');
-            } elseif (is_file(__DIR__.'/../fixtures/'.$body)) {
+            } elseif (is_string($body) && is_file(__DIR__.'/../fixtures/'.$body)) {
                 $body = fopen(__DIR__.'/../fixtures/'.$body, 'r');
             } elseif (is_array($body)) {
                 $body = \GuzzleHttp\json_encode($body);

--- a/tests/src/Unit/DataService/Media/MediaTest.php
+++ b/tests/src/Unit/DataService/Media/MediaTest.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\Tests\Unit\DataService\Media;
 
 use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 
 /**
  * Test the Media data object.
@@ -20,7 +21,7 @@ class MediaTest extends ObjectTestBase
     public function setUp()
     {
         parent::setUp();
-        $this->loadFixture('media-object.json');
+        $this->loadFixture('media-object.json', new ReflectionExtractor());
     }
 
     /**

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\NotificationListener;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\JsonResponse;
+use Lullabot\Mpx\Tests\MockClientTrait;
+use Lullabot\Mpx\TokenCachePool;
+use Lullabot\Mpx\User;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests listening for notifications.
+ *
+ * @coversDefaultClass  \Lullabot\Mpx\DataService\NotificationListener
+ */
+class NotificationListenerTest extends TestCase
+{
+    use MockClientTrait;
+
+    /**
+     * Test fetching the last sync ID.
+     *
+     * @covers ::__construct
+     * @covers ::sync
+     */
+    public function testSync()
+    {
+        $id = rand(1, getrandmax());
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'resolveAllUrls.json'),
+            new JsonResponse(200, [], [
+                [
+                    'id' => $id,
+                ],
+            ]),
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        $session = new UserSession($client, $user, $tokenCachePool, new NullLogger());
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $listener = new NotificationListener($session, $service, 'unit-tests');
+        $last = $listener->sync()->wait();
+        $this->assertEquals($id, $last);
+    }
+
+    /**
+     * Test listening for notifications.
+     *
+     * @covers ::__construct
+     * @covers ::listen
+     */
+    public function testListen()
+    {
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'resolveAllUrls.json'),
+            new JsonResponse(200, [], 'notification.json'),
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        $session = new UserSession($client, $user, $tokenCachePool, new NullLogger());
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $listener = new NotificationListener($session, $service, 'unit-tests');
+        $last = 98765;
+        /** @var \Lullabot\Mpx\DataService\Notification[] $notifications */
+        $notifications = $listener->listen($last)->wait();
+        $this->assertCount(2, $notifications);
+
+        foreach ($notifications as $index => $notification) {
+            // MPX IDs start at 1, so we bump up this index.
+            ++$index;
+
+            $this->assertEquals($index, $notification->getId());
+
+            (1 == $index ? $method = 'put' : $method = 'post');
+            $this->assertEquals($method, $notification->getMethod());
+            $this->assertEquals('Media', $notification->getType());
+
+            /** @var Media $media */
+            $media = $notification->getEntry();
+            $this->assertInstanceOf(Media::class, $media);
+
+            $this->assertEquals('http://data.media.theplatform.com/media/data/Media/'.$index, $media->getId());
+            $this->assertEquals('http://access.auth.theplatform.com/data/Account/'.$index, $media->getOwnerId());
+            $this->assertEquals('https://identity.auth.theplatform.com/idm/data/User/service/'.$index, $media->getUpdatedByUserId());
+            $this->assertEquals(1521790000 + ($index - 1) * 1000, $media->getUpdated()->format('U'));
+        }
+    }
+}

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\Notification;
+use Lullabot\Mpx\DataService\NotificationTypeExtractor;
+
+/**
+ * Tests the Notification object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Notification
+ */
+class NotificationTest extends ObjectTestBase
+{
+    protected $class = Notification::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $notificationExtractor = new NotificationTypeExtractor();
+        $notificationExtractor->setClass(Media::class);
+        $this->loadFixture('notification.json', $notificationExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field The field on Notification to test.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field)
+    {
+        /** @var Notification[] $notifications */
+        $notifications = $this->serializer->deserialize(json_encode($this->decoded), Notification::class.'[]', 'json');
+        $method = 'get'.ucfirst($field);
+        foreach ($notifications as $index => $notification) {
+            if ('entry' == $field) {
+                $this->assertInstanceOf(Media::class, $notification->$method());
+            } else {
+                $expected = $this->decoded[$index][$field];
+                $this->assertEquals($expected, $notification->$method());
+            }
+        }
+    }
+}

--- a/tests/src/Unit/DataService/NotificationTypeExtractorTest.php
+++ b/tests/src/Unit/DataService/NotificationTypeExtractorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use Lullabot\Mpx\DataService\NotificationTypeExtractor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test extracting the type of notification object returned from MPX.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\DataService\NotificationTypeExtractor
+ */
+class NotificationTypeExtractorTest extends TestCase
+{
+    /**
+     * Test normal fetching of an entry type.
+     *
+     * @covers ::setClass
+     * @covers ::getTypes
+     */
+    public function testGetTypes()
+    {
+        $extractor = new NotificationTypeExtractor();
+        $extractor->setClass(static::class);
+        $type = $extractor->getTypes('', 'entry');
+        $this->assertEquals(static::class, $type[0]->getClassName());
+    }
+
+    /**
+     * Test trying to extract a non-entry property.
+     *
+     * @covers ::getTypes
+     */
+    public function testNotEntry()
+    {
+        $extractor = new NotificationTypeExtractor();
+        $extractor->setClass(static::class);
+        $this->assertNull($extractor->getTypes('', 'not-entry'));
+    }
+
+    /**
+     * Test trying to extract before setting a target class.
+     *
+     * @covers ::getTypes
+     */
+    public function testClassNotSet()
+    {
+        $extractor = new NotificationTypeExtractor();
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('setClass() must be called before using this extractor.');
+        $extractor->getTypes('', 'entry');
+    }
+}

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -6,7 +6,7 @@ use Lullabot\Mpx\Encoder\CJsonEncoder;
 use Lullabot\Mpx\Normalizer\UnixMicrosecondNormalizer;
 use Lullabot\Mpx\Normalizer\UriNormalizer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -55,8 +55,9 @@ abstract class ObjectTestBase extends TestCase
 
     /**
      * @param $fixture
+     * @param $propertyTypeExtractor
      */
-    protected function loadFixture($fixture)
+    protected function loadFixture($fixture, PropertyTypeExtractorInterface $propertyTypeExtractor)
     {
         $encoders = [new CJsonEncoder()];
 
@@ -64,7 +65,7 @@ abstract class ObjectTestBase extends TestCase
         $normalizers = [
             new UnixMicrosecondNormalizer(),
             new UriNormalizer(),
-            new ObjectNormalizer(null, null, null, new ReflectionExtractor()),
+            new ObjectNormalizer(null, null, null, $propertyTypeExtractor),
             new ArrayDenormalizer(),
         ];
 
@@ -82,7 +83,6 @@ abstract class ObjectTestBase extends TestCase
     protected function assertObjectClass($class, string $field, $expected)
     {
         // This significantly improves test performance as we only deserialize a single field at a time.
-        $value = $this->decoded[$field];
         $filtered = [
             $field => $this->decoded[$field],
         ];

--- a/tests/src/Unit/DataService/Player/PlayerTest.php
+++ b/tests/src/Unit/DataService/Player/PlayerTest.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\Tests\Unit\DataService\Player;
 
 use Lullabot\Mpx\DataService\Player\Player;
 use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 
 /**
  * Tests the Player object.
@@ -22,7 +23,7 @@ class PlayerTest extends ObjectTestBase
     public function setUp()
     {
         parent::setUp();
-        $this->loadFixture('player-object.json');
+        $this->loadFixture('player-object.json', new ReflectionExtractor());
     }
 
     /**


### PR DESCRIPTION
Resolves #23.

This PR fully supports media object notifications, and in fact any type of object that supports them

Highlights include:

* I pulled the trigger and changed the `path` annotation to `objectType`. If we find a service that doesn't have `/data/` in it's path, we can always add a new annotation key for that case.
* A new `DiscoveredDataService` class replacing the class / annotation array.
* We now index data services also by schema version, so we can totally support multiple versions of an object in the same codebase.
* MPX highly recommends filtering to an object type for notifications. So for now, we force that by only ever listening for one object type per `NotificationListener` instance. If calling code needs to listen for multiple types of objects, they can call listen multiple times and wait on the promises.