### PR TITLE
Support getting the account from the client

### DIFF
--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Psr\Http\Message\RequestInterface;
@@ -78,6 +79,21 @@ class AuthenticatedClient implements ClientInterface
     public function getConfig($option = null)
     {
         return $this->client->getConfig($option);
+    }
+
+    /**
+     * Return the mpx Account associated with this authenticated client.
+     *
+     * Normally this is the root mpx account. The account object is not completely loaded, and only contains an id.
+     *
+     * @return Account An mpx Account.
+     */
+    public function getAccount(): Account
+    {
+        $account = new Account();
+        $account->setId($this->user->acquireToken()->getUserId());
+
+        return $account;
     }
 
     /**

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -70,6 +70,10 @@ class DataObjectFactory
      */
     public function loadByNumericId(int $id, Account $account = null, bool $readonly = false)
     {
+        if (!$account) {
+            $account = $this->authenticatedClient->getAccount();
+        }
+
         $annotation = $this->dataService->getAnnotation();
         $base = $this->getBaseUri($account, $annotation, $readonly);
 
@@ -125,12 +129,17 @@ class DataObjectFactory
      * Query for MPX data using 'byField' parameters.
      *
      * @param ByFields $byFields The fields and values to filter by. Note these are exact matches.
-     * @param Account  $account  The account context to use in the request.
+     * @param Account  $account  (optional) The account context to use in the request. Defaults to the account
+     *                           associated with the authenticated client.
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
-    public function select(ByFields $byFields, Account $account): ObjectListIterator
+    public function select(ByFields $byFields, Account $account = null): ObjectListIterator
     {
+        if (!$account) {
+            $account = $this->authenticatedClient->getAccount();
+        }
+
         return new ObjectListIterator($this->selectRequest($byFields, $account));
     }
 
@@ -182,7 +191,7 @@ class DataObjectFactory
      *
      * @return string The base URI.
      */
-    private function getBaseUri(Account $account = null, DataService $annotation, bool $readonly = false): string
+    private function getBaseUri(Account $account, DataService $annotation, bool $readonly = false): string
     {
         // Accounts are optional as you need to be able to load an account
         // before you can resolve services.


### PR DESCRIPTION
When an implementation searches for objects, such as with `\Lullabot\Mpx\DataService\DataObjectFactory::select`, they need to have some sort of account context. This can be a root account - it just can't be nothing.

This PR makes it so that if no specific account is specified, the account that is returned by the initial `signIn` call is used automatically.