### PR TITLE
Allow down to doctrine/annotations:^1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "cache/cache": "^1.0",
     "symfony/serializer": "^3.4",
     "symfony/property-access": "^3.4",
-    "doctrine/annotations": "^1.4",
+    "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4",
     "symfony/lock": "^3.4"
   },


### PR DESCRIPTION
This fixes a conflict with Drupal 8's annotation library.

https://github.com/composer/composer/issues/7230