### PR TITLE
Fix null fatal when no range is set on ByFields

### DIFF
--- a/src/DataService/ByFields.php
+++ b/src/DataService/ByFields.php
@@ -34,10 +34,14 @@ class ByFields
      */
     protected $range;
 
+    /**
+     * ByFields constructor.
+     */
     public function __construct()
     {
         $this->sort = new Sort();
         $this->sort->addSort('id');
+        $this->range = new Range();
     }
 
     /**

--- a/src/DataService/Range.php
+++ b/src/DataService/Range.php
@@ -66,7 +66,7 @@ class Range
      *
      * @return Range A new range.
      */
-    public static function nextRange(ObjectList $list)
+    public static function nextRange(ObjectList $list): self
     {
         $range = new self();
         $start = $list->getStartIndex() + $list->getEntryCount();
@@ -79,10 +79,14 @@ class Range
     /**
      * Return an array of query parameters representing this range.
      *
-     * @return array An array with a 'range' key.
+     * @return array An array with a 'range' key, or an empty array if neither start or end is set.
      */
-    public function toQueryParts()
+    public function toQueryParts(): array
     {
+        if (empty($this->startIndex) && empty($this->endIndex)) {
+            return [];
+        }
+
         return ['range' => $this->startIndex.'-'.$this->endIndex];
     }
 }

--- a/src/DataService/Sort.php
+++ b/src/DataService/Sort.php
@@ -34,10 +34,14 @@ class Sort
     /**
      * Return this sort as an array suitable for a Guzzle query.
      *
-     * @return array An array with a 'sort' key.
+     * @return array An array with a 'sort' key, or an empty array if no sorts are set.
      */
     public function toQueryParts()
     {
+        if (empty($this->fields)) {
+            return [];
+        }
+
         return [
             'sort' => implode(',', $this->fields),
         ];

--- a/tests/src/Unit/DataService/ByFieldsTest.php
+++ b/tests/src/Unit/DataService/ByFieldsTest.php
@@ -47,4 +47,15 @@ class ByFieldsTest extends TestCase
             'range' => '1-10',
         ], $parts);
     }
+
+    /**
+     * Test that a completely empty ByFields object can still be rendered to query parts.
+     *
+     * @covers ::toQueryParts()
+     */
+    public function testNoValues()
+    {
+        $byFields = new ByFields();
+        $this->assertEquals(['sort' => 'id'], $byFields->toQueryParts());
+    }
 }

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -48,6 +48,15 @@ class RangeTest extends TestCase
     }
 
     /**
+     * @covers ::toQueryParts()
+     */
+    public function testEmpty()
+    {
+        $range = new Range();
+        $this->assertEquals([], $range->toQueryParts());
+    }
+
+    /**
      * @covers ::setStartIndex
      */
     public function testBadStartIndex()

--- a/tests/src/Unit/DataService/SortTest.php
+++ b/tests/src/Unit/DataService/SortTest.php
@@ -21,4 +21,13 @@ class SortTest extends TestCase
         $sort->addSort('title');
         $this->assertEquals(['sort' => 'id|desc,title'], $sort->toQueryParts());
     }
+
+    /**
+     * @covers ::toQueryParts()
+     */
+    public function testEmptySort()
+    {
+        $sort = new Sort();
+        $this->assertEquals([], $sort->toQueryParts());
+    }
 }


### PR DESCRIPTION
Ranges are optional, and mpx will automatically set a `1-500` range if one isn't requested. This PR fixes making queries that don't specify a range.