### PR TITLE
Limit queries to 100 items by default

### DIFF
--- a/src/DataService/ByFields.php
+++ b/src/DataService/ByFields.php
@@ -9,6 +9,10 @@ namespace Lullabot\Mpx\DataService;
  * specified. Since sorting may be inconsistent across pages, this class will
  * automatically sort by 'id' if no sort is specified.
  *
+ * By default, pages are set to 100 items per page. This matches well with
+ * memory consumption (where PHP leaks memory at the default 500 items mpx
+ * returns) and CPU use.
+ *
  * @see https://docs.theplatform.com/help/wsf-selecting-objects-by-using-a-byfield-query-parameter
  */
 class ByFields
@@ -42,6 +46,8 @@ class ByFields
         $this->sort = new Sort();
         $this->sort->addSort('id');
         $this->range = new Range();
+        $this->range->setStartIndex(1);
+        $this->range->setEndIndex(101);
     }
 
     /**

--- a/src/DataService/ByFields.php
+++ b/src/DataService/ByFields.php
@@ -47,7 +47,7 @@ class ByFields
         $this->sort->addSort('id');
         $this->range = new Range();
         $this->range->setStartIndex(1);
-        $this->range->setEndIndex(101);
+        $this->range->setEndIndex(100);
     }
 
     /**

--- a/src/DataService/Range.php
+++ b/src/DataService/Range.php
@@ -87,6 +87,15 @@ class Range
             return [];
         }
 
+        // @todo PHP appears to leak memory in both json_decode() and unserialize() with large result sets. Our best
+        // guess is that some amount of data causes PHP to allocate larger chunks, and perhaps that class of memory
+        // isn't ever a candidate for garbage collection. In general, paging over result sets (like in
+        // \Lullabot\Mpx\Tests\Functional\DataService\Media\MediaQueryTest) should use a constant amount of memory per
+        // page. 250 comes from tests on macOS with PHP 7.2 - going to 300 results causes an obvious memory leak.
+        if ($this->endIndex - $this->startIndex > 250) {
+            @trigger_error('PHP may leak memory with large result pages. Consider reducing the number of results per page.', E_USER_DEPRECATED);
+        }
+
         return ['range' => $this->startIndex.'-'.$this->endIndex];
     }
 }

--- a/tests/src/Unit/DataService/ByFieldsTest.php
+++ b/tests/src/Unit/DataService/ByFieldsTest.php
@@ -56,6 +56,6 @@ class ByFieldsTest extends TestCase
     public function testNoValues()
     {
         $byFields = new ByFields();
-        $this->assertEquals(['sort' => 'id'], $byFields->toQueryParts());
+        $this->assertEquals(['sort' => 'id', 'range' => '1-101'], $byFields->toQueryParts());
     }
 }

--- a/tests/src/Unit/DataService/ByFieldsTest.php
+++ b/tests/src/Unit/DataService/ByFieldsTest.php
@@ -56,6 +56,6 @@ class ByFieldsTest extends TestCase
     public function testNoValues()
     {
         $byFields = new ByFields();
-        $this->assertEquals(['sort' => 'id', 'range' => '1-101'], $byFields->toQueryParts());
+        $this->assertEquals(['sort' => 'id', 'range' => '1-100'], $byFields->toQueryParts());
     }
 }

--- a/tests/src/Unit/TokenCachePoolTest.php
+++ b/tests/src/Unit/TokenCachePoolTest.php
@@ -40,8 +40,10 @@ class TokenCachePoolTest extends TestCase
     /**
      * Test getting and setting the token from the cache.
      *
+     * @covers ::__construct()
      * @covers ::setToken
      * @covers ::getToken
+     * @covers ::cacheKey()
      */
     public function testGetSetToken()
     {
@@ -71,6 +73,7 @@ class TokenCachePoolTest extends TestCase
      *
      * @covers ::deleteToken
      * @covers ::getToken
+     * @covers ::cacheKey()
      */
     public function testDeleteToken()
     {


### PR DESCRIPTION
As I was testing importing media objects with the Drupal library, I kept seeing memory leaks. Each result page that was loaded would take an additional 30-40MB of memory, across multiple PHP versions and operating systems. Both xhprof and Blackfire showed the memory use as being within PHP's own C code in `json_decode()`. Thinking it was still in our code somehow, I reduced the result set to try and create more objects and run loops more often, hoping to make the leak worse and easier to fix.

However, I found that once I got below a certain amount, PHP's memory use would stabilize instead of growing. For example, at 100 items per page, PHP would only use ~60MB of memory, and happily stay there.

I need to dig in more, probably starting with [the Zend Memory Manager](http://www.phpinternalsbook.com/php7/memory_management/zend_memory_manager.html), but I figured I'd get a PR up that's good enough for our purposes.

Some quick testing doesn't show any real performance hit by using smaller result sets (and makes things less bursty too).