### PR TITLE
Fix broken range calculations for the end of a list of ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Fix nextlist returning true for single-item lists #108
+- Fix nextList returning true for single-item lists #108
+- Fix broken range calculations for the end of a list of ranges #113
 
 ### Removed
 

--- a/src/DataService/Range.php
+++ b/src/DataService/Range.php
@@ -87,7 +87,7 @@ class Range
     {
         $ranges = [];
 
-        // The end index of the next list.
+        // The end index of the next list. We do this here in case there are no further ranges to return.
         $endIndex = $list->getStartIndex() + $list->getItemsPerPage() - 1;
 
         // The last index of the final list.
@@ -96,6 +96,8 @@ class Range
         while ($endIndex < $finalEndIndex) {
             // The start index of the next list.
             $startIndex = ($startIndex ?? $list->getStartIndex()) + $list->getEntryCount();
+
+            // We need to be sure we never return an end range greater than the total count of objects.
             $endIndex = min($startIndex + $list->getItemsPerPage() - 1, $finalEndIndex);
 
             $range = new self();

--- a/src/DataService/Range.php
+++ b/src/DataService/Range.php
@@ -86,17 +86,21 @@ class Range
     public static function nextRanges(ObjectList $list): array
     {
         $ranges = [];
-        $startIndex = $list->getStartIndex() + $list->getEntryCount();
-        $endIndex = $startIndex + $list->getItemsPerPage() - 1;
-        $finalIndex = $startIndex + $list->getTotalResults() - 1;
 
-        while ($startIndex <= $finalIndex) {
+        // The end index of the next list.
+        $endIndex = $list->getStartIndex() + $list->getItemsPerPage() - 1;
+
+        // The last index of the final list.
+        $finalEndIndex = $list->getTotalResults();
+
+        while ($endIndex < $finalEndIndex) {
+            // The start index of the next list.
+            $startIndex = ($startIndex ?? $list->getStartIndex()) + $list->getEntryCount();
+            $endIndex = min($startIndex + $list->getItemsPerPage() - 1, $finalEndIndex);
+
             $range = new self();
             $range->setStartIndex($startIndex)
                 ->setEndIndex($endIndex);
-
-            $startIndex = $startIndex + $list->getEntryCount();
-            $endIndex = min($startIndex - 1 + $list->getItemsPerPage(), $finalIndex);
             $ranges[] = $range;
         }
 

--- a/tests/src/Functional/DataService/Media/MediaQueryTest.php
+++ b/tests/src/Functional/DataService/Media/MediaQueryTest.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx\Tests\Functional\DataService\Media;
 use Lullabot\Mpx\DataService\ByFields;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\ObjectList;
 use Lullabot\Mpx\DataService\Range;
 use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
 use Psr\Http\Message\UriInterface;
@@ -37,6 +38,39 @@ class MediaQueryTest extends FunctionalTestBase
             if ($index + 1 > 2) {
                 break;
             }
+        }
+    }
+
+    /**
+     * Loads the most recently uploaded media items.
+     *
+     * The fastest way to do this is to add a sort on the initial query.
+     * However, a bug was found in our range calculation when test code worked
+     * this way, which while not optimal should still work.
+     */
+    public function testLoadRecentContent()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $dof = new DataObjectFactory($manager->getDataService('Media Data Service', 'Media', '1.10'), $this->authenticatedClient);
+        $filter = new ByFields();
+        $range = new Range();
+        $range->setStartIndex(1)
+            ->setEndIndex(2);
+        $filter->setRange($range);
+        /** @var ObjectList $list */
+        $list = $dof->selectRequest($filter, $this->account)->wait();
+
+        // Determine the end of the list of ranges.
+        $ranges = Range::nextRanges($list);
+        $filter->setRange(end($ranges));
+        $results = $dof->select($filter, $this->account);
+
+        foreach ($results as $index => $result) {
+            $this->assertInstanceOf(UriInterface::class, $result->getId());
+
+            // Loading the object by itself.
+            $reload = $dof->load($result->getId());
+            $this->assertEquals($result, $reload->wait());
         }
     }
 }

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -91,15 +91,15 @@ class RangeTest extends TestCase
         $list->setStartIndex($start);
         $list->setEntryCount($entryCount);
         $list->setItemsPerPage($entryCount);
-        $pages = rand(1, 10);
-        $list->setTotalResults($entryCount * $pages);
+        $remainingPages = rand(1, 10);
+        $list->setTotalResults($start + ($entryCount * $remainingPages));
         $ranges = Range::nextRanges($list);
 
-        $this->assertEquals($pages, count($ranges));
+        $this->assertEquals($remainingPages, count($ranges));
 
         foreach ($ranges as $range) {
             $start += $entryCount;
-            $end = $start + $entryCount - 1;
+            $end = min($start + $entryCount - 1, $list->getTotalResults());
             $this->assertEquals("$start-$end", $range->toQueryParts()['range']);
         }
     }

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -103,4 +103,38 @@ class RangeTest extends TestCase
             $this->assertEquals("$start-$end", $range->toQueryParts()['range']);
         }
     }
+
+    /**
+     * Tests that we return the right number of ranges when the last range is not a complete page.
+     *
+     * @covers ::nextRanges()
+     */
+    public function testPartialEndRange()
+    {
+        $list = new ObjectList();
+        $list->setStartIndex(1);
+        $list->setItemsPerpage(2);
+        $list->setEntryCount(2);
+        $list->setTotalResults(79425);
+        $ranges = Range::nextRanges($list);
+        $this->assertCount(39712, $ranges);
+        $this->assertEquals("3-4", reset($ranges)->toQueryParts()['range']);
+        $this->assertEquals("79425-79425", end($ranges)->toQueryParts()['range']);
+    }
+
+    /**
+     * Test that no ranges are returned if we are already on the last page.
+     *
+     * @covers ::nextRanges()
+     */
+    public function testNextOnLastRange()
+    {
+        $list = new ObjectList();
+        $list->setStartIndex(11);
+        $list->setItemsPerPage(10);
+        $list->setEntryCount(10);
+        $list->setTotalResults(20);
+        $ranges = Range::nextRanges($list);
+        $this->assertCount(0, $ranges);
+    }
 }

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -118,8 +118,8 @@ class RangeTest extends TestCase
         $list->setTotalResults(79425);
         $ranges = Range::nextRanges($list);
         $this->assertCount(39712, $ranges);
-        $this->assertEquals("3-4", reset($ranges)->toQueryParts()['range']);
-        $this->assertEquals("79425-79425", end($ranges)->toQueryParts()['range']);
+        $this->assertEquals('3-4', reset($ranges)->toQueryParts()['range']);
+        $this->assertEquals('79425-79425', end($ranges)->toQueryParts()['range']);
     }
 
     /**


### PR DESCRIPTION
I discovered this when loading some real content from mpx. The test at `testPartialEndRange()` currently fails on master, where too many ranges are returned and their indexes are beyond the end of the list. I also added a functional test showing what I was doing that triggered the bug (though it's dependent on the data in the mpx account you're testing with).