### PR TITLE
Always use https

### DIFF
--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -46,13 +46,6 @@ class DataService
     public $baseUri;
 
     /**
-     * Is this service only available over HTTP?
-     *
-     * @var bool
-     */
-    public $insecure = false;
-
-    /**
      * Return the service of the data object, such as 'Media Data Service'.
      *
      * @param bool $readonly (optional) Set to true to return the read-only name of the service.

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -12,7 +12,6 @@ use Psr\Http\Message\UriInterface;
  *     service="Player Data Service",
  *     objectType="Player",
  *     schemaVersion="1.6",
- *     insecure=true,
  * )
  */
 class Player extends ObjectBase

--- a/src/Service/AccessManagement/ResolveDomainResponse.php
+++ b/src/Service/AccessManagement/ResolveDomainResponse.php
@@ -32,6 +32,9 @@ class ResolveDomainResponse
      * Note that no 'getResolveDomainResponse' method is implemented, to ensure
      * that callers get https URLs unless they explicitly ask for insecure URLs.
      *
+     * While resolveDomainResponse currently returns many services with http
+     * URLs, according to thePlatform all services should now support https.
+     *
      * @param string $service  The name of the service, such as 'Media Data Service read-only'.
      * @param bool   $insecure (optional) Set to true to request the insecure version of this service.
      *

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit\DataService;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\DataService\DataObjectFactory;
@@ -26,11 +27,11 @@ class DataObjectFactoryTest extends TestCase
     use MockClientTrait;
 
     /**
-     * Tests the correct path when loading by ID.
+     * Tests loading a URI to an mpx object.
      *
-     * @covers ::loadByNumericId()
+     * @covers ::load()
      */
-    public function testLoadByNumericId()
+    public function testLoad()
     {
         $manager = DataServiceManager::basicDiscovery();
         $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
@@ -38,6 +39,7 @@ class DataObjectFactoryTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'resolveDomain.json'),
             function (\Psr\Http\Message\RequestInterface $request) {
+                $this->assertEquals('https', $request->getUri()->getScheme());
                 $this->assertEquals('/media/data/Media/12345', $request->getUri()->getPath());
 
                 return new JsonResponse(200, [], 'media-object.json');
@@ -52,7 +54,40 @@ class DataObjectFactoryTest extends TestCase
         $factory = new DataObjectFactory($service, $authenticatedClient);
 
         $account = new Account();
-        $account->setId(new \GuzzleHttp\Psr7\Uri('http://example.com/1'));
+        $account->setId(new Uri('http://example.com/1'));
+        $media = $factory->load(new Uri('http://data.media.theplatform.com/media/data/Media/12345'))->wait();
+        $this->assertInstanceOf(Media::class, $media);
+    }
+
+    /**
+     * Tests the correct path when loading by ID.
+     *
+     * @covers ::loadByNumericId()
+     */
+    public function testLoadByNumericId()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'resolveDomain.json'),
+            function (\Psr\Http\Message\RequestInterface $request) {
+                $this->assertEquals('https', $request->getUri()->getScheme());
+                $this->assertEquals('/media/data/Media/12345', $request->getUri()->getPath());
+
+                return new JsonResponse(200, [], 'media-object.json');
+            },
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $session = new UserSession($user, $client, $store, $tokenCachePool);
+        $authenticatedClient = new AuthenticatedClient($client, $session);
+        $factory = new DataObjectFactory($service, $authenticatedClient);
+
+        $account = new Account();
+        $account->setId(new Uri('http://example.com/1'));
         $media = $factory->loadByNumericId(12345, $account)->wait();
         $this->assertInstanceOf(Media::class, $media);
     }


### PR DESCRIPTION
~~Depends on #99.~~

After discussing with thePlatform, they say that all services should be available over https, even if their docs are not updated reflecting that. This PR:

* Removes the `insecure` annotation for a data service, which we previously used for the Player data r/w service, as that service is now available over https.
* When loading mpx objects, we always convert URLs to https. I thought about doing it at the client layer, but I think as a developer if you use the client directly you expect the protocol of your request to remain untouched.