### PR TITLE
Fix ad policy property being in the base data trait

### DIFF
--- a/src/DataService/AdPolicyDataTrait.php
+++ b/src/DataService/AdPolicyDataTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Trait for objects implementing advertising policies.
+ */
+trait AdPolicyDataTrait
+{
+    /**
+     * The identifier for the advertising policy for this object.
+     *
+     * @var UriInterface
+     */
+    protected $adPolicyId;
+
+    /**
+     * Returns the id of the AdPolicy associated with this content.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAdPolicyId(): UriInterface
+    {
+        return $this->adPolicyId;
+    }
+
+    /**
+     * Set the id of the AdPolicy associated with this content.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAdPolicyId($adPolicyId)
+    {
+        $this->adPolicyId = $adPolicyId;
+    }
+}

--- a/src/DataService/BaseDataTrait.php
+++ b/src/DataService/BaseDataTrait.php
@@ -24,13 +24,6 @@ trait BaseDataTrait
     protected $addedByUserId;
 
     /**
-     * the identifier for the advertising policy for this object.
-     *
-     * @var UriInterface
-     */
-    protected $adPolicyId;
-
-    /**
      * The globally unique URI of this object.
      *
      * @var UriInterface

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\CreateKeyInterface;
+use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\BaseDataTrait;
 use Psr\Http\Message\UriInterface;
@@ -23,6 +24,7 @@ use Psr\Http\Message\UriInterface;
 class Media implements CreateKeyInterface
 {
     use BaseDataTrait;
+    use AdPolicyDataTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -366,26 +368,6 @@ class Media implements CreateKeyInterface
      * @var int
      */
     protected $version;
-
-    /**
-     * Returns the id of the AdPolicy associated with this content.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getAdPolicyId(): UriInterface
-    {
-        return $this->adPolicyId;
-    }
-
-    /**
-     * Set the id of the AdPolicy associated with this content.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setAdPolicyId($adPolicyId)
-    {
-        $this->adPolicyId = $adPolicyId;
-    }
 
     /**
      * Returns the administrative workflow tags for this object.

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\DataService\Player;
 
 use Lullabot\Mpx\CreateKeyInterface;
+use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\BaseDataTrait;
 use Psr\Http\Message\UriInterface;
 
@@ -17,6 +18,7 @@ use Psr\Http\Message\UriInterface;
 class Player implements CreateKeyInterface
 {
     use BaseDataTrait;
+    use AdPolicyDataTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -624,26 +626,6 @@ class Player implements CreateKeyInterface
     public function setAdminTags($adminTags)
     {
         $this->adminTags = $adminTags;
-    }
-
-    /**
-     * Returns the identifier for the advertising policy for this object.
-     *
-     * @return UriInterface
-     */
-    public function getAdPolicyId(): UriInterface
-    {
-        return $this->adPolicyId;
-    }
-
-    /**
-     * Set the identifier for the advertising policy for this object.
-     *
-     * @param UriInterface
-     */
-    public function setAdPolicyId($adPolicyId)
-    {
-        $this->adPolicyId = $adPolicyId;
     }
 
     /**


### PR DESCRIPTION
The policy property was accidentally put into the BaseDataTrait, when it's totally not common to all objects. Also, the get / set methods were duplicated in the Media and Player classes, so I pulled all three out into a trait.