### PR TITLE
Add the missing Functional test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,11 @@
             <directory suffix="Test.php">./tests/src/Unit</directory>
         </testsuite>
     </testsuites>
+    <testsuites>
+        <testsuite name="Functional">
+            <directory suffix="Test.php">./tests/src/Functional</directory>
+        </testsuite>
+    </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>


### PR DESCRIPTION
I had this in my local `phpunit.xml` but never added it to `phpunit.xml.dist`. If you want to try running these (they are skipped on CircleCI because they require a real account):

1. Copy `phpunit.xml.dist` to `phpunit.xml`.
1. Edit the `MPX_*` environment variables. Ask me if you need credentials.
1. `composer install` if you haven't already.
1. To run all tests locally, run `vendor/bin/phpunit`, or for just the functional tests run `vendor/bin/phpunit --testsuite functional`.