### PR TITLE
Support insecure data services

### DIFF
--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -71,28 +71,6 @@ class DataService
     }
 
     /**
-     * Return the relative path of the data service, such as '/data/Media'.
-     *
-     * @see https://docs.theplatform.com/help/wsf-how-to-find-the-url-of-a-service-in-the-service-registry
-     *
-     * @return string
-     */
-    public function getPath(): string
-    {
-        return $this->path;
-    }
-
-    /**
-     * Return the schema version this class implements, such as '1.10'.
-     *
-     * @return string
-     */
-    public function getSchemaVersion(): string
-    {
-        return $this->schemaVersion;
-    }
-
-    /**
      * @return string
      */
     public function getBaseUri(): string
@@ -103,15 +81,5 @@ class DataService
     public function hasBaseUri(): bool
     {
         return (bool) $this->baseUri;
-    }
-
-    /**
-     * Return if this service is only available over HTTP.
-     *
-     * @return bool
-     */
-    public function isInsecure(): bool
-    {
-        return $this->insecure;
     }
 }

--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -48,6 +48,13 @@ class DataService
     public $baseUri;
 
     /**
+     * Is this service only available over HTTP?
+     *
+     * @var bool
+     */
+    public $insecure = false;
+
+    /**
      * Return the service of the data object, such as 'Media Data Service'.
      *
      * @param bool $readonly (optional) Set to true to return the read-only name of the service.
@@ -96,5 +103,15 @@ class DataService
     public function hasBaseUri(): bool
     {
         return (bool) $this->baseUri;
+    }
+
+    /**
+     * Return if this service is only available over HTTP.
+     *
+     * @return bool
+     */
+    public function isInsecure(): bool
+    {
+        return $this->insecure;
     }
 }

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\UriInterface;
  *     service="Player Data Service",
  *     path="/data/Player",
  *     schemaVersion="1.6",
+ *     insecure=true,
  * )
  */
 class Player implements CreateKeyInterface

--- a/src/DataService/ResolveDomainResponseExtractor.php
+++ b/src/DataService/ResolveDomainResponseExtractor.php
@@ -11,7 +11,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * Unfortunately, PhpDocExtractor's code uses private variables and final
  * classes, so we can't override it to allow string array keys. Since this API
- * only has one key, it is simpler to to just hardcode the property type.
+ * only has one key, it is simpler to just hardcode the property type.
  *
  * @see \Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor
  */

--- a/src/DataService/ResolveDomainResponseExtractor.php
+++ b/src/DataService/ResolveDomainResponseExtractor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use GuzzleHttp\Psr7\Uri;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Extracts URIs with string array keys.
+ *
+ * Unfortunately, PhpDocExtractor's code uses private variables and final
+ * classes, so we can't override it to allow string array keys. Since this API
+ * only has one key, it is simpler to to just hardcode the property type.
+ *
+ * @see \Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor
+ */
+class ResolveDomainResponseExtractor implements PropertyTypeExtractorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTypes($class, $property, array $context = [])
+    {
+        if ('resolveDomainResponse' != $property) {
+            throw new \InvalidArgumentException('This extractor only supports resolveDomainResponse properties.');
+        }
+
+        $collectionKeyType = new Type(Type::BUILTIN_TYPE_STRING);
+        $collectionValueType = new Type('object', false, Uri::class);
+
+        return [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, $collectionKeyType, $collectionValueType)];
+    }
+}

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -9,6 +9,11 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * Resolve all URLs for a given service.
  *
+ * In general, ResolveDomain should be used instead, as it can return all
+ * services at once. However, it requires an Account context, so if you do not
+ * have one available use this instead.
+ *
+ * @see \Lullabot\Mpx\Service\AccessManagement\ResolveDomain
  * @see https://docs.theplatform.com/help/wsf-resolveallurls-method
  */
 class ResolveAllUrls

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -40,8 +40,6 @@ class ResolveAllUrls
     /**
      * ResolveAllUrls constructor.
      *
-     * @todo Is there value in storing Responses in all classes?
-     *
      * @param string $service The service that was queried, such as 'Access Data Service'.
      * @param array  $data    The MPX response.
      */

--- a/src/Service/AccessManagement/ResolveDomainResponse.php
+++ b/src/Service/AccessManagement/ResolveDomainResponse.php
@@ -2,6 +2,8 @@
 
 namespace Lullabot\Mpx\Service\AccessManagement;
 
+use GuzzleHttp\Psr7\Uri;
+
 /**
  * A response of all service domains.
  */
@@ -10,40 +12,47 @@ class ResolveDomainResponse
     /**
      * The array of resolveDomainResponse domains, indexed by their service name.
      *
-     * @var \GuzzleHttp\Psr7\Uri[]
+     * @var Uri[]
      */
     protected $resolveDomainResponse;
 
     /**
-     * Return all resolveDomainResponse domains.
+     * Return all available services.
      *
-     * @return \GuzzleHttp\Psr7\Uri[]
+     * @return string[]
      */
-    public function getResolveDomainResponse(): array
+    public function getServices(): array
     {
-        return $this->resolveDomainResponse;
+        return array_keys($this->resolveDomainResponse);
     }
 
     /**
      * Get the URL for a given service.
      *
-     * @param string $service The name of the service, such as 'Media Data Service read-only'.
+     * Note that no 'getResolveDomainResponse' method is implemented, to ensure
+     * that callers get https URLs unless they explicitly ask for insecure URLs.
      *
-     * @return string The URL for the service.
+     * @param string $service  The name of the service, such as 'Media Data Service read-only'.
+     * @param bool   $insecure (optional) Set to true to request the insecure version of this service.
      *
-     * @throws \RuntimeException When the service is not found.
+     * @return Uri The URL for the service.
      */
-    public function getUrl(string $service): string
+    public function getUrl(string $service, bool $insecure = false): Uri
     {
         if (!isset($this->resolveDomainResponse[$service])) {
             throw new \RuntimeException(sprintf('%s service was not found.', $service));
         }
 
-        return $this->resolveDomainResponse[$service];
+        $url = $this->resolveDomainResponse[$service];
+        if (!$insecure) {
+            $url = $url->withScheme('https');
+        }
+
+        return $url;
     }
 
     /**
-     * @param \GuzzleHttp\Psr7\Uri[] $resolveDomainResponse
+     * @param Uri[] $resolveDomainResponse
      */
     public function setResolveDomainResponse(array $resolveDomainResponse)
     {

--- a/src/Service/AccessManagement/ResolveDomainResponse.php
+++ b/src/Service/AccessManagement/ResolveDomainResponse.php
@@ -8,34 +8,20 @@ namespace Lullabot\Mpx\Service\AccessManagement;
 class ResolveDomainResponse
 {
     /**
-     * The array of resolved domains, indexed by their service name.
+     * The array of resolveDomainResponse domains, indexed by their service name.
      *
-     * @var array
+     * @var \GuzzleHttp\Psr7\Uri[]
      */
-    protected $resolved;
+    protected $resolveDomainResponse;
 
     /**
-     * ResolveDomainResponse constructor.
+     * Return all resolveDomainResponse domains.
      *
-     * @param array $resolved The array of data from the resolveDomain response.
+     * @return \GuzzleHttp\Psr7\Uri[]
      */
-    public function __construct(array $resolved)
+    public function getResolveDomainResponse(): array
     {
-        if (empty($resolved['resolveDomainResponse'])) {
-            throw new \InvalidArgumentException('The resolved data must contain a resolveDomainResponse key.');
-        }
-
-        $this->resolved = $resolved['resolveDomainResponse'];
-    }
-
-    /**
-     * Return all resolved domains.
-     *
-     * @return array
-     */
-    public function getResolved(): array
-    {
-        return $this->resolved;
+        return $this->resolveDomainResponse;
     }
 
     /**
@@ -49,10 +35,18 @@ class ResolveDomainResponse
      */
     public function getUrl(string $service): string
     {
-        if (!isset($this->resolved[$service])) {
+        if (!isset($this->resolveDomainResponse[$service])) {
             throw new \RuntimeException(sprintf('%s service was not found.', $service));
         }
 
-        return $this->resolved[$service];
+        return $this->resolveDomainResponse[$service];
+    }
+
+    /**
+     * @param \GuzzleHttp\Psr7\Uri[] $resolveDomainResponse
+     */
+    public function setResolveDomainResponse(array $resolveDomainResponse)
+    {
+        $this->resolveDomainResponse = $resolveDomainResponse;
     }
 }

--- a/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
@@ -17,11 +17,13 @@ class ResolveDomainTest extends FunctionalTestBase
     public function testResolve()
     {
         $resolveDomain = new ResolveDomain($this->session);
-        $resolved = $resolveDomain->resolve($this->account)->getResolveDomainResponse();
-        $this->assertInternalType('array', $resolved);
-        $this->assertNotEmpty($resolved);
-        foreach ($resolved as $uri) {
+        $resolved = $resolveDomain->resolve($this->account);
+        $this->assertNotEmpty($resolved->getServices());
+
+        foreach ($resolved->getServices() as $service) {
+            $uri = $resolved->getUrl($service);
             $this->assertInstanceOf(UriInterface::class, $uri);
+            $this->assertEquals('https', $uri->getScheme());
         }
     }
 }

--- a/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveDomainTest.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\Tests\Functional\Service\AccessManagement;
 
 use Lullabot\Mpx\Service\AccessManagement\ResolveDomain;
 use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Test calling resolveDomain.
@@ -16,8 +17,11 @@ class ResolveDomainTest extends FunctionalTestBase
     public function testResolve()
     {
         $resolveDomain = new ResolveDomain($this->session);
-        $resolved = $resolveDomain->resolve($this->account)->getResolved();
+        $resolved = $resolveDomain->resolve($this->account)->getResolveDomainResponse();
         $this->assertInternalType('array', $resolved);
         $this->assertNotEmpty($resolved);
+        foreach ($resolved as $uri) {
+            $this->assertInstanceOf(UriInterface::class, $uri);
+        }
     }
 }

--- a/tests/src/Unit/DataService/ResolveDomainResponseExtractorTest.php
+++ b/tests/src/Unit/DataService/ResolveDomainResponseExtractorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\ResolveDomainResponseExtractor;
+use Lullabot\Mpx\Service\AccessManagement\ResolveDomainResponse;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * Tests mapping resolve domain array responses to strings and URIs.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\DataService\ResolveDomainResponseExtractor
+ */
+class ResolveDomainResponseExtractorTest extends TestCase
+{
+
+    /**
+     * @covers ::getTypes
+     */
+    public function testGetTypes()
+    {
+        $extractor = new ResolveDomainResponseExtractor();
+        $types = $extractor->getTypes(ResolveDomainResponse::class, 'resolveDomainResponse');
+        $this->assertCount(1, $types);
+        /** @var \Symfony\Component\PropertyInfo\Type $type */
+        $type = $types[0];
+        $this->assertEquals(Type::BUILTIN_TYPE_ARRAY, $type->getBuiltinType());
+        $this->assertEquals(Type::BUILTIN_TYPE_STRING, $type->getCollectionKeyType()->getBuiltinType());
+        $this->assertEquals('object', $type->getCollectionValueType()->getBuiltinType());
+        $this->assertEquals(Uri::class, $type->getCollectionValueType()->getClassName());
+    }
+}

--- a/tests/src/Unit/DataService/ResolveDomainResponseExtractorTest.php
+++ b/tests/src/Unit/DataService/ResolveDomainResponseExtractorTest.php
@@ -15,7 +15,6 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class ResolveDomainResponseExtractorTest extends TestCase
 {
-
     /**
      * @covers ::getTypes
      */
@@ -30,5 +29,16 @@ class ResolveDomainResponseExtractorTest extends TestCase
         $this->assertEquals(Type::BUILTIN_TYPE_STRING, $type->getCollectionKeyType()->getBuiltinType());
         $this->assertEquals('object', $type->getCollectionValueType()->getBuiltinType());
         $this->assertEquals(Uri::class, $type->getCollectionValueType()->getClassName());
+    }
+
+    /**
+     * @covers ::getTypes
+     */
+    public function testInvalidProperty()
+    {
+        $extractor = new ResolveDomainResponseExtractor();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('This extractor only supports resolveDomainResponse properties.');
+        $extractor->getTypes('', 'not-valid');
     }
 }

--- a/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -35,6 +35,7 @@ class ResolveAllUrlsTest extends TestCase
         $client = $this->getMockClient([
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'resolveAllUrls.json'),
+            new JsonResponse(200, [], 'resolveAllUrls.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface $store */
@@ -47,7 +48,10 @@ class ResolveAllUrlsTest extends TestCase
         /** @var \Lullabot\Mpx\Service\AccessManagement\ResolveAllUrls $r */
         $r = ResolveAllUrls::load($session, 'Media Data Service')->wait();
         $this->assertEquals('Media Data Service', $r->getService());
-        $this->assertEquals('http://data.media.theplatform.com/media', $r->resolve());
+        $this->assertEquals('https://data.media.theplatform.com/media', (string) $r->resolve());
+
+        $r = ResolveAllUrls::load($session, 'Media Data Service', true)->wait();
+        $this->assertEquals('http://data.media.theplatform.com/media', (string) $r->resolve());
     }
 
     /**

--- a/tests/src/Unit/Service/AccessManagement/ResolveDomainResponseTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveDomainResponseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Service\AccessManagement;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\Service\AccessManagement\ResolveDomainResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests ResolveDomainResponses.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\Service\AccessManagement\ResolveDomainResponse
+ */
+class ResolveDomainResponseTest extends TestCase
+{
+    /**
+     * Test retrieving all found services.
+     *
+     * @covers ::setResolveDomainResponse
+     * @covers ::getServices
+     */
+    public function testGetServices()
+    {
+        $response = new ResolveDomainResponse();
+        $services = [
+            'first service' => new Uri('http://example.com/1'),
+            'second service' => new Uri('http://example.com/2'),
+        ];
+        $response->setResolveDomainResponse($services);
+
+        $this->assertEquals(array_keys($services), $response->getServices());
+    }
+
+    /**
+     * Test getting service URLs.
+     *
+     * @covers ::getUrl
+     */
+    public function testGetUrl()
+    {
+        $response = new ResolveDomainResponse();
+        $first = new Uri('http://example.com/1');
+        $second = new Uri('http://example.com/2');
+        $services = [
+            'first service' => $first,
+            'second service' => $second,
+        ];
+        $response->setResolveDomainResponse($services);
+
+        $this->assertEquals($first->withScheme('https'), $response->getUrl('first service'));
+        $this->assertSame($second, $response->getUrl('second service', true));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not found service was not found.');
+        $response->getUrl('not found');
+    }
+}


### PR DESCRIPTION
Resolves #31.

This PR adds support for marking a service as "insecure", meaning it is only available over http and not https. As well, it uses Symfony's serializer for decoding the response, specifically so we can use the existing class to convert strings into Uri objects. This is particularly useful for converting service urls to HTTPS, which in general are available but are not discoverable via the API.

Also, if MPX updates their API so everything is available over HTTPS, we can simply ignore the 'insecure' marking in objects without breaking compatibility.