### PR TITLE
Fix account incorrectly using the user ID

### DIFF
--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -5,7 +5,6 @@ namespace Lullabot\Mpx;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Psr\Http\Message\RequestInterface;
@@ -79,21 +78,6 @@ class AuthenticatedClient implements ClientInterface
     public function getConfig($option = null)
     {
         return $this->client->getConfig($option);
-    }
-
-    /**
-     * Return the mpx Account associated with this authenticated client.
-     *
-     * Normally this is the root mpx account. The account object is not completely loaded, and only contains an id.
-     *
-     * @return Account An mpx Account.
-     */
-    public function getAccount(): Account
-    {
-        $account = new Account();
-        $account->setId($this->user->acquireToken()->getUserId());
-
-        return $account;
     }
 
     /**

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\DataService\Access;
 
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
+use Lullabot\Mpx\DataService\IdInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -14,7 +15,7 @@ use Psr\Http\Message\UriInterface;
  *   objectType="Account"
  * )
  */
-class Account
+class Account implements IdInterface
 {
     /**
      * The date and time that this object was created.

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -284,13 +284,10 @@ class Account implements IdInterface
     /**
      * Set the globally unique URI of this object.
      *
-     * @param \Psr\Http\Message\UriInterface|string
+     * @param \Psr\Http\Message\UriInterface
      */
-    public function setId($id)
+    public function setId(UriInterface $id)
     {
-        if (is_string($id)) {
-            $id = new Uri($id);
-        }
         $this->id = $id;
     }
 

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -5,7 +5,6 @@ namespace Lullabot\Mpx\DataService;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use GuzzleHttp\Promise\PromiseInterface;
 use Lullabot\Mpx\AuthenticatedClient;
-use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\Encoder\CJsonEncoder;
 use Lullabot\Mpx\Normalizer\UnixMicrosecondNormalizer;
@@ -146,12 +145,12 @@ class DataObjectFactory
      * Query for MPX data using 'byField' parameters.
      *
      * @param ByFields $byFields The fields and values to filter by. Note these are exact matches.
-     * @param Account  $account  (optional) The account context to use in the request. Defaults to the account
+     * @param IdInterface  $account  (optional) The account context to use in the request. Defaults to the account
      *                           associated with the authenticated client.
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
-    public function select(ByFields $byFields, Account $account = null): ObjectListIterator
+    public function select(ByFields $byFields, IdInterface $account = null): ObjectListIterator
     {
         return new ObjectListIterator($this->selectRequest($byFields, $account));
     }

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -80,13 +80,13 @@ class DataObjectFactory
     /**
      * Load a data object from MPX, returning a promise to it.
      *
-     * @param int                                      $id       The numeric ID to load.
-     * @param \Lullabot\Mpx\DataService\Access\Account $account
-     * @param bool                                     $readonly (optional) Load from the read-only service.
+     * @param int             $id       The numeric ID to load.
+     * @param ObjectInterface $account
+     * @param bool            $readonly (optional) Load from the read-only service.
      *
      * @return PromiseInterface
      */
-    public function loadByNumericId(int $id, Account $account = null, bool $readonly = false)
+    public function loadByNumericId(int $id, ObjectInterface $account = null, bool $readonly = false)
     {
         $annotation = $this->dataService->getAnnotation();
         $base = $this->getBaseUri($annotation, $account, $readonly);
@@ -161,13 +161,13 @@ class DataObjectFactory
      *
      * @see \Lullabot\Mpx\DataService\DataObjectFactory::select
      *
-     * @param ByFields $byFields The fields and values to filter by. Note these are exact matches.
-     * @param Account  $account  (optional) The account context to use in the request. Note that most requests require
-     *                           an account context.
+     * @param ByFields        $byFields The fields and values to filter by. Note these are exact matches.
+     * @param ObjectInterface $account  (optional) The account context to use in the request. Note that most requests require
+     *                                  an account context.
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */
-    public function selectRequest(ByFields $byFields, Account $account = null): PromiseInterface
+    public function selectRequest(ByFields $byFields, ObjectInterface $account = null): PromiseInterface
     {
         $annotation = $this->dataService->getAnnotation();
         $options = [
@@ -201,13 +201,13 @@ class DataObjectFactory
      *
      * @todo This should cache resolved URLs.
      *
-     * @param DataService $annotation The annotation data is being loaded for.
-     * @param Account     $account    (optional) The account to use for service resolution.
-     * @param bool        $readonly   (optional) Load from the read-only service.
+     * @param DataService     $annotation The annotation data is being loaded for.
+     * @param ObjectInterface $account    (optional) The account to use for service resolution.
+     * @param bool            $readonly   (optional) Load from the read-only service.
      *
      * @return string The base URI.
      */
-    private function getBaseUri(DataService $annotation, Account $account = null, bool $readonly = false): string
+    private function getBaseUri(DataService $annotation, ObjectInterface $account = null, bool $readonly = false): string
     {
         // Accounts are optional as you need to be able to load an account
         // before you can resolve services.

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -79,9 +79,9 @@ class DataObjectFactory
     /**
      * Load a data object from MPX, returning a promise to it.
      *
-     * @param int             $id       The numeric ID to load.
+     * @param int         $id       The numeric ID to load.
      * @param IdInterface $account
-     * @param bool            $readonly (optional) Load from the read-only service.
+     * @param bool        $readonly (optional) Load from the read-only service.
      *
      * @return PromiseInterface
      */
@@ -144,9 +144,9 @@ class DataObjectFactory
     /**
      * Query for MPX data using 'byField' parameters.
      *
-     * @param ByFields $byFields The fields and values to filter by. Note these are exact matches.
-     * @param IdInterface  $account  (optional) The account context to use in the request. Defaults to the account
-     *                           associated with the authenticated client.
+     * @param ByFields    $byFields The fields and values to filter by. Note these are exact matches.
+     * @param IdInterface $account  (optional) The account context to use in the request. Defaults to the account
+     *                              associated with the authenticated client.
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
@@ -160,9 +160,9 @@ class DataObjectFactory
      *
      * @see \Lullabot\Mpx\DataService\DataObjectFactory::select
      *
-     * @param ByFields        $byFields The fields and values to filter by. Note these are exact matches.
+     * @param ByFields    $byFields The fields and values to filter by. Note these are exact matches.
      * @param IdInterface $account  (optional) The account context to use in the request. Note that most requests require
-     *                                  an account context.
+     *                              an account context.
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */
@@ -200,9 +200,9 @@ class DataObjectFactory
      *
      * @todo This should cache resolved URLs.
      *
-     * @param DataService     $annotation The annotation data is being loaded for.
+     * @param DataService $annotation The annotation data is being loaded for.
      * @param IdInterface $account    (optional) The account to use for service resolution.
-     * @param bool            $readonly   (optional) Load from the read-only service.
+     * @param bool        $readonly   (optional) Load from the read-only service.
      *
      * @return string The base URI.
      */

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -50,7 +50,7 @@ class DataObjectFactory
     protected $authenticatedClient;
 
     /**
-     * Cache to store reflection metadata from implementing clasess.
+     * Cache to store reflection metadata from implementing classes.
      *
      * @var CacheItemPoolInterface
      */
@@ -81,12 +81,12 @@ class DataObjectFactory
      * Load a data object from MPX, returning a promise to it.
      *
      * @param int             $id       The numeric ID to load.
-     * @param ObjectInterface $account
+     * @param IdInterface $account
      * @param bool            $readonly (optional) Load from the read-only service.
      *
      * @return PromiseInterface
      */
-    public function loadByNumericId(int $id, ObjectInterface $account = null, bool $readonly = false)
+    public function loadByNumericId(int $id, IdInterface $account = null, bool $readonly = false)
     {
         $annotation = $this->dataService->getAnnotation();
         $base = $this->getBaseUri($annotation, $account, $readonly);
@@ -104,7 +104,7 @@ class DataObjectFactory
      * @param string $class The full class name to create.
      * @param string $data  The JSON string to deserialize.
      *
-     * @return ObjectInterface
+     * @return IdInterface
      */
     public function deserialize(string $class, $data)
     {
@@ -162,12 +162,12 @@ class DataObjectFactory
      * @see \Lullabot\Mpx\DataService\DataObjectFactory::select
      *
      * @param ByFields        $byFields The fields and values to filter by. Note these are exact matches.
-     * @param ObjectInterface $account  (optional) The account context to use in the request. Note that most requests require
+     * @param IdInterface $account  (optional) The account context to use in the request. Note that most requests require
      *                                  an account context.
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */
-    public function selectRequest(ByFields $byFields, ObjectInterface $account = null): PromiseInterface
+    public function selectRequest(ByFields $byFields, IdInterface $account = null): PromiseInterface
     {
         $annotation = $this->dataService->getAnnotation();
         $options = [
@@ -202,12 +202,12 @@ class DataObjectFactory
      * @todo This should cache resolved URLs.
      *
      * @param DataService     $annotation The annotation data is being loaded for.
-     * @param ObjectInterface $account    (optional) The account to use for service resolution.
+     * @param IdInterface $account    (optional) The account to use for service resolution.
      * @param bool            $readonly   (optional) Load from the read-only service.
      *
      * @return string The base URI.
      */
-    private function getBaseUri(DataService $annotation, ObjectInterface $account = null, bool $readonly = false): string
+    private function getBaseUri(DataService $annotation, IdInterface $account = null, bool $readonly = false): string
     {
         // Accounts are optional as you need to be able to load an account
         // before you can resolve services.

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -88,10 +88,6 @@ class DataObjectFactory
      */
     public function loadByNumericId(int $id, Account $account = null, bool $readonly = false)
     {
-        if (!$account) {
-            $account = $this->authenticatedClient->getAccount();
-        }
-
         $annotation = $this->dataService->getAnnotation();
         $base = $this->getBaseUri($annotation, $account, $readonly);
 

--- a/src/DataService/IdInterface.php
+++ b/src/DataService/IdInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Interface for mpx objects with an ID.
+ *
+ * While all mpx objects have an ID, this interface is separated from
+ * ObjectInterface so calling libraries can provide a narrow implementation.
+ */
+interface IdInterface
+{
+    /**
+     * Returns the globally unique URI of this object.
+     *
+     * @return UriInterface
+     */
+    public function getId(): UriInterface;
+
+    /**
+     * Set the globally unique URI of this object.
+     *
+     * @param UriInterface
+     */
+    public function setId(UriInterface $id);
+}

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -2,6 +2,8 @@
 
 namespace Lullabot\Mpx\DataService;
 
+use Psr\Http\Message\UriInterface;
+
 /**
  * Base class for common data used by all mpx objects.
  */
@@ -78,7 +80,7 @@ abstract class ObjectBase implements ObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function setId($id)
+    public function setId(UriInterface $id)
     {
         $this->id = $id;
     }

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -5,7 +5,7 @@ namespace Lullabot\Mpx\DataService;
 /**
  * Defines an interface object properties common to all mpx objects.
  */
-interface ObjectInterface
+interface ObjectInterface extends IdInterface
 {
     /**
      * Returns the date and time that this object was created.
@@ -34,20 +34,6 @@ interface ObjectInterface
      * @param \Psr\Http\Message\UriInterface
      */
     public function setAddedByUserId($addedByUserId);
-
-    /**
-     * Returns the globally unique URI of this object.
-     *
-     * @return \Psr\Http\Message\UriInterface
-     */
-    public function getId(): \Psr\Http\Message\UriInterface;
-
-    /**
-     * Set the globally unique URI of this object.
-     *
-     * @param \Psr\Http\Message\UriInterface
-     */
-    public function setId($id);
 
     /**
      * Returns the id of the account that owns this object.

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -204,9 +204,9 @@ class ObjectList implements \ArrayAccess, \Iterator
      * Set the objects needed to generate a next request.
      *
      * @param DataObjectFactory $dataObjectFactory The factory used to load the next ObjectList.
-     * @param Account           $account           The account context to use for the request.
+     * @param Account           $account           (optional) The account context to use for the request.
      */
-    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory, Account $account)
+    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory, Account $account = null)
     {
         $this->dataObjectFactory = $dataObjectFactory;
         $this->account = $account;
@@ -235,7 +235,7 @@ class ObjectList implements \ArrayAccess, \Iterator
             return false;
         }
 
-        if (!isset($this->dataObjectFactory) || !isset($this->account)) {
+        if (!isset($this->dataObjectFactory)) {
             throw new \LogicException('setDataObjectFactory must be called before calling nextList.');
         }
 

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -204,9 +204,9 @@ class ObjectList implements \ArrayAccess, \Iterator
      * Set the objects needed to generate a next request.
      *
      * @param DataObjectFactory $dataObjectFactory The factory used to load the next ObjectList.
-     * @param Account           $account           (optional) The account context to use for the request.
+     * @param IdInterface       $account           (optional) The account context to use for the request.
      */
-    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory, Account $account = null)
+    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory, IdInterface $account = null)
     {
         $this->dataObjectFactory = $dataObjectFactory;
         $this->account = $account;

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -4,7 +4,7 @@ namespace Lullabot\Mpx\Service\AccessManagement;
 
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
-use Lullabot\Mpx\DataService\ObjectInterface;
+use Lullabot\Mpx\DataService\IdInterface;
 use Lullabot\Mpx\Normalizer\UriNormalizer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
@@ -41,11 +41,11 @@ class ResolveDomain
     /**
      * Resolve all URLs for an account.
      *
-     * @param ObjectInterface $account The account to resolve service URLs for.
+     * @param IdInterface $account The account to resolve service URLs for.
      *
      * @return ResolveDomainResponse A response with the service URLs.
      */
-    public function resolve(ObjectInterface $account)
+    public function resolve(IdInterface $account)
     {
         $options = [
             'query' => [

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -4,6 +4,7 @@ namespace Lullabot\Mpx\Service\AccessManagement;
 
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\ObjectInterface;
 use Lullabot\Mpx\Normalizer\UriNormalizer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
@@ -40,11 +41,11 @@ class ResolveDomain
     /**
      * Resolve all URLs for an account.
      *
-     * @param Account $account The account to resolve service URLs for.
+     * @param ObjectInterface $account The account to resolve service URLs for.
      *
      * @return ResolveDomainResponse A response with the service URLs.
      */
-    public function resolve(Account $account)
+    public function resolve(ObjectInterface $account)
     {
         $options = [
             'query' => [

--- a/src/Token.php
+++ b/src/Token.php
@@ -160,6 +160,8 @@ class Token
     }
 
     /**
+     * Return the user ID associated with this token.
+     *
      * @return string
      */
     public function getUserId(): string

--- a/tests/fixtures/select-account.json
+++ b/tests/fixtures/select-account.json
@@ -1,0 +1,14 @@
+{
+  "totalResults" : 1,
+  "entries" : [
+    {
+      "ownerId" : "urn:theplatform:auth:root",
+      "title" : "customer root account",
+      "id" : "http://access.auth.theplatform.com/data/Account/55555"
+    }
+  ],
+  "startIndex" : 1,
+  "entryCount" : 1,
+  "itemsPerPage" : 1
+}
+

--- a/tests/src/Functional/DataService/Access/AccountQueryTest.php
+++ b/tests/src/Functional/DataService/Access/AccountQueryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\DataService\Account;
+
+use Lullabot\Mpx\DataService\ByFields;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\Range;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Tests loading Account objects.
+ */
+class AccountQueryTest extends FunctionalTestBase
+{
+    /**
+     * Test loading two Account objects.
+     */
+    public function testQueryAccount()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $dof = new DataObjectFactory($manager->getDataService('Access Data Service', 'Account', '1.0'), $this->authenticatedClient);
+        $filter = new ByFields();
+        $range = new Range();
+        $range->setStartIndex(1)
+            ->setEndIndex(2);
+        $filter->setRange($range);
+        $results = $dof->select($filter);
+
+        foreach ($results as $index => $result) {
+            $this->assertInstanceOf(UriInterface::class, $result->getId());
+
+            // Loading the object by itself.
+            $reload = $dof->load($result->getId());
+            $this->assertEquals($result, $reload->wait());
+            if ($index + 1 > 2) {
+                break;
+            }
+        }
+    }
+}

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx\Tests\Functional;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Concat\Http\Middleware\Logger;
 use GuzzleHttp\MessageFormatter;
+use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\Client;
 use Lullabot\Mpx\DataService\Access\Account;
@@ -51,9 +52,9 @@ abstract class FunctionalTestBase extends TestCase
 
         $username = getenv('MPX_USERNAME');
         $password = getenv('MPX_PASSWORD');
-        $account = getenv('MPX_ACCOUNT');
+        $account_id = getenv('MPX_ACCOUNT');
 
-        if (empty($username) || empty($password) || empty($account)) {
+        if (empty($username) || empty($password) || empty($account_id)) {
             $this->markTestSkipped(
                 'MPX_USER, MPX_PASSWORD, and MPX_ACCOUNT must be defined as environment variables or in phpunit.xml for functional tests.'
             );
@@ -90,6 +91,6 @@ abstract class FunctionalTestBase extends TestCase
         );
 
         $this->account = new Account();
-        $this->account->setId($account);
+        $this->account->setId(new Uri($account_id));
     }
 }

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -191,28 +191,6 @@ class AuthenticatedClientTest extends TestCase
     }
 
     /**
-     * @covers ::getAccount()
-     */
-    public function testGetAccount()
-    {
-        $client = $this->getMockClient([
-            new JsonResponse(200, [], 'signin-success.json'),
-        ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
-            ->getMock();
-        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-
-        $logger = $this->fetchTokenLogger(1);
-
-        $user = new User('USER-NAME', 'correct-password');
-        $userSession = new UserSession($user, $client, $store, $tokenCachePool);
-        $userSession->setLogger($logger);
-        $authenticatedClient = new AuthenticatedClient($client, $userSession);
-        $this->assertEquals('https://identity.auth.theplatform.com/idm/data/User/mpx/1', $authenticatedClient->getAccount()->getId()->__toString());
-    }
-
-    /**
      * @covers ::getConfig()
      */
     public function testGetConfig()

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -5,9 +5,11 @@ namespace Lullabot\Mpx\Tests\Unit\DataService;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\ByFields;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
 use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\ObjectList;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Lullabot\Mpx\Tests\JsonResponse;
@@ -55,5 +57,36 @@ class DataObjectFactoryTest extends TestCase
         $account->setId(new \GuzzleHttp\Psr7\Uri('http://example.com/1'));
         $media = $factory->loadByNumericId(12345, $account)->wait();
         $this->assertInstanceOf(Media::class, $media);
+    }
+
+    /**
+     * Tests fetching a list of objects.
+     *
+     * @covers ::selectRequest()
+     */
+    public function testSelectRequest()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Access Data Service', 'Account', '1.0');
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'select-account.json'),
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $session = new UserSession($user, $client, $store, $tokenCachePool);
+        $authenticatedClient = new AuthenticatedClient($client, $session);
+        $factory = new DataObjectFactory($service, $authenticatedClient);
+        /** @var ObjectList $objectList */
+        $objectList = $factory->selectRequest(new ByFields())->wait();
+        $this->assertEquals(1, $objectList->getEntryCount());
+        $this->assertEquals(1, $objectList->getItemsPerPage());
+        $this->assertEquals(1, $objectList->getStartIndex());
+        $this->assertEquals(1, $objectList->getTotalResults());
+        $account = $objectList->current();
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals('http://access.auth.theplatform.com/data/Account/55555', $account->getId());
     }
 }


### PR DESCRIPTION
This fixes #93 .

While an account context is required for almost all data service requests, it is not required for Account requests (since you may not know the account to use until you fetch accounts). There was a mixup in the `getAccount` method where it actually used a User ID, and not an Account ID.

This PR removes that, and makes account contexts optional, with a bit of documentation that they are almost always required.