### PR TITLE
Add a method to yield pages in lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a method to yield pages in lists #107
+
 ### Changed
 
 ### Removed

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -186,7 +186,7 @@ class DataObjectFactory
             ],
         ];
 
-        $uri = $this->getBaseUri($annotation, $account);
+        $uri = $this->getBaseUri($annotation, $account, true);
 
         $request = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
             function (ResponseInterface $response) use ($byFields, $account) {

--- a/src/DataService/Range.php
+++ b/src/DataService/Range.php
@@ -77,6 +77,33 @@ class Range
     }
 
     /**
+     * Given an object list, return the ranges for each subsequent page.
+     *
+     * @param ObjectList $list The list to generate ranges for.
+     *
+     * @return static[] An array of Range objects.
+     */
+    public static function nextRanges(ObjectList $list): array
+    {
+        $ranges = [];
+        $startIndex = $list->getStartIndex() + $list->getEntryCount();
+        $endIndex = $startIndex + $list->getItemsPerPage() - 1;
+        $finalIndex = $startIndex + $list->getTotalResults() - 1;
+
+        while ($startIndex <= $finalIndex) {
+            $range = new self();
+            $range->setStartIndex($startIndex)
+                ->setEndIndex($endIndex);
+
+            $startIndex = $startIndex + $list->getEntryCount();
+            $endIndex = min($startIndex - 1 + $list->getItemsPerPage(), $finalIndex);
+            $ranges[] = $range;
+        }
+
+        return $ranges;
+    }
+
+    /**
      * Return an array of query parameters representing this range.
      *
      * @return array An array with a 'range' key, or an empty array if neither start or end is set.

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -77,4 +77,30 @@ class RangeTest extends TestCase
         $this->expectExceptionMessage('The end index must be 1 or greater.');
         $range->setEndIndex(0);
     }
+
+    /**
+     * Tests generating all ranges in the result set.
+     *
+     * @covers ::nextRanges()
+     */
+    public function testNextRanges()
+    {
+        $list = new ObjectList();
+        $start = rand(1, getrandmax());
+        $entryCount = rand(1, 10);
+        $list->setStartIndex($start);
+        $list->setEntryCount($entryCount);
+        $list->setItemsPerPage($entryCount);
+        $pages = rand(1, 10);
+        $list->setTotalResults($entryCount * $pages);
+        $ranges = Range::nextRanges($list);
+
+        $this->assertEquals($pages, count($ranges));
+
+        foreach ($ranges as $range) {
+            $start += $entryCount;
+            $end = $start + $entryCount - 1;
+            $this->assertEquals("$start-$end", $range->toQueryParts()['range']);
+        }
+    }
 }


### PR DESCRIPTION
We would like to support concurrent requests as there's some clear performance benefits in importing mpx data.

Initially, I thought we could build an array of promises to `ObjectLists`, and pass them to `each_limit`:

```
<?php
    each_limit($promises_to_lists, 10, function(ObjectList $list) use ($media_type, $importer) {
      foreach ($list as $item) {
        ...
      }
    })->wait();
```

However, this was causing my initial tests to hang. After debugging, I discovered that Guzzle's curl handler doesn't actually respect the limit passed in to each_limit. Instead, all (in this case, 700+) requests are opened, and they are all attempted in parallel. That's because each call to generate a Request object automatically adds it to the list of curl handles to be executed.

In other words, for the first time I found a real-world case to use generators and the `yield` keyword.

With `yield`, each_limit ensures that there are only 10 outstanding promises total, and additional promises are generated as needed. This also helps a bit with memory use too.