### PR TITLE
Fix using the number of entries in the current page instead of the total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix broken range calculations for the end of a list of ranges #113
 - `\Lullabot\Mpx\Service\IdentityManagement\UserInterface` has been added to
   simplify bridging user configuration from applications. #116
+- Fix using the number of entries in the current page instead of the total #118
 
 ### Removed
 

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -137,6 +137,8 @@ class ObjectList implements \ArrayAccess, \Iterator
     }
 
     /**
+     * Set the number of entries in the current list.
+     *
      * @param int $entryCount
      */
     public function setEntryCount(int $entryCount)
@@ -220,7 +222,7 @@ class ObjectList implements \ArrayAccess, \Iterator
      */
     public function hasNext(): bool
     {
-        return !empty($this->entries) && ($this->getStartIndex() + $this->getItemsPerPage() - 1 < $this->getEntryCount());
+        return !empty($this->entries) && ($this->getStartIndex() + $this->getItemsPerPage() - 1 < $this->getTotalResults());
     }
 
     /**

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -79,14 +79,15 @@ class ObjectListTest extends TestCase
     {
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(1);
-        $this->list->setEntryCount(11);
+        $this->list->setEntryCount(10);
         $this->list->setItemsPerPage(10);
+        $this->list->setTotalResults(20);
         $this->assertTrue($this->list->hasNext());
 
-        $this->list->setItemsPerPage(11);
+        $this->list->setTotalResults(10);
         $this->assertFalse($this->list->hasNext());
 
-        $this->list->setItemsPerPage(10);
+        $this->list->setTotalResults(11);
         $this->list->setEntries([]);
         $this->assertFalse($this->list->hasNext());
     }
@@ -100,8 +101,9 @@ class ObjectListTest extends TestCase
 
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(50);
+        $this->list->setEntryCount(10);
         $this->list->setItemsPerPage(10);
+        $this->list->setTotalResults(50);
 
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
@@ -137,8 +139,9 @@ class ObjectListTest extends TestCase
     {
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(40);
+        $this->list->setEntryCount(10);
         $this->list->setItemsPerPage(10);
+        $this->list->setTotalResults(50);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('setDataObjectFactory must be called before calling nextList.');
         $this->list->nextList();
@@ -151,8 +154,9 @@ class ObjectListTest extends TestCase
     {
         $this->list->setEntries([new \stdClass()]);
         $this->list->setStartIndex(30);
-        $this->list->setEntryCount(60);
+        $this->list->setEntryCount(10);
         $this->list->setItemsPerPage(10);
+        $this->list->setTotalResults(50);
 
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
`\Lullabot\Mpx\DataService\ObjectList::hasNext()` was mistakenly using the number of entries in the current page to determine if a next page existed. It should have been using the total number of results across all pages. Prior to #108 this worked as we checked if the entry count was less than the items specified per page, but left us open to the bug we fixed there.

I've added docs to clarify that entry count is only for the current page.