### PR TITLE
Support generating player URLs for iframes

### DIFF
--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
@@ -91,7 +92,7 @@ class AuthenticatedClient implements ClientInterface
     public function getAccount(): Account
     {
         $account = new Account();
-        $account->setId($this->user->acquireToken()->getUserId());
+        $account->setId(new Uri($this->user->acquireToken()->getUserId()));
 
         return $account;
     }

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -4,6 +4,8 @@ namespace Lullabot\Mpx\DataService\Access;
 
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
+use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -14,22 +16,8 @@ use Psr\Http\Message\UriInterface;
  *   objectType="Account"
  * )
  */
-class Account
+class Account extends ObjectBase implements PublicIdentifierInterface
 {
-    /**
-     * The date and time that this object was created.
-     *
-     * @var \DateTime
-     */
-    protected $added;
-
-    /**
-     * The id of the user that created this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $addedByUserId;
-
     /**
      * The description of this object.
      *
@@ -66,25 +54,11 @@ class Account
     protected $guid;
 
     /**
-     * The globally unique URI of this object.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $id;
-
-    /**
      * Whether this object currently allows updates.
      *
      * @var bool
      */
     protected $locked;
-
-    /**
-     * The id of the account that owns this account.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $ownerId;
 
     /**
      * A public identifier for the account.
@@ -131,46 +105,6 @@ class Account
     protected $version;
 
     /**
-     * Returns the date and time that this object was created.
-     *
-     * @return \DateTime
-     */
-    public function getAdded(): \DateTime
-    {
-        return $this->added;
-    }
-
-    /**
-     * Set the date and time that this object was created.
-     *
-     * @param \DateTime
-     */
-    public function setAdded($added)
-    {
-        $this->added = $added;
-    }
-
-    /**
-     * Returns the id of the user that created this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getAddedByUserId(): UriInterface
-    {
-        return $this->addedByUserId;
-    }
-
-    /**
-     * Set the id of the user that created this object.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setAddedByUserId($addedByUserId)
-    {
-        $this->addedByUserId = $addedByUserId;
-    }
-
-    /**
      * Returns the description of this object.
      *
      * @return string
@@ -191,7 +125,7 @@ class Account
     }
 
     /**
-     * Returns Whether this account is disabled.
+     * Returns whether this account is disabled.
      *
      * @return bool
      */
@@ -201,7 +135,7 @@ class Account
     }
 
     /**
-     * Set Whether this account is disabled.
+     * Set whether this account is disabled.
      *
      * @param bool
      */
@@ -271,29 +205,6 @@ class Account
     }
 
     /**
-     * Returns the globally unique URI of this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getId(): UriInterface
-    {
-        return $this->id;
-    }
-
-    /**
-     * Set the globally unique URI of this object.
-     *
-     * @param \Psr\Http\Message\UriInterface|string
-     */
-    public function setId($id)
-    {
-        if (is_string($id)) {
-            $id = new Uri($id);
-        }
-        $this->id = $id;
-    }
-
-    /**
      * Returns Whether this object currently allows updates.
      *
      * @return bool
@@ -311,26 +222,6 @@ class Account
     public function setLocked($locked)
     {
         $this->locked = $locked;
-    }
-
-    /**
-     * Returns the id of the account that owns this account.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getOwnerId(): UriInterface
-    {
-        return $this->ownerId;
-    }
-
-    /**
-     * Set the id of the account that owns this account.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setOwnerId($ownerId)
-    {
-        $this->ownerId = $ownerId;
     }
 
     /**

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -2,7 +2,6 @@
 
 namespace Lullabot\Mpx\DataService\Access;
 
-use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx\DataService\Access;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdentifierTrait;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -17,6 +18,8 @@ use Psr\Http\Message\UriInterface;
  */
 class Account extends ObjectBase implements PublicIdentifierInterface
 {
+    use PublicIdentifierTrait;
+
     /**
      * The description of this object.
      *
@@ -58,13 +61,6 @@ class Account extends ObjectBase implements PublicIdentifierInterface
      * @var bool
      */
     protected $locked;
-
-    /**
-     * A public identifier for the account.
-     *
-     * @var string
-     */
-    protected $pid;
 
     /**
      * The account's region.
@@ -221,32 +217,6 @@ class Account extends ObjectBase implements PublicIdentifierInterface
     public function setLocked($locked)
     {
         $this->locked = $locked;
-    }
-
-    /**
-     * Returns A public identifier for the account.
-     *
-     * @return string
-     */
-    public function getPid(): string
-    {
-        return $this->pid;
-    }
-
-    /**
-     * Set A public identifier for the account.
-     *
-     * @param string
-     */
-    public function setPid($pid)
-    {
-        if (strlen($pid) > 64) {
-            throw new \InvalidArgumentException('Public Identifiers must not be longer than 64 characters.');
-        }
-        if ('ASCII' != mb_check_encoding($pid)) {
-            throw new \InvalidArgumentException('Public Identifiers must be ASCII encoded strings.');
-        }
-        $this->pid = $pid;
     }
 
     /**

--- a/src/DataService/AdPolicyDataTrait.php
+++ b/src/DataService/AdPolicyDataTrait.php
@@ -12,7 +12,7 @@ trait AdPolicyDataTrait
     /**
      * The identifier for the advertising policy for this object.
      *
-     * @var UriInterface
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $adPolicyId;
 
@@ -31,7 +31,7 @@ trait AdPolicyDataTrait
      *
      * @param \Psr\Http\Message\UriInterface
      */
-    public function setAdPolicyId($adPolicyId)
+    public function setAdPolicyId(UriInterface $adPolicyId)
     {
         $this->adPolicyId = $adPolicyId;
     }

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -21,7 +22,7 @@ use Psr\Http\Message\UriInterface;
  *   objectType="Media",
  * )
  */
-class Media extends ObjectBase
+class Media extends ObjectBase implements PublicIdentifierInterface
 {
     use AdPolicyDataTrait;
 

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -7,6 +7,7 @@ use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdentifierTrait;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -25,6 +26,7 @@ use Psr\Http\Message\UriInterface;
 class Media extends ObjectBase implements PublicIdentifierInterface
 {
     use AdPolicyDataTrait;
+    use PublicIdentifierTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -249,13 +251,6 @@ class Media extends ObjectBase implements PublicIdentifierInterface
      * @var \Psr\Http\Message\UriInterface[]
      */
     protected $originalOwnerIds;
-
-    /**
-     * The globally unique public identifier for this media.
-     *
-     * @var string
-     */
-    protected $pid;
 
     /**
      * The ID of the Program that represents this media. The GUID URI is recommended.
@@ -1007,26 +1002,6 @@ class Media extends ObjectBase implements PublicIdentifierInterface
     public function setOriginalOwnerIds($originalOwnerIds)
     {
         $this->originalOwnerIds = $originalOwnerIds;
-    }
-
-    /**
-     * Returns the globally unique public identifier for this media.
-     *
-     * @return string
-     */
-    public function getPid(): string
-    {
-        return $this->pid;
-    }
-
-    /**
-     * Set the globally unique public identifier for this media.
-     *
-     * @param string
-     */
-    public function setPid($pid)
-    {
-        $this->pid = $pid;
     }
 
     /**

--- a/src/DataService/Media/MediaFile.php
+++ b/src/DataService/Media/MediaFile.php
@@ -4,7 +4,6 @@ namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 
 /**
  * Implements a MediaFile object.

--- a/src/DataService/Media/MediaFile.php
+++ b/src/DataService/Media/MediaFile.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 
 /**
  * Implements a MediaFile object.

--- a/src/DataService/Media/Release.php
+++ b/src/DataService/Media/Release.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\DataService\Media;
 
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 
 /**
  * @DataService(
@@ -12,7 +13,7 @@ use Lullabot\Mpx\DataService\ObjectBase;
  *   objectType="Release",
  * )
  */
-class Release extends ObjectBase
+class Release extends ObjectBase implements PublicIdentifierInterface
 {
     /**
      * The id of the AdPolicy object this object is associated with.

--- a/src/DataService/Media/Release.php
+++ b/src/DataService/Media/Release.php
@@ -2,9 +2,11 @@
 
 namespace Lullabot\Mpx\DataService\Media;
 
+use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdentifierTrait;
 
 /**
  * @DataService(
@@ -15,12 +17,8 @@ use Lullabot\Mpx\DataService\PublicIdentifierInterface;
  */
 class Release extends ObjectBase implements PublicIdentifierInterface
 {
-    /**
-     * The id of the AdPolicy object this object is associated with.
-     *
-     * @var \Psr\Http\Message\UriInterface
-     */
-    protected $adPolicyId;
+    use AdPolicyDataTrait;
+    use PublicIdentifierTrait;
 
     /**
      * Whether this object is approved; if false this object is not visible in feeds.
@@ -84,13 +82,6 @@ class Release extends ObjectBase implements PublicIdentifierInterface
      * @var string
      */
     protected $parameters;
-
-    /**
-     * The globally unique public identifier for this object.
-     *
-     * @var string
-     */
-    protected $pid;
 
     /**
      * The id of the Restriction object this object is associated with.
@@ -312,26 +303,6 @@ class Release extends ObjectBase implements PublicIdentifierInterface
     public function setParameters($parameters)
     {
         $this->parameters = $parameters;
-    }
-
-    /**
-     * Returns the globally unique public identifier for this object.
-     *
-     * @return string
-     */
-    public function getPid(): string
-    {
-        return $this->pid;
-    }
-
-    /**
-     * Set the globally unique public identifier for this object.
-     *
-     * @param string
-     */
-    public function setPid($pid)
-    {
-        $this->pid = $pid;
     }
 
     /**

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -2,6 +2,8 @@
 
 namespace Lullabot\Mpx\DataService;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Base class for common data used by all mpx objects.
  */
@@ -78,7 +80,7 @@ abstract class ObjectBase implements ObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function setId($id)
+    public function setId(UriInterface $id)
     {
         $this->id = $id;
     }

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -2,6 +2,8 @@
 
 namespace Lullabot\Mpx\DataService;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Defines an interface object properties common to all mpx objects.
  */
@@ -24,42 +26,42 @@ interface ObjectInterface
     /**
      * Returns the id of the user that created this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getAddedByUserId(): \Psr\Http\Message\UriInterface;
+    public function getAddedByUserId(): UriInterface;
 
     /**
      * Set the id of the user that created this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setAddedByUserId($addedByUserId);
 
     /**
      * Returns the globally unique URI of this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getId(): \Psr\Http\Message\UriInterface;
+    public function getId(): UriInterface;
 
     /**
      * Set the globally unique URI of this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
-    public function setId($id);
+    public function setId(UriInterface $id);
 
     /**
      * Returns the id of the account that owns this object.
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return UriInterface
      */
-    public function getOwnerId(): \Psr\Http\Message\UriInterface;
+    public function getOwnerId(): UriInterface;
 
     /**
      * Set the id of the account that owns this object.
      *
-     * @param \Psr\Http\Message\UriInterface
+     * @param UriInterface
      */
     public function setOwnerId($ownerId);
 }

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -6,6 +6,7 @@ use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdentifierTrait;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -19,6 +20,7 @@ use Psr\Http\Message\UriInterface;
 class Player extends ObjectBase implements PublicIdentifierInterface
 {
     use AdPolicyDataTrait;
+    use PublicIdentifierTrait;
 
     /**
      * The administrative workflow tags for this object.
@@ -397,13 +399,6 @@ class Player extends ObjectBase implements PublicIdentifierInterface
      * @var string
      */
     protected $pdk;
-
-    /**
-     * The public identifier for this player when requested through the Player Service.
-     *
-     * @var string
-     */
-    protected $pid;
 
     /**
      * Indicates if the player should automatically play the next release when one finishes.
@@ -1686,26 +1681,6 @@ class Player extends ObjectBase implements PublicIdentifierInterface
     public function setPdk($pdk)
     {
         $this->pdk = $pdk;
-    }
-
-    /**
-     * Returns the public identifier for this player when requested through the Player Service.
-     *
-     * @return string
-     */
-    public function getPid(): string
-    {
-        return $this->pid;
-    }
-
-    /**
-     * Set the public identifier for this player when requested through the Player Service.
-     *
-     * @param string
-     */
-    public function setPid($pid)
-    {
-        $this->pid = $pid;
     }
 
     /**

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx\DataService\Player;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\AdPolicyDataTrait;
 use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -15,7 +16,7 @@ use Psr\Http\Message\UriInterface;
  *     insecure=true,
  * )
  */
-class Player extends ObjectBase
+class Player extends ObjectBase implements PublicIdentifierInterface
 {
     use AdPolicyDataTrait;
 

--- a/src/DataService/PublicIdentifierInterface.php
+++ b/src/DataService/PublicIdentifierInterface.php
@@ -13,5 +13,4 @@ interface PublicIdentifierInterface
      * @return string
      */
     public function getPid(): string;
-
 }

--- a/src/DataService/PublicIdentifierInterface.php
+++ b/src/DataService/PublicIdentifierInterface.php
@@ -13,4 +13,11 @@ interface PublicIdentifierInterface
      * @return string
      */
     public function getPid(): string;
+
+    /**
+     * Set the public identifier for this mpx object.
+     *
+     * @param string
+     */
+    public function setPid(string $pid);
 }

--- a/src/DataService/PublicIdentifierInterface.php
+++ b/src/DataService/PublicIdentifierInterface.php
@@ -14,10 +14,4 @@ interface PublicIdentifierInterface
      */
     public function getPid(): string;
 
-    /**
-     * Set the public identifier for this mpx object.
-     *
-     * @param string
-     */
-    public function setPid($pid);
 }

--- a/src/DataService/PublicIdentifierInterface.php
+++ b/src/DataService/PublicIdentifierInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Interface definition for all mpx objects with a public identifier.
+ */
+interface PublicIdentifierInterface
+{
+    /**
+     * Returns the public identifier for this mpx object.
+     *
+     * @return string
+     */
+    public function getPid(): string;
+
+    /**
+     * Set the public identifier for this mpx object.
+     *
+     * @param string
+     */
+    public function setPid($pid);
+}

--- a/src/DataService/PublicIdentifierTrait.php
+++ b/src/DataService/PublicIdentifierTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Trait for mpx objects implementing a public identifier.
+ */
+trait PublicIdentifierTrait
+{
+    /**
+     * A public identifier for the account.
+     *
+     * @var string
+     */
+    protected $pid;
+
+    /**
+     * Returns a public identifier for the account.
+     *
+     * @return string
+     */
+    public function getPid(): string
+    {
+        return $this->pid;
+    }
+
+    /**
+     * Set a public identifier for the account.
+     *
+     * @param string
+     */
+    public function setPid(string $pid)
+    {
+        if (strlen($pid) > 64) {
+            throw new \InvalidArgumentException('Public Identifiers must not be longer than 64 characters.');
+        }
+        if ('ASCII' != mb_check_encoding($pid)) {
+            throw new \InvalidArgumentException('Public Identifiers must be ASCII encoded strings.');
+        }
+        $this->pid = $pid;
+    }
+}

--- a/src/Player/Url.php
+++ b/src/Player/Url.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Lullabot\Mpx\Player;
+
+use function GuzzleHttp\Psr7\build_query;
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\Player\Player;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Represents a player URL, suitable for embedding with an iframe.
+ *
+ * @see https://docs.theplatform.com/help/displaying-mpx-players-to-your-audience
+ * @see https://docs.theplatform.com/help/generate-a-player-url-for-a-media
+ */
+class Url
+{
+    /**
+     * The base URL for all players.
+     */
+    const BASE_URL = 'https://player.theplatform.com/p/';
+
+    /**
+     * The account the player belongs to.
+     *
+     * @var \Lullabot\Mpx\DataService\PublicIdentifierInterface
+     */
+    private $account;
+
+    /**
+     * The player object the URL is being generated for.
+     *
+     * @var Player
+     */
+    private $player;
+
+    /**
+     * The media that is being played.
+     *
+     * @var Media
+     */
+    private $media;
+
+    /**
+     * Should autoplay be overridden?
+     *
+     * @var bool
+     */
+    private $autoplay;
+
+    /**
+     * Should the playAll setting be overridden?
+     *
+     * @var bool
+     */
+    private $playAll;
+
+    /**
+     * Url constructor.
+     *
+     * @param PublicIdentifierInterface $account The account the player is owned by.
+     * @param Player                    $player  The player to play $media with.
+     * @param Media                     $media   The media to play.
+     */
+    public function __construct(PublicIdentifierInterface $account, Player $player, Media $media)
+    {
+        $this->player = $player;
+        $this->media = $media;
+        $this->account = $account;
+    }
+
+    /**
+     * Return the URL for this player and media.
+     *
+     * @return UriInterface
+     */
+    public function toUri(): UriInterface
+    {
+        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/'.$this->media->getPid());
+        $query_parts = [];
+
+        if ($this->autoplay) {
+            $query_parts['autoplay'] = $this->autoplay;
+        }
+        if ($this->playAll) {
+            $query_parts['playAll'] = $this->playAll;
+        }
+
+        $uri = $uri->withQuery(build_query($query_parts));
+
+        return $uri;
+    }
+
+    /**
+     * Returns the URL of this player as a string.
+     *
+     * @return string The player URL.
+     */
+    public function __toString()
+    {
+        return (string) $this->toUri();
+    }
+
+    /**
+     * Override the player's autoplay setting for this URL.
+     *
+     * @see https://docs.theplatform.com/help/player-player-autoplay
+     *
+     * @param bool $autoplay True to enable autoplay, false otherwise.
+     */
+    public function setAutoplay(bool $autoplay)
+    {
+        $this->autoplay = $autoplay;
+    }
+
+    /**
+     * Override the player's playAll setting for playlist auto-advance for this URL.
+     *
+     * @see https://docs.theplatform.com/help/player-player-playall
+     *
+     * @param bool $playAll
+     */
+    public function setPlayAll(bool $playAll)
+    {
+        $this->playAll = $playAll;
+    }
+}

--- a/tests/src/Unit/Player/UrlTest.php
+++ b/tests/src/Unit/Player/UrlTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Player;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\Player\Player;
+use Lullabot\Mpx\Player\Url;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests generating player URLs for embedding.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\Player\Url
+ */
+class UrlTest extends TestCase
+{
+
+    /**
+     * Tests generating a URI object.
+     *
+     * @covers ::__construct()
+     * @covers ::toUri()
+     * @covers ::setPlayAll()
+     * @covers ::setAutoplay()
+     * @covers ::__toString()
+     */
+    public function testToUri()
+    {
+        $account = new Account();
+        $account->setPid("account-pid");
+
+        $player = new Player();
+        $player->setPid("player-pid");
+
+        $media = new Media();
+        $media->setPid("media-pid");
+        $player_url = new Url($account, $player, $media);
+
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media-pid', (string) $player_url->toUri());
+
+        $player_url->setAutoplay(true);
+        $player_url->setPlayAll(true);
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media-pid?autoplay=1&playAll=1', (string) $player_url);
+    }
+}

--- a/tests/src/Unit/Player/UrlTest.php
+++ b/tests/src/Unit/Player/UrlTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
  */
 class UrlTest extends TestCase
 {
-
     /**
      * Tests generating a URI object.
      *
@@ -28,13 +27,13 @@ class UrlTest extends TestCase
     public function testToUri()
     {
         $account = new Account();
-        $account->setPid("account-pid");
+        $account->setPid('account-pid');
 
         $player = new Player();
-        $player->setPid("player-pid");
+        $player->setPid('player-pid');
 
         $media = new Media();
-        $media->setPid("media-pid");
+        $media->setPid('media-pid');
         $player_url = new Url($account, $player, $media);
 
         $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media-pid', (string) $player_url->toUri());


### PR DESCRIPTION
The `PublicIdentifierInterface` has been added so the Drupal module can implement it on the Account config entity object, allowing it to be directly passed in to the PHP library.

I also fixed the Account object duplicating some code that is now available in the `ObjectBase` class.