### PR TITLE
Detect notification exceptions

### DIFF
--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -30,7 +30,44 @@ class MpxExceptionFactory
         MpxExceptionTrait::validateData($data);
 
         $altered = $response->withStatus($data['responseCode'], $data['title']);
+        return self::createException($request, $altered, $previous, $ctx);
+    }
 
+    /**
+     * Create a new MPX API exception from a notification.
+     *
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
+     * @param \Exception|null   $previous
+     * @param array             $ctx
+     *
+     * @return ClientException|ServerException
+     */
+    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = [])
+    {
+        $data = \GuzzleHttp\json_decode($response->getBody(), true);
+        MpxExceptionTrait::validateNotificationData($data);
+
+        $altered = $response->withStatus($data[0]['entry']['responseCode'], $data[0]['entry']['title']);
+        return self::createException($request, $altered, $previous, $ctx);
+    }
+
+    /**
+     * Create a client or server exception.
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $altered
+     *
+     * @param \Exception $previous
+     * @param array $ctx
+     *
+     * @return ClientException|ServerException
+     */
+    private static function createException(RequestInterface $request,
+        ResponseInterface $altered,
+        \Exception $previous = null,
+        array $ctx = []
+    ) {
         if ($altered->getStatusCode() >= 400 && $altered->getStatusCode() < 500) {
             return new ClientException($request, $altered, $previous, $ctx);
         }

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -30,6 +30,7 @@ class MpxExceptionFactory
         MpxExceptionTrait::validateData($data);
 
         $altered = $response->withStatus($data['responseCode'], $data['title']);
+
         return self::createException($request, $altered, $previous, $ctx);
     }
 
@@ -49,17 +50,17 @@ class MpxExceptionFactory
         MpxExceptionTrait::validateNotificationData($data);
 
         $altered = $response->withStatus($data[0]['entry']['responseCode'], $data[0]['entry']['title']);
+
         return self::createException($request, $altered, $previous, $ctx);
     }
 
     /**
      * Create a client or server exception.
      *
-     * @param RequestInterface $request
+     * @param RequestInterface  $request
      * @param ResponseInterface $altered
-     *
-     * @param \Exception $previous
-     * @param array $ctx
+     * @param \Exception        $previous
+     * @param array             $ctx
      *
      * @return ClientException|ServerException
      */

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -40,6 +40,12 @@ class Middleware
                         }
 
                         $data = \GuzzleHttp\json_decode($response->getBody(), true);
+
+                        // Notification responses have a different exception format.
+                        if (isset($data[0]) && isset($data[0]['type']) && $data[0]['type'] == 'Exception') {
+                            throw MpxExceptionFactory::createFromNotificationException($request, $response);
+                        }
+
                         if (empty($data['responseCode']) && empty($data['isException'])) {
                             return $response;
                         }

--- a/tests/src/Unit/Exception/MpxExceptionFactoryTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionFactoryTest.php
@@ -79,8 +79,8 @@ class MpxExceptionFactoryTest extends TestCase
                     'isException' => true,
                     'title' => 'Internal error',
                     'description' => 'It is totally the worst',
-                ]
-            ]
+                ],
+            ],
         ];
         $response = new Response(200, [], json_encode($data));
 

--- a/tests/src/Unit/Exception/MpxExceptionFactoryTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionFactoryTest.php
@@ -16,6 +16,7 @@ class MpxExceptionFactoryTest extends TestCase
 {
     /**
      * @covers ::create
+     * @covers ::createException()
      */
     public function testCreateClientException()
     {
@@ -38,6 +39,7 @@ class MpxExceptionFactoryTest extends TestCase
 
     /**
      * @covers ::create
+     * @covers ::createException()
      */
     public function testCreateServerException()
     {
@@ -56,5 +58,35 @@ class MpxExceptionFactoryTest extends TestCase
         $this->assertInstanceOf(ServerException::class, $exception);
         $this->assertEquals($data['responseCode'], $exception->getResponse()->getStatusCode());
         $this->assertEquals($data['title'], $exception->getResponse()->getReasonPhrase());
+    }
+
+    /**
+     * Test creating an exception from a notification error.
+     *
+     * @covers ::createFromNotificationException()
+     * @covers ::createException()
+     */
+    public function testCreateFromNotificationException()
+    {
+        /** @var \Psr\Http\Message\RequestInterface $request */
+        $request = $this->getMockBuilder(RequestInterface::class)
+            ->getMock();
+        $data = [
+            [
+                'type' => 'Exception',
+                'entry' => [
+                    'responseCode' => 503,
+                    'isException' => true,
+                    'title' => 'Internal error',
+                    'description' => 'It is totally the worst',
+                ]
+            ]
+        ];
+        $response = new Response(200, [], json_encode($data));
+
+        $exception = MpxExceptionFactory::createFromNotificationException($request, $response);
+        $this->assertInstanceOf(ServerException::class, $exception);
+        $this->assertEquals($data[0]['entry']['responseCode'], $exception->getResponse()->getStatusCode());
+        $this->assertEquals($data[0]['entry']['title'], $exception->getResponse()->getReasonPhrase());
     }
 }

--- a/tests/src/Unit/Exception/MpxExceptionTraitTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionTraitTest.php
@@ -124,8 +124,8 @@ class MpxExceptionTraitTest extends TestCase
                     'description' => 'Authentication credentials invalid',
                     'correlationId' => 'correlation-id',
                     'serverStackTrace' => 'stack-trace',
-                ]
-            ]
+                ],
+            ],
         ];
         $trait->setNotificationData($data);
         $this->assertEquals($data[0]['entry']['title'], $trait->getTitle());

--- a/tests/src/Unit/MiddlewareTest.php
+++ b/tests/src/Unit/MiddlewareTest.php
@@ -74,6 +74,33 @@ class MiddlewareTest extends TestCase
     }
 
     /**
+     * Tests throwing mpx notification errors.
+     *
+     * @covers ::mpxErrors()
+     */
+    public function testNotificationException()
+    {
+        /** @var \Psr\Http\Message\RequestInterface $request */
+        $request = $this->getMockBuilder(RequestInterface::class)
+            ->getMock();
+        $body = json_encode([
+            [
+                'type' => 'Exception',
+                'entry' => [
+                    'isException' => true,
+                    'responseCode' => 404,
+                    'title' => 'ObjectNotFoundException',
+                    'description' => 'Sequence 1234 is no longer available',
+                ],
+            ],
+        ]);
+        $response = new Response(200, ['Content-Type' => 'application/json'], $body);
+        $this->expectException(MpxExceptionInterface::class);
+        $this->expectExceptionMessage('Sequence 1234 is no longer available');
+        $this->getResponse($request, $response, Middleware::mpxErrors());
+    }
+
+    /**
      * Get the response from the MPX error handler.
      *
      * @param \Psr\Http\Message\RequestInterface  $request


### PR DESCRIPTION
If an error occurs while listening for notifications, mpx returns the data in a different format compared to other API calls. This PR adds support for those errors.