### PR TITLE
Support generating custom field classes

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Lullabot\Mpx\Command\CreateCustomFieldClassCommand;
 use Lullabot\Mpx\Command\CreateDataServiceClassCommand;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -9,6 +10,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 $application = new Symfony\Component\Console\Application;
 
 $application->add(new CreateDataServiceClassCommand());
+$application->add(new CreateCustomFieldClassCommand());
 
 // Run it
 $application->run();

--- a/command/csv/field-object.csv
+++ b/command/csv/field-object.csv
@@ -1,0 +1,27 @@
+FIELD NAME,ATTRIBUTES,DATA TYPE,DESCRIPTION
+added,,DateTime,"The date and time that this object was created
+ This field is queryable on the following endpoints only:AssetType/Field Category/Field Media/Field MediaFile/Field Release/Field Server/Field"
+addedByUserId,,URI,The id of the user that created this object
+allowedValues,,dataType[],The allowed values for this custom field
+dataStructure,,DataStructure,The data structure of this custom field
+dataType,,DataType,The data type of this custom field
+defaultValue,,dataType,The default value for this custom field
+description,,String,The description of this object
+fieldName,,String,The node name for this custom field in XML and JSON
+guid,,String,An alternate identifier for this object that is unique within the owning account
+id,,URI,The globally unique URI of this object
+includeInTextSearch,,Boolean,Whether this custom field is indexed for search
+isUnique,,Boolean,Whether this custom field stores unique values and functions as a create key
+length,,Integer,The maximum string length or the number of decimal positions allowed in this custom field's value
+locked,,Boolean,Whether this object currently allows updates
+namespace,,String,The namespace this custom field belongs to
+namespacePrefix,,String,An XML namespace prefix for this field
+notifyAlways,,Boolean,Whether this custom field is always available in change notifications
+notifyChanges,,Boolean,Whether this custom field is available on change in update notifications
+notifyDelete,,Boolean,Whether this custom field is available in delete notifications
+ownerId,,URI,The id of the account that owns this object
+searchFieldName,,String,The name that this custom field is indexed under
+title,,String,The name of this object
+updated,,DateTime,The date and time this object was last modified
+updatedByUserId,,URI,The id of the user that last modified this object
+version,,Long,"This object's modification version, used for optimistic locking"

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Lullabot\Mpx\Command;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Lullabot\Mpx\AuthenticatedClient;
+use Lullabot\Mpx\Client;
+use Lullabot\Mpx\DataService\ByFields;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\Field;
+use Lullabot\Mpx\Service\IdentityManagement\User;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\TokenCachePool;
+use Nette\PhpGenerator\PhpNamespace;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Lock\Store\FlockStore;
+
+/**
+ * Command to generate classes for custom mpx fields.
+ */
+class CreateCustomFieldClassCommand extends Command {
+
+    /**
+     * Maps custom mpx field types to PHP datatypes.
+     */
+    CONST TYPE_MAP = [
+        'Boolean' => 'bool',
+        'Date' => '\\' . \DateTime::class,
+        'DateTime' => '\\' . \DateTime::class,
+        'Duration' => 'int',
+        'Decimal' => 'float',
+        'Image' => '\\' . UriInterface::class,
+        'Integer' => 'int',
+        'Link' => '\\' . UriInterface::class,
+        'String' => 'string',
+        'Time' => '\\' . \DateTime::class,
+        'URI' => '\\' . UriInterface::class,
+    ];
+
+    protected function configure() {
+        $help = <<<EOD
+This command generates a PHP class for a custom field implementation.
+
+A mpx username and password is required. They will be requested interactively,
+or MPX_USERNAME and MPX_PASSWORD environment variables will be used.
+
+As mpx provides no way to infer a reasonable class name, each class is named
+sequentially with the expectation that it will be renamed later. One file will
+be generated for each namespace of custom fields that is detected. Files will
+be written to the current working directory.
+EOD;
+        $this->setName('mpx:create-custom-field')
+            ->setDescription('This command helps to create a custom field class.')
+            ->setHelp($help)
+            ->addUsage("mpx:create-custom-field 'Lullabot\\Mpx\\CustomField' 'Media Data Service' 'Media' '1.10'")
+            ->addArgument('namespace', InputArgument::REQUIRED, 'The fully-qualified class name to generate. Do not include the leading slash, and wrap the class name in single-quotes to handle shell escaping.')
+            ->addArgument('data-service', InputArgument::REQUIRED, "The data service to generate the class for, such as 'Media Data Service'.")
+            ->addArgument('data-object', InputArgument::REQUIRED, "The object to generate the class for, such as 'Media'")
+            ->addArgument('schema', InputArgument::REQUIRED, "The schema version of the object, such as '1.10'");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        $helper = $this->getHelper('question');
+        if (!$username = getenv('MPX_USERNAME')) {
+            $question = new Question('Enter the mpx user name, such as mpx/you@example.com: ');
+            $username = $helper->ask($input, $output, $question);
+        }
+        if (!$password = getenv('MPX_PASSWORD')) {
+            $question = new Question('Enter the mpx password: ');
+            $question->setHidden(true)
+                ->setHiddenFallback(false);
+            $password = $helper->ask($input, $output, $question);
+        }
+
+        $config = Client::getDefaultConfiguration();
+        $client = new Client(new \GuzzleHttp\Client($config));
+        $store = new FlockStore();
+        $user = new User($username, $password);
+        $userSession = new UserSession($user, $client, $store, new TokenCachePool(new ArrayCachePool()));
+        $authenticatedClient = new AuthenticatedClient(
+            $client,
+            $userSession
+        );
+        $manager = DataServiceManager::basicDiscovery();
+        $mediaDataService = $manager->getDataService($input->getArgument('data-service'), $input->getArgument('data-object'), $input->getArgument('schema'));
+        $dof = new DataObjectFactory($mediaDataService->getAnnotation()->getFieldDataService(), $authenticatedClient);
+        $filter = new ByFields();
+        /** @var Field[] $results */
+        $results = $dof->select($filter);
+
+        $namespaceClasses = [];
+        $classNames = [];
+
+        $nf = new \NumberFormatter("en", \NumberFormatter::SPELLOUT);
+        foreach ($results as $field) {
+            $mpxNamespace = (string)$field->getNamespace();
+            if (!isset($namespaceClasses[$mpxNamespace])) {
+                $className = 'CustomFieldClass'.ucfirst(str_replace('-', '', $nf->format(count($namespaceClasses) + 1)));
+                $namespace = new PhpNamespace($input->getArgument('namespace'));
+                $class = $namespace->addClass($className);
+                $classNames[$mpxNamespace] = $className;
+                $namespaceClasses[$mpxNamespace] = $namespace;
+
+                $class->addComment('Custom fields for namespace at '.$mpxNamespace);
+            }
+            else {
+                $namespace = $namespaceClasses[$mpxNamespace];
+                $class = $namespace->getClasses()[$classNames[$mpxNamespace]];
+            }
+
+            $property = $class->addProperty($field->getFieldName());
+            $property->setVisibility('protected');
+            $property->setComment($field->getDescription());
+            $property->addComment('');
+            $dataType = static::TYPE_MAP[$field->getDataType()];
+            $property->addComment('@var '.$dataType);
+
+            $get = $class->addMethod('get' . ucfirst($property->getName()));
+            $get->setVisibility('public');
+            $get->addComment('Returns ' . lcfirst($field->getDescription()));
+            $get->addComment('');
+            $get->addComment('@return ' . $dataType);
+
+            // If the property is a typed array, PHP will only let us use
+            // array in the return typehint.
+            $substr = substr($dataType, -2);
+            switch ($substr) {
+                case '[]':
+                    $get->setReturnType('array');
+                    break;
+                default:
+                    $get->setReturnType($dataType);
+                    break;
+            }
+
+            $get->addBody('return $this->' . $field->getFieldName() . ';');
+
+            // Add a set method for the property.
+            $set = $class->addMethod('set' . ucfirst($property->getName()));
+            $set->setVisibility('public');
+            $set->addComment('Set ' . lcfirst($field->getDescription()));
+            $set->addComment('');
+            $set->addComment('@param ' . $field->getDataType());
+            $set->addParameter($field->getFieldName());
+            $set->addBody('$this->' . $field->getFieldName() . ' = ' . '$' . $field->getFieldName() . ';');
+        }
+
+        foreach ($namespaceClasses as $namespaceClass) {
+            $array = $namespaceClass->getClasses();
+            $classType = reset($array);
+            $classFile = new StreamOutput(fopen($classType->getName().'.php', 'w'));
+            $classFile->write("<?php\n\n");
+            $classFile->write((string) $namespaceClass);
+            fclose($classFile->getStream());
+        }
+    }
+}

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -67,6 +67,10 @@ EOD;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) {
+        if (!extension_loaded('intl')) {
+            throw new \RuntimeException('The intl extension is required to run this command.');
+        }
+
         $helper = $this->getHelper('question');
         if (!$username = getenv('MPX_USERNAME')) {
             $question = new Question('Enter the mpx user name, such as mpx/you@example.com: ');

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -117,15 +117,19 @@ EOD;
 
             $property = $class->addProperty($field->getFieldName());
             $property->setVisibility('protected');
-            $property->setComment($field->getDescription());
-            $property->addComment('');
+            if (!empty($field->getDescription())) {
+                $property->setComment($field->getDescription());
+                $property->addComment('');
+            }
             $dataType = static::TYPE_MAP[$field->getDataType()];
             $property->addComment('@var '.$dataType);
 
             $get = $class->addMethod('get' . ucfirst($property->getName()));
             $get->setVisibility('public');
-            $get->addComment('Returns ' . lcfirst($field->getDescription()));
-            $get->addComment('');
+            if (!empty($field->getDescription())) {
+                $get->addComment('Returns ' . lcfirst($field->getDescription()));
+                $get->addComment('');
+            }
             $get->addComment('@return ' . $dataType);
 
             // If the property is a typed array, PHP will only let us use
@@ -145,8 +149,10 @@ EOD;
             // Add a set method for the property.
             $set = $class->addMethod('set' . ucfirst($property->getName()));
             $set->setVisibility('public');
-            $set->addComment('Set ' . lcfirst($field->getDescription()));
-            $set->addComment('');
+            if (!empty($field->getDescription())) {
+                $set->addComment('Set ' . lcfirst($field->getDescription()));
+                $set->addComment('');
+            }
             $set->addComment('@param ' . $field->getDataType());
             $set->addParameter($field->getFieldName());
             $set->addBody('$this->' . $field->getFieldName() . ' = ' . '$' . $field->getFieldName() . ';');

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -48,7 +48,7 @@ class CreateCustomFieldClassCommand extends Command {
         $help = <<<EOD
 This command generates a PHP class for a custom field implementation.
 
-A mpx username and password is required. They will be requested interactively,
+An mpx username and password is required. They will be requested interactively,
 or MPX_USERNAME and MPX_PASSWORD environment variables will be used.
 
 As mpx provides no way to infer a reasonable class name, each class is named

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "symfony/lock": "^3.4"
   },
   "require-dev": {
-    "ext-intl": "*",
     "phpunit/phpunit": "^6.5",
     "squizlabs/php_codesniffer": "^2.9",
     "friendsofphp/php-cs-fixer": "^2.10",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "symfony/lock": "^3.4"
   },
   "require-dev": {
+    "ext-intl": "*",
     "phpunit/phpunit": "^6.5",
     "squizlabs/php_codesniffer": "^2.9",
     "friendsofphp/php-cs-fixer": "^2.10",

--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -2,6 +2,9 @@
 
 namespace Lullabot\Mpx\DataService\Annotation;
 
+use Lullabot\Mpx\DataService\DiscoveredDataService;
+use Lullabot\Mpx\DataService\Field;
+
 /**
  * @Annotation
  *
@@ -104,5 +107,25 @@ class DataService
     public function getPath(): string
     {
         return '/data/'.$this->objectType;
+    }
+
+    /**
+     * Return a discovered data service for custom fields.
+     *
+     * Custom fields break the conventions set by all other data services in
+     * that they support CRUD operations, but have paths that are the child of
+     * another object type. As well, they have schemas, but thePlatform has no
+     * documentation of their history. To simplify the implementation, we do
+     * not support discoverable classes for field definitions.
+     *
+     * @return DiscoveredDataService A data service suitable for using with a DataObjectFactory.
+     */
+    public function getFieldDataService(): DiscoveredDataService
+    {
+        $service = clone $this;
+        $service->objectType .= '/Field';
+        $service->schemaVersion = '1.2';
+
+        return new DiscoveredDataService(Field::class, $service);
     }
 }

--- a/src/DataService/Field.php
+++ b/src/DataService/Field.php
@@ -1,0 +1,642 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Class representing custom mpx field definitions.
+ *
+ * @see https://docs.theplatform.com/help/wsf-field-object
+ */
+class Field extends ObjectBase
+{
+    /**
+     * The allowed values for this custom field.
+     *
+     * @var array
+     */
+    protected $allowedValues;
+
+    /**
+     * The data structure of this custom field.
+     *
+     * @var string
+     */
+    protected $dataStructure;
+
+    /**
+     * The data type of this custom field.
+     *
+     * @var string
+     */
+    protected $dataType;
+
+    /**
+     * The default value for this custom field.
+     *
+     * @var mixed
+     */
+    protected $defaultValue;
+
+    /**
+     * The description of this object.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * The node name for this custom field in XML and JSON.
+     *
+     * @var string
+     */
+    protected $fieldName;
+
+    /**
+     * An alternate identifier for this object that is unique within the owning account.
+     *
+     * @var string
+     */
+    protected $guid;
+
+    /**
+     * Whether this custom field is indexed for search.
+     *
+     * @var bool
+     */
+    protected $includeInTextSearch;
+
+    /**
+     * Whether this custom field stores unique values and functions as a create key.
+     *
+     * @var bool
+     */
+    protected $isUnique;
+
+    /**
+     * The maximum string length or the number of decimal positions allowed in this custom field's value.
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Whether this object currently allows updates.
+     *
+     * @var bool
+     */
+    protected $locked;
+
+    /**
+     * The namespace this custom field belongs to.
+     *
+     * @var UriInterface
+     */
+    protected $namespace;
+
+    /**
+     * An XML namespace prefix for this field.
+     *
+     * @var string
+     */
+    protected $namespacePrefix;
+
+    /**
+     * Whether this custom field is always available in change notifications.
+     *
+     * @var bool
+     */
+    protected $notifyAlways;
+
+    /**
+     * Whether this custom field is available on change in update notifications.
+     *
+     * @var bool
+     */
+    protected $notifyChanges;
+
+    /**
+     * Whether this custom field is available in delete notifications.
+     *
+     * @var bool
+     */
+    protected $notifyDelete;
+
+    /**
+     * The name that this custom field is indexed under.
+     *
+     * @var string
+     */
+    protected $searchFieldName;
+
+    /**
+     * The name of this object.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The date and time this object was last modified.
+     *
+     * @var \DateTime
+     */
+    protected $updated;
+
+    /**
+     * The id of the user that last modified this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $updatedByUserId;
+
+    /**
+     * This object's modification version, used for optimistic locking.
+     *
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * Returns the date and time that this object was created
+     *  This field is queryable on the following endpoints only:AssetType/Field Category/Field Media/Field MediaFile/Field Release/Field Server/Field.
+     *
+     * @return \DateTime
+     */
+    public function getAdded(): \DateTime
+    {
+        return $this->added;
+    }
+
+    /**
+     * Set the date and time that this object was created
+     *  This field is queryable on the following endpoints only:AssetType/Field Category/Field Media/Field MediaFile/Field Release/Field Server/Field.
+     *
+     * @param \DateTime
+     */
+    public function setAdded($added)
+    {
+        $this->added = $added;
+    }
+
+    /**
+     * Returns the id of the user that created this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAddedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->addedByUserId;
+    }
+
+    /**
+     * Set the id of the user that created this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setAddedByUserId($addedByUserId)
+    {
+        $this->addedByUserId = $addedByUserId;
+    }
+
+    /**
+     * Returns the allowed values for this custom field.
+     *
+     * @return array
+     */
+    public function getAllowedValues(): array
+    {
+        return $this->allowedValues;
+    }
+
+    /**
+     * Set the allowed values for this custom field.
+     *
+     * @param array
+     */
+    public function setAllowedValues($allowedValues)
+    {
+        $this->allowedValues = $allowedValues;
+    }
+
+    /**
+     * Returns the data structure of this custom field.
+     *
+     * @return string
+     */
+    public function getDataStructure(): string
+    {
+        return $this->dataStructure;
+    }
+
+    /**
+     * Set the data structure of this custom field.
+     *
+     * @param string
+     */
+    public function setDataStructure($dataStructure)
+    {
+        $this->dataStructure = $dataStructure;
+    }
+
+    /**
+     * Returns the data type of this custom field.
+     *
+     * @return string
+     */
+    public function getDataType(): string
+    {
+        return $this->dataType;
+    }
+
+    /**
+     * Set the data type of this custom field.
+     *
+     * @param string
+     */
+    public function setDataType($dataType)
+    {
+        $this->dataType = $dataType;
+    }
+
+    /**
+     * Returns the default value for this custom field.
+     *
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
+
+    /**
+     * Set the default value for this custom field.
+     *
+     * @param mixed
+     */
+    public function setDefaultValue($defaultValue)
+    {
+        $this->defaultValue = $defaultValue;
+    }
+
+    /**
+     * Returns the description of this object.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set the description of this object.
+     *
+     * @param string
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Returns the node name for this custom field in XML and JSON.
+     *
+     * @return string
+     */
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+
+    /**
+     * Set the node name for this custom field in XML and JSON.
+     *
+     * @param string
+     */
+    public function setFieldName($fieldName)
+    {
+        $this->fieldName = $fieldName;
+    }
+
+    /**
+     * Returns an alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): string
+    {
+        return $this->guid;
+    }
+
+    /**
+     * Set an alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string
+     */
+    public function setGuid($guid)
+    {
+        $this->guid = $guid;
+    }
+
+    /**
+     * Returns whether this custom field is indexed for search.
+     *
+     * @return bool
+     */
+    public function getIncludeInTextSearch(): bool
+    {
+        return $this->includeInTextSearch;
+    }
+
+    /**
+     * Set whether this custom field is indexed for search.
+     *
+     * @param bool
+     */
+    public function setIncludeInTextSearch($includeInTextSearch)
+    {
+        $this->includeInTextSearch = $includeInTextSearch;
+    }
+
+    /**
+     * Returns whether this custom field stores unique values and functions as a create key.
+     *
+     * @return bool
+     */
+    public function getIsUnique(): bool
+    {
+        return $this->isUnique;
+    }
+
+    /**
+     * Set whether this custom field stores unique values and functions as a create key.
+     *
+     * @param bool
+     */
+    public function setIsUnique($isUnique)
+    {
+        $this->isUnique = $isUnique;
+    }
+
+    /**
+     * Returns the maximum string length or the number of decimal positions allowed in this custom field's value.
+     *
+     * @return int
+     */
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+
+    /**
+     * Set the maximum string length or the number of decimal positions allowed in this custom field's value.
+     *
+     * @param int
+     */
+    public function setLength($length)
+    {
+        $this->length = $length;
+    }
+
+    /**
+     * Returns whether this object currently allows updates.
+     *
+     * @return bool
+     */
+    public function getLocked(): bool
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Set whether this object currently allows updates.
+     *
+     * @param bool
+     */
+    public function setLocked($locked)
+    {
+        $this->locked = $locked;
+    }
+
+    /**
+     * Returns the namespace this custom field belongs to.
+     *
+     * @return UriInterface
+     */
+    public function getNamespace(): UriInterface
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Set the namespace this custom field belongs to.
+     *
+     * @param UriInterface
+     */
+    public function setNamespace(UriInterface $namespace)
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * Returns an XML namespace prefix for this field.
+     *
+     * @return string
+     */
+    public function getNamespacePrefix(): string
+    {
+        return $this->namespacePrefix;
+    }
+
+    /**
+     * Set an XML namespace prefix for this field.
+     *
+     * @param string
+     */
+    public function setNamespacePrefix($namespacePrefix)
+    {
+        $this->namespacePrefix = $namespacePrefix;
+    }
+
+    /**
+     * Returns whether this custom field is always available in change notifications.
+     *
+     * @return bool
+     */
+    public function getNotifyAlways(): bool
+    {
+        return $this->notifyAlways;
+    }
+
+    /**
+     * Set whether this custom field is always available in change notifications.
+     *
+     * @param bool
+     */
+    public function setNotifyAlways($notifyAlways)
+    {
+        $this->notifyAlways = $notifyAlways;
+    }
+
+    /**
+     * Returns whether this custom field is available on change in update notifications.
+     *
+     * @return bool
+     */
+    public function getNotifyChanges(): bool
+    {
+        return $this->notifyChanges;
+    }
+
+    /**
+     * Set whether this custom field is available on change in update notifications.
+     *
+     * @param bool
+     */
+    public function setNotifyChanges($notifyChanges)
+    {
+        $this->notifyChanges = $notifyChanges;
+    }
+
+    /**
+     * Returns whether this custom field is available in delete notifications.
+     *
+     * @return bool
+     */
+    public function getNotifyDelete(): bool
+    {
+        return $this->notifyDelete;
+    }
+
+    /**
+     * Set whether this custom field is available in delete notifications.
+     *
+     * @param bool
+     */
+    public function setNotifyDelete($notifyDelete)
+    {
+        $this->notifyDelete = $notifyDelete;
+    }
+
+    /**
+     * Returns the id of the account that owns this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getOwnerId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * Set the id of the account that owns this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setOwnerId($ownerId)
+    {
+        $this->ownerId = $ownerId;
+    }
+
+    /**
+     * Returns the name that this custom field is indexed under.
+     *
+     * @return string
+     */
+    public function getSearchFieldName(): string
+    {
+        return $this->searchFieldName;
+    }
+
+    /**
+     * Set the name that this custom field is indexed under.
+     *
+     * @param string
+     */
+    public function setSearchFieldName($searchFieldName)
+    {
+        $this->searchFieldName = $searchFieldName;
+    }
+
+    /**
+     * Returns the name of this object.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the name of this object.
+     *
+     * @param string
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Returns the date and time this object was last modified.
+     *
+     * @return \DateTime
+     */
+    public function getUpdated(): \DateTime
+    {
+        return $this->updated;
+    }
+
+    /**
+     * Set the date and time this object was last modified.
+     *
+     * @param \DateTime
+     */
+    public function setUpdated($updated)
+    {
+        $this->updated = $updated;
+    }
+
+    /**
+     * Returns the id of the user that last modified this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        return $this->updatedByUserId;
+    }
+
+    /**
+     * Set the id of the user that last modified this object.
+     *
+     * @param \Psr\Http\Message\UriInterface
+     */
+    public function setUpdatedByUserId($updatedByUserId)
+    {
+        $this->updatedByUserId = $updatedByUserId;
+    }
+
+    /**
+     * Returns this object's modification version, used for optimistic locking.
+     *
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    /**
+     * Set this object's modification version, used for optimistic locking.
+     *
+     * @param int
+     */
+    public function setVersion($version)
+    {
+        $this->version = $version;
+    }
+}

--- a/tests/fixtures/field-object.json
+++ b/tests/fixtures/field-object.json
@@ -1,0 +1,28 @@
+{
+  "id": "http://data.media.theplatform.com/media/data/Media/Field/12345",
+  "guid": "MwC3WwD7PACqVQBRgADslhWRLfnR4s3w",
+  "title": "uri field",
+  "description": "",
+  "added": 1236030615000,
+  "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+  "updated": 1236030615000,
+  "addedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mps/82749532",
+  "updatedByUserId": "https://identity.auth.theplatform.com/idm/data/User/mps/82749532",
+  "version": 0,
+  "locked": false,
+  "fieldName": "uriField",
+  "namespace": "http://access.auth.theplatform.com/data/Account/55555",
+  "namespacePrefix": "",
+  "dataType": "URI",
+  "dataStructure": "Single",
+  "defaultValue": "http://www.example.com",
+  "allowedValues": [
+  ],
+  "isUnique": false,
+  "length": 0,
+  "notifyAlways": false,
+  "notifyChanges": false,
+  "notifyDelete": false,
+  "searchFieldName": "uriField",
+  "includeInTextSearch": false
+}

--- a/tests/src/Functional/DataService/CustomFieldTest.php
+++ b/tests/src/Functional/DataService/CustomFieldTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\DataService;
+
+use Lullabot\Mpx\DataService\ByFields;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\Field;
+use Lullabot\Mpx\DataService\Range;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+
+/**
+ * Tests loading custom fields.
+ */
+class CustomFieldTest extends FunctionalTestBase
+{
+    /**
+     * Tests loading custom field definitions.
+     */
+    public function testCustomFields()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $mediaDataService = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $dof = new DataObjectFactory($mediaDataService->getAnnotation()->getFieldDataService(), $this->authenticatedClient);
+        $filter = new ByFields();
+        $range = new Range();
+        $range->setStartIndex(1)
+            ->setEndIndex(2);
+        $filter->setRange($range);
+        $results = $dof->select($filter, $this->account);
+        foreach ($results as $index => $field) {
+            $this->assertInstanceOf(Field::class, $field);
+
+            // Loading the object by itself.
+            $reload = $dof->load($field->getId());
+            $this->assertEquals($field, $reload->wait());
+            if ($index + 1 > 2) {
+                break;
+            }
+        }
+    }
+}

--- a/tests/src/Unit/DataService/FieldTest.php
+++ b/tests/src/Unit/DataService/FieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService;
+
+use Lullabot\Mpx\DataService\DataServiceExtractor;
+use Lullabot\Mpx\DataService\Field;
+
+/**
+ * Test the Field data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Field
+ */
+class FieldTest extends ObjectTestBase
+{
+    protected $class = Field::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $dataServiceExtractor = new DataServiceExtractor();
+        $dataServiceExtractor->setClass($this->class);
+        $this->loadFixture('field-object.json', $dataServiceExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return array
+     */
+    public function getSetMethods()
+    {
+        $tests = parent::getSetMethods();
+        $tests['added'] = ['added', \DateTime::createFromFormat('U.u', '1236030615.000')];
+        $tests['updated'] = ['updated', \DateTime::createFromFormat('U.u', '1236030615.000')];
+
+        return $tests;
+    }
+}


### PR DESCRIPTION
This PR _mostly_ handles #92 by:

1. Adds support for loading custom field data from mpx. This ensures developers are working with custom fields as they are actually set configured.
1. Adds a console command to generate classes for custom fields. Each class represents a namespace.

```
bin/console help mpx:create-custom-field
Usage:
  mpx:create-custom-field <namespace> <data-service> <data-object> <schema>
  mpx:create-custom-field 'Lullabot\Mpx\CustomField' 'Media Data Service' 'Media' '1.10'

Arguments:
  namespace             The fully-qualified class name to generate. Do not include the leading slash, and wrap the class name in single-quotes to handle shell escaping.
  data-service          The data service to generate the class for, such as 'Media Data Service'.
  data-object           The object to generate the class for, such as 'Media'
  schema                The schema version of the object, such as '1.10'

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  This command generates a PHP class for a custom field implementation.

  A mpx username and password is required. They will be requested interactively,
  or MPX_USERNAME and MPX_PASSWORD environment variables will be used.

  As mpx provides no way to infer a reasonable class name, each class is named
  sequentially with the expectation that it will be renamed later. One file will
  be generated for each namespace of custom fields that is detected. Files will
  be written to the current working directory.
```

Still to be done is to add an annotation for custom field classes. That way, site-specific code can annotate a generated class as belonging to a specific namespace, and we can discover them automatically when deserializing a mpx response. I will do that as a new PR if this gets merged first.