### PR TITLE
Fix nextlist returning true for single-item lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Fix nextlist returning true for single-item lists #108
+
 ### Removed
 
 ## [0.1.0] - 2018-05-04

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -220,7 +220,7 @@ class ObjectList implements \ArrayAccess, \Iterator
      */
     public function hasNext(): bool
     {
-        return !empty($this->entries) && ($this->getEntryCount() >= $this->getItemsPerPage());
+        return !empty($this->entries) && ($this->getStartIndex() + $this->getItemsPerPage() - 1 < $this->getEntryCount());
     }
 
     /**

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -78,7 +78,8 @@ class ObjectListTest extends TestCase
     public function testHasNext()
     {
         $this->list->setEntries([new \stdClass()]);
-        $this->list->setEntryCount(10);
+        $this->list->setStartIndex(1);
+        $this->list->setEntryCount(11);
         $this->list->setItemsPerPage(10);
         $this->assertTrue($this->list->hasNext());
 
@@ -99,7 +100,7 @@ class ObjectListTest extends TestCase
 
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(10);
+        $this->list->setEntryCount(50);
         $this->list->setItemsPerPage(10);
 
         /** @var DataObjectFactory $dof */
@@ -118,7 +119,7 @@ class ObjectListTest extends TestCase
     {
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(10);
+        $this->list->setEntryCount(40);
         $this->list->setItemsPerPage(10);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('setDataObjectFactory must be called before calling nextList.');
@@ -132,7 +133,7 @@ class ObjectListTest extends TestCase
     {
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(10);
+        $this->list->setEntryCount(60);
         $this->list->setItemsPerPage(10);
 
         /** @var DataObjectFactory $dof */

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -113,6 +113,24 @@ class ObjectListTest extends TestCase
     }
 
     /**
+     * Test that a single item list has no next list.
+     */
+    public function testSingleItemList()
+    {
+        $this->list->setEntries([new \stdClass()]);
+        $this->list->setStartIndex(1);
+        $this->list->setEntryCount(1);
+        $this->list->setItemsPerPage(1);
+
+        /** @var DataObjectFactory $dof */
+        $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
+        $account = new Account();
+        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setByFields(new ByFields());
+        $this->assertFalse($this->list->nextList());
+    }
+
+    /**
      * Test that an exception is thrown if a DataObjectFactory is not set.
      */
     public function testNextListNoDof()


### PR DESCRIPTION
https://github.com/Lullabot/mpx-php/pull/108/commits/c5a65033971e0c76f2e480dba17b17bb0532afec is the test case that currently fails on master, and is fixed by this PR.