### PR TITLE
Denormalize custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Service URLs are now cached when loading objects and listening for
-  notifications. #144
+  notifications. #114
+- Support for loading custom fields, including denormalizing into custom
+  classes not shipped with this library. See the README for detailed
+  documentation. #120
 
 ### Changed
 
@@ -21,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   it's API as a result. #144
 - The UnixMicrosecondNormalizer class has been renamed to
   UnixMillisecondNormalizer #115
+- The deserialize method on DataObjectFactory is now protected #120
+- create() methods that were broken and unused were removed in the plugin
+  managers #120
 
 ## [0.1.1] - 2018-05-16
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,57 @@ If your application does not wish to log these actions at all, use
 `\Psr\Log\NullLogger` for any constructors that require a
 `\Psr\Log\LoggerInterface`.
 
+## Implementing custom mpx fields
+
+mpx data service objects can have up to 100 custom fields defined per account.
+These fields can contain a variety of data types, with multiple namespaces of
+custom fields applying to a single object. This library allows for developers
+to create structured classes in their own application code that are discovered
+and used automatically.
+
+### 1. Use the console tool to create initial classes
+
+This CLI tool uses the mpx Field API to generate matching classes. Consider
+adding descriptions for each custom field in mpx, as these will be used
+automatically in doc comments. Run `bin/console help mpx:create-custom-field`
+for up-to-date documentation on this command.
+
+For example, to generate classes for all custom fields attached to a Media
+object:
+
+1. Clone this repository.
+1. `$ composer install`
+1. `$ bin/console mpx:create-custom-field 'Php\Namespace\For\These\Classes' 'Media Data Service' 'Media' '1.10'`
+1. Enter your username and password. Progress will be shown for each field that is found.
+
+As the mpx API has no data useful in creating class names, classes for each
+field namespace will be created with names like `CustomFieldClassOne.php`. It
+is highly suggested that these classes are renamed to match the fields they
+contain.
+
+Each generated class will contain an `@CustomField` annotation:
+
+```php
+/**
+ * @CustomField(
+ *     namespace="http://access.auth.theplatform.com/data/Account/555555",
+ *     service="Media Data Service",
+ *     objectType="Media",
+ * )
+ */
+```
+
+This is what the library uses to determine which class corresponds to a given
+namespace. Note that **custom fields do not have schema versions**. Be careful
+when deleting or changing data types on existing fields.
+
+These custom fields should live in your application code. As such, you will
+need to provide a way to discover the classes since different applications
+have different source code structures. If you're using a module for a CMS like
+Drupal, it should already provide that functionality. If not, see
+`\Lullabot\Mpx\DataService\CustomFieldManager::basicDiscovery` for an example
+that can be adapted in many cases.
+
 ## Overview of main classes
 
 ### Lullabot\Mpx\Client

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ $media = $dof->load(new Uri('http://data.media.theplatform.com/media/data/Media/
 $fields = $media->getCustomFields('http://access.auth.theplatform.com/data/Account/555555'):
 ```
 
+If a custom field class is not found, a notice will be logged and the empty
+`MissingCustomFieldsClass` will be attached in place of each set of fields.
+
 ## Overview of main classes
 
 ### Lullabot\Mpx\Client

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Drupal, it should already provide that functionality. If not, see
 `\Lullabot\Mpx\DataService\CustomFieldManager::basicDiscovery` for an example
 that can be adapted in many cases.
 
+Once the classes are available, they will be automatically used when loading
+mpx objects. For example, to retrieve fields for the above namespace on a
+Media object, call:
+
+```php
+$dof = new DataObjectFactory($manager->getDataService('Media Data Service', 'Media', '1.10'), $this->authenticatedClient);
+$media = $dof->load(new Uri('http://data.media.theplatform.com/media/data/Media/12345'))->wait();
+$fields = $media->getCustomFields('http://access.auth.theplatform.com/data/Account/555555'):
+```
+
 ## Overview of main classes
 
 ### Lullabot\Mpx\Client

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -6,6 +6,7 @@ use Cache\Adapter\PHPArray\ArrayCachePool;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\Client;
 use Lullabot\Mpx\DataService\ByFields;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
 use Lullabot\Mpx\DataService\Field;
@@ -118,6 +119,7 @@ EOD;
                 $class = $namespace->addClass($className);
                 $classNames[$mpxNamespace] = $className;
                 $namespaceClasses[$mpxNamespace] = $namespace;
+                $class->addImplement(CustomFieldInterface::class);
 
                 $class->addComment('@CustomField(');
                 $class->addComment('    namespace="'.$mpxNamespace.'",');

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -119,7 +119,11 @@ EOD;
                 $classNames[$mpxNamespace] = $className;
                 $namespaceClasses[$mpxNamespace] = $namespace;
 
-                $class->addComment('Custom fields for namespace at '.$mpxNamespace);
+                $class->addComment('@CustomField(');
+                $class->addComment('    namespace="'.$mpxNamespace.'",');
+                $class->addComment('    service="'.$input->getArgument('data-service').'",');
+                $class->addComment('    objectType="'.$input->getArgument('data-object').'",');
+                $class->addComment(')');
             }
             else {
                 $namespace = $namespaceClasses[$mpxNamespace];

--- a/src/DataService/Annotation/CustomField.php
+++ b/src/DataService/Annotation/CustomField.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Annotation;
+
+/**
+ * @Annotation
+ */
+class CustomField
+{
+    /**
+     * The URI of the custom field namespace the class represents.
+     *
+     * @var string
+     */
+    public $namespace;
+
+    /**
+     * The name of the service the custom fields apply to, such as 'Media Data Service'.
+     *
+     * @var string
+     */
+    public $service;
+
+    /**
+     * The object type the custom fields are attached to, such as 'Media'.
+     *
+     * @var string
+     */
+    public $objectType;
+}

--- a/src/DataService/Annotation/CustomField.php
+++ b/src/DataService/Annotation/CustomField.php
@@ -3,7 +3,13 @@
 namespace Lullabot\Mpx\DataService\Annotation;
 
 /**
+ * Annotation definition for custom field classes.
+ *
+ * All classes with this annotation must implement \Lullabot\Mpx\DataService\CustomFieldInterface.
+ *
  * @Annotation
+ *
+ * @see \Lullabot\Mpx\DataService\CustomFieldInterface
  */
 class CustomField
 {

--- a/src/DataService/Annotation/DataService.php
+++ b/src/DataService/Annotation/DataService.php
@@ -28,7 +28,7 @@ class DataService
     public $service;
 
     /**
-     * The object type in the service, such as 'Media'.
+     * The object type of the service, such as 'Media'.
      *
      * @var string
      */

--- a/src/DataService/CustomFieldDiscovery.php
+++ b/src/DataService/CustomFieldDiscovery.php
@@ -89,15 +89,13 @@ class CustomFieldDiscovery
         foreach ($finder as $file) {
             $class = $this->classForFile($file);
             /* @var \Lullabot\Mpx\DataService\Annotation\CustomField $annotation */
-            $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\CustomField');
-            if (!$annotation) {
-                continue;
-            }
-            if (!is_subclass_of($class, CustomFieldInterface::class)) {
-                throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
-            }
+            if ($annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\CustomField')) {
+                if (!is_subclass_of($class, CustomFieldInterface::class)) {
+                    throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
+                }
 
-            $this->customFields[$annotation->service][$annotation->objectType][$annotation->namespace] = new DiscoveredCustomField($class, $annotation);
+                $this->customFields[$annotation->service][$annotation->objectType][$annotation->namespace] = new DiscoveredCustomField($class, $annotation);
+            }
         }
     }
 

--- a/src/DataService/CustomFieldDiscovery.php
+++ b/src/DataService/CustomFieldDiscovery.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Doctrine\Common\Annotations\Reader;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Class to discover Custom Field implementations.
+ */
+class CustomFieldDiscovery
+{
+    /**
+     * The namespace to search within, such as '\Lullabot\Mpx'.
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * The root directory of the namespace, such as 'src'.
+     *
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * The class to use for reading annotations.
+     *
+     * @var \Doctrine\Common\Annotations\Reader
+     */
+    private $annotationReader;
+
+    /**
+     * The root directory to discover from, containing the namespace directory.
+     *
+     * @var string
+     */
+    private $rootDir;
+
+    /**
+     * The array of discovered data services.
+     *
+     * @var DiscoveredCustomField[]
+     */
+    private $customFields = [];
+
+    /**
+     * CustomFieldDiscovery constructor.
+     *
+     * @param string $namespace The namespace of the plugins.
+     * @param string $directory The directory of the plugins.
+     * @param $rootDir
+     * @param \Doctrine\Common\Annotations\Reader $annotationReader
+     */
+    public function __construct($namespace, $directory, $rootDir, Reader $annotationReader)
+    {
+        $this->namespace = $namespace;
+        $this->annotationReader = $annotationReader;
+        $this->directory = $directory;
+        $this->rootDir = $rootDir;
+    }
+
+    /**
+     * Returns all the data services.
+     *
+     * @return DiscoveredCustomField[] An array of all discovered data services, indexed by service name, object type, and namespace.
+     */
+    public function getCustomFields(): array
+    {
+        if (!$this->customFields) {
+            $this->discoverCustomFields();
+        }
+
+        return $this->customFields;
+    }
+
+    /**
+     * Discovers custom fields.
+     */
+    private function discoverCustomFields()
+    {
+        $path = $this->rootDir.'/'.$this->directory;
+        $finder = new Finder();
+        $finder->files()->in($path);
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $class = $this->classForFile($file);
+            /* @var \Lullabot\Mpx\DataService\Annotation\CustomField $annotation */
+            $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\CustomField');
+            if (!$annotation) {
+                continue;
+            }
+            if (!is_subclass_of($class, CustomFieldInterface::class)) {
+                throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));
+            }
+
+            $this->customFields[$annotation->service][$annotation->objectType][$annotation->namespace] = new DiscoveredCustomField($class, $annotation);
+        }
+    }
+
+    /**
+     * Given a file path, return the PSR-4 class it should contain.
+     *
+     * @param SplFileInfo $file The file to generate the class name for.
+     *
+     * @return string The fully-qualified class name.
+     */
+    private function classForFile(SplFileInfo $file): string
+    {
+        $subnamespace = str_replace('/', '\\', $file->getRelativePath());
+        if (!empty($subnamespace)) {
+            $subnamespace .= '\\';
+        }
+        $class = $this->namespace.'\\'.$subnamespace.$file->getBasename('.php');
+
+        return $class;
+    }
+}

--- a/src/DataService/CustomFieldInterface.php
+++ b/src/DataService/CustomFieldInterface.php
@@ -5,7 +5,7 @@ namespace Lullabot\Mpx\DataService;
 /**
  * Interface for all classes implementing a custom field definition.
  *
- * All classes implementing the @CustomField annotation must implement this
+ * All classes implementing the CustomField annotation must implement this
  * interface.
  *
  * @see \Lullabot\Mpx\DataService\Annotation\CustomField

--- a/src/DataService/CustomFieldInterface.php
+++ b/src/DataService/CustomFieldInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Interface for all classes implementing a custom field definition.
+ *
+ * All classes implementing the @CustomField annotation must implement this
+ * interface.
+ *
+ * @see \Lullabot\Mpx\DataService\Annotation\CustomField
+ */
+interface CustomFieldInterface
+{
+}

--- a/src/DataService/CustomFieldManager.php
+++ b/src/DataService/CustomFieldManager.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+
+class CustomFieldManager
+{
+    /**
+     * @var \Lullabot\Mpx\DataService\CustomFieldDiscovery
+     */
+    private $discovery;
+
+    public function __construct(CustomFieldDiscovery $discovery)
+    {
+        $this->discovery = $discovery;
+    }
+
+    /**
+     * Register our annotations, relative to this file.
+     *
+     * @return static
+     */
+    public static function basicDiscovery()
+    {
+        // @todo Check Drupal core for other tags to ignore?
+        AnnotationReader::addGlobalIgnoredName('class');
+        AnnotationRegistry::registerFile(__DIR__.'/Annotation/CustomField.php');
+        $discovery = new CustomFieldDiscovery('\\Lullabot\\Mpx', 'src', __DIR__.'/../..', new AnnotationReader());
+
+        return new static($discovery);
+    }
+
+    /**
+     * Returns a list of available custom fields.
+     *
+     * @return array
+     */
+    public function getCustomFields()
+    {
+        return $this->discovery->getCustomFields();
+    }
+
+    /**
+     * Returns one custom field.
+     *
+     * @param string $name
+     * @param string $objectType
+     * @param string $namespace
+     *
+     * @return CustomField
+     */
+    public function getCustomField(string $name, string $objectType, string $namespace)
+    {
+        $services = $this->discovery->getCustomFields();
+        if (isset($services[$name][$objectType][$namespace])) {
+            return $services[$name][$objectType][$namespace];
+        }
+
+        throw new \RuntimeException('Custom field not found.');
+    }
+
+    /**
+     * Creates a custom field.
+     *
+     * @param string $name
+     *
+     * @throws \RuntimeException
+     *
+     * @return ObjectInterface
+     *
+     * @todo Not called.
+     */
+    public function create($name)
+    {
+        $services = $this->discovery->getCustomFields();
+        // @todo This is broken.
+        if (array_key_exists($name, $services)) {
+            $class = $services[$name]['class'];
+            if (!class_exists($class)) {
+                throw new \RuntimeException('Custom field class does not exist.');
+            }
+
+            return new $class();
+        }
+
+        throw new \RuntimeException('Custom field does not exist.');
+    }
+}

--- a/src/DataService/CustomFieldManager.php
+++ b/src/DataService/CustomFieldManager.php
@@ -61,31 +61,4 @@ class CustomFieldManager
 
         throw new \RuntimeException('Custom field not found.');
     }
-
-    /**
-     * Creates a custom field.
-     *
-     * @param string $name
-     *
-     * @throws \RuntimeException
-     *
-     * @return ObjectInterface
-     *
-     * @todo Not called.
-     */
-    public function create($name)
-    {
-        $services = $this->discovery->getCustomFields();
-        // @todo This is broken.
-        if (array_key_exists($name, $services)) {
-            $class = $services[$name]['class'];
-            if (!class_exists($class)) {
-                throw new \RuntimeException('Custom field class does not exist.');
-            }
-
-            return new $class();
-        }
-
-        throw new \RuntimeException('Custom field does not exist.');
-    }
 }

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -108,7 +108,7 @@ class DataObjectFactory
      *
      * @return IdInterface
      */
-    public function deserialize(string $class, $data)
+    protected function deserialize(string $class, $data)
     {
         // @todo Is this extractor required?
         $dataServiceExtractor = new DataServiceExtractor();

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\DataService;
 
 use Doctrine\Common\Annotations\Reader;
+use Lullabot\Mpx\DataService\Annotation\DataService;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -105,11 +106,7 @@ class DataServiceDiscovery
 
             // Now that we have a new data service, we need to attach any
             // custom field implementations.
-            $fields = $this->customFieldManager->getCustomFields();
-            $customFields = [];
-            if (isset($fields[$annotation->getService()][$annotation->getObjectType()])) {
-                $customFields = $fields[$annotation->getService()][$annotation->getObjectType()];
-            }
+            $customFields = $this->getCustomFields($annotation);
             $this->dataServices[$annotation->getService()][$annotation->getObjectType()][$annotation->getSchemaVersion()] = new DiscoveredDataService($class, $annotation, $customFields);
         }
     }
@@ -130,5 +127,23 @@ class DataServiceDiscovery
         $class = $this->namespace.'\\'.$subnamespace.$file->getBasename('.php');
 
         return $class;
+    }
+
+    /**
+     * Return the array of custom fields for an annotation.
+     *
+     * @param DataService $annotation The Data Service annotation being discovered.
+     *
+     * @return DiscoveredCustomField[] An array of custom field definitions.
+     */
+    private function getCustomFields(DataService $annotation): array
+    {
+        $fields = $this->customFieldManager->getCustomFields();
+        $customFields = [];
+        if (isset($fields[$annotation->getService()][$annotation->getObjectType()])) {
+            $customFields = $fields[$annotation->getService()][$annotation->getObjectType()];
+        }
+
+        return $customFields;
     }
 }

--- a/src/DataService/DataServiceExtractor.php
+++ b/src/DataService/DataServiceExtractor.php
@@ -87,6 +87,12 @@ class DataServiceExtractor extends CachingPhpDocExtractor
             return [new Type('object', false, $discoveredCustomField->getClass())];
         }
 
+        if ($property == 'customFields') {
+            $collectionKeyType = new Type(Type::BUILTIN_TYPE_STRING);
+            $collectionValueType = new Type('object', false, CustomFieldInterface::class);
+            return [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, $collectionKeyType, $collectionValueType)];
+        }
+
         // Early return for normal top-level properties.
         if ('entries' !== $property) {
             return parent::getTypes($class, $property, $context);

--- a/src/DataService/DataServiceExtractor.php
+++ b/src/DataService/DataServiceExtractor.php
@@ -87,9 +87,10 @@ class DataServiceExtractor extends CachingPhpDocExtractor
             return [new Type('object', false, $discoveredCustomField->getClass())];
         }
 
-        if ($property == 'customFields') {
+        if ('customFields' == $property) {
             $collectionKeyType = new Type(Type::BUILTIN_TYPE_STRING);
             $collectionValueType = new Type('object', false, CustomFieldInterface::class);
+
             return [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, $collectionKeyType, $collectionValueType)];
         }
 

--- a/src/DataService/DataServiceExtractor.php
+++ b/src/DataService/DataServiceExtractor.php
@@ -3,9 +3,20 @@
 namespace Lullabot\Mpx\DataService;
 
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Exception\LogicException;
 
 /**
- * A property extractor to allow for a ObjectList to have varying 'entries' data types.
+ * A property extractor for mpx objects.
+ *
+ * Unlike normalizers, only a single extractor can be used with an
+ * ObjectNormalizer. This class handles all custom extractions, including:
+ *   - Handling the 'entries' key in an Object List.
+ *   - Detecting custom fields and assigning them to the appropriate class.
+ *
+ * This extractor relies on custom fields being decoded into their own arrays,
+ * with each array key corresponding to the namespace prefix in the response.
+ *
+ * @see \Lullabot\Mpx\Encoder\CJsonEncoder
  */
 class DataServiceExtractor extends CachingPhpDocExtractor
 {
@@ -15,6 +26,20 @@ class DataServiceExtractor extends CachingPhpDocExtractor
      * @var string
      */
     protected $class;
+
+    /**
+     * The array of custom field namespaces to use for extracting property info.
+     *
+     * @var DiscoveredCustomField[]
+     */
+    protected $customFields = [];
+
+    /**
+     * The array of custom field namespace prefix mappings.
+     *
+     * @var array
+     */
+    protected $xmlns;
 
     /**
      * Set the class that is being extracted, such as \Lullabot\Mpx\DataService\Media\Media.
@@ -27,14 +52,47 @@ class DataServiceExtractor extends CachingPhpDocExtractor
     }
 
     /**
+     * Set the array of discovered custom fields.
+     *
+     * @param DiscoveredCustomField[] $customFields The array of custom field namespaces to use for extracting property info.
+     */
+    public function setCustomFields(array $customFields)
+    {
+        $this->customFields = $customFields;
+    }
+
+    /**
+     * Set the array of namespace mappings.
+     *
+     * @param array $xmlns
+     */
+    public function setNamespaceMapping(array $xmlns)
+    {
+        $this->xmlns = $xmlns;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getTypes($class, $property, array $context = [])
     {
+        // First, check to see if this is a custom field.
+        if (isset($this->xmlns[$property])) {
+            $ns = $this->xmlns[$property];
+
+            if (!$discoveredCustomField = $this->customFields[$ns]) {
+                throw new LogicException(sprintf('No custom field class was found for %s. setCustomFields() must be called before using this extractor.', $ns));
+            }
+
+            return [new Type('object', false, $discoveredCustomField->getClass())];
+        }
+
+        // Early return for normal top-level properties.
         if ('entries' !== $property) {
             return parent::getTypes($class, $property, $context);
         }
 
+        // This is an object list, so handle the 'entries' key.
         if (!isset($this->class)) {
             throw new \UnexpectedValueException('setClass() must be called before using this extractor.');
         }

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -66,29 +66,4 @@ class DataServiceManager
 
         throw new \RuntimeException('Data service not found.');
     }
-
-    /**
-     * Creates a data service.
-     *
-     * @param string $name
-     *
-     * @throws \RuntimeException
-     *
-     * @return ObjectInterface
-     */
-    public function create($name)
-    {
-        $services = $this->discovery->getDataServices();
-        // @todo This is broken.
-        if (array_key_exists($name, $services)) {
-            $class = $services[$name]['class'];
-            if (!class_exists($class)) {
-                throw new \RuntimeException('Data service class does not exist.');
-            }
-
-            return new $class();
-        }
-
-        throw new \RuntimeException('Data service does not exist.');
-    }
 }

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -20,14 +20,20 @@ class DataServiceManager
     /**
      * Register our annotations, relative to this file.
      *
+     * @param CustomFieldManager $customFieldManager (optional) The manager used to discover custom fields.
+     *
      * @return static
      */
-    public static function basicDiscovery()
+    public static function basicDiscovery(CustomFieldManager $customFieldManager = null)
     {
+        if (!$customFieldManager) {
+            $customFieldManager = CustomFieldManager::basicDiscovery();
+        }
+
         // @todo Check Drupal core for other tags to ignore?
         AnnotationReader::addGlobalIgnoredName('class');
         AnnotationRegistry::registerFile(__DIR__.'/Annotation/DataService.php');
-        $discovery = new DataServiceDiscovery('\\Lullabot\\Mpx', 'src', __DIR__.'/../..', new AnnotationReader());
+        $discovery = new DataServiceDiscovery('\\Lullabot\\Mpx', 'src', __DIR__.'/../..', new AnnotationReader(), $customFieldManager);
 
         return new static($discovery);
     }

--- a/src/DataService/DiscoveredCustomField.php
+++ b/src/DataService/DiscoveredCustomField.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+
+/**
+ * Class representing a discovered custom field class.
+ */
+class DiscoveredCustomField
+{
+    /**
+     * The fully-qualified class name of the discovered class.
+     *
+     * @var string
+     */
+    private $class;
+
+    /**
+     * The annotation object attached to the class.
+     *
+     * @var CustomField
+     */
+    private $annotation;
+
+    /**
+     * DiscoveredCustomField constructor.
+     *
+     * @param string      $class      The fully-qualified class name of the discovered class.
+     * @param CustomField $annotation The annotation object attached to the class.
+     */
+    public function __construct(string $class, CustomField $annotation)
+    {
+        $this->class = $class;
+        $this->annotation = $annotation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    /**
+     * @return CustomField
+     */
+    public function getAnnotation()
+    {
+        return $this->annotation;
+    }
+}

--- a/src/DataService/DiscoveredDataService.php
+++ b/src/DataService/DiscoveredDataService.php
@@ -16,10 +16,25 @@ class DiscoveredDataService
      */
     private $annotation;
 
-    public function __construct(string $class, DataService $annotation)
+    /**
+     * The array of custom field objects found for this data service.
+     *
+     * @var DiscoveredCustomField[]
+     */
+    private $customFields;
+
+    /**
+     * DiscoveredDataService constructor.
+     *
+     * @param string      $class        The class of the discovered data service.
+     * @param DataService $annotation   The annotation of the discovered class.
+     * @param array       $customFields (optional) The array of custom field classes.
+     */
+    public function __construct(string $class, DataService $annotation, array $customFields = [])
     {
         $this->class = $class;
         $this->annotation = $annotation;
+        $this->customFields = $customFields;
     }
 
     /**
@@ -36,5 +51,13 @@ class DiscoveredDataService
     public function getAnnotation()
     {
         return $this->annotation;
+    }
+
+    /**
+     * @return DiscoveredCustomField[]
+     */
+    public function getCustomFields(): array
+    {
+        return $this->customFields;
     }
 }

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -38,6 +38,11 @@ abstract class ObjectBase implements ObjectInterface
     protected $ownerId;
 
     /**
+     * @var CustomFieldInterface[]
+     */
+    protected $customFields;
+
+    /**
      * {@inheritdoc}
      */
     public function getAdded(): \DateTime
@@ -99,5 +104,21 @@ abstract class ObjectBase implements ObjectInterface
     public function setOwnerId($ownerId)
     {
         $this->ownerId = $ownerId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomFields($namespace)
+    {
+        return $this->customFields[$namespace];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCustomFields(array $customFields)
+    {
+        $this->customFields = $customFields;
     }
 }

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -50,4 +50,20 @@ interface ObjectInterface extends IdInterface
      * @param UriInterface
      */
     public function setOwnerId($ownerId);
+
+    /**
+     * Return custom fields attached to this object.
+     *
+     * @param string $namespace The namespace of the fields to retrieve.
+     *
+     * @return CustomFieldInterface
+     */
+    public function getCustomFields($namespace);
+
+    /**
+     * Set the custom fields attached to this data object.
+     *
+     * @param CustomFieldInterface[] $customFields The array of custom field implementations, keyed by their namespace.
+     */
+    public function setCustomFields(array $customFields);
 }

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -1777,7 +1777,7 @@ class Player extends ObjectBase implements PublicIdentifierInterface
      *
      * @param string
      */
-    public function setPosterImageMetaAssetType($posterImageMetaAssetType)
+    public function setPosterImageMetaAssetType(string $posterImageMetaAssetType)
     {
         $this->posterImageMetaAssetType = $posterImageMetaAssetType;
     }

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -15,7 +15,9 @@ class CJsonEncoder extends JsonEncoder
     public function decode($data, $format, array $context = [])
     {
         $decoded = parent::decode($data, $format, $context);
-        $decoded = $this->decodeCustomFields($decoded);
+        if (isset($decoded['$xmlns'])) {
+            $decoded = $this->decodeCustomFields($decoded);
+        }
 
         return $this->cleanup($decoded);
     }
@@ -59,16 +61,14 @@ class CJsonEncoder extends JsonEncoder
      */
     protected function decodeCustomFields($decoded)
     {
-        if (isset($decoded['$xmlns'])) {
-            // @todo This is O(namespaces * entries) and can be optimized.
-            foreach ($decoded['$xmlns'] as $prefix => $namespace) {
-                if (isset($decoded['entries'])) {
-                    foreach ($decoded['entries'] as &$entry) {
-                        $this->decodeObject($prefix, $namespace, $entry);
-                    }
-                } else {
-                    $this->decodeObject($prefix, $namespace, $decoded);
+        // @todo This is O(namespaces * entries) and can be optimized.
+        foreach ($decoded['$xmlns'] as $prefix => $namespace) {
+            if (isset($decoded['entries'])) {
+                foreach ($decoded['entries'] as &$entry) {
+                    $this->decodeObject($prefix, $namespace, $entry);
                 }
+            } else {
+                $this->decodeObject($prefix, $namespace, $decoded);
             }
         }
 

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -20,6 +20,7 @@ class CJsonEncoder extends JsonEncoder
         }
 
         $this->cleanup($decoded);
+
         return $decoded;
     }
 
@@ -62,12 +63,13 @@ class CJsonEncoder extends JsonEncoder
     {
         // @todo This is O(namespaces * entries) and can be optimized.
         foreach ($decoded['$xmlns'] as $prefix => $namespace) {
-            if (isset($decoded['entries'])) {
-                foreach ($decoded['entries'] as &$entry) {
-                    $this->decodeObject($prefix, $namespace, $entry);
-                }
-            } else {
+            if (!isset($decoded['entries'])) {
                 $this->decodeObject($prefix, $namespace, $decoded);
+                continue;
+            }
+
+            foreach ($decoded['entries'] as &$entry) {
+                $this->decodeObject($prefix, $namespace, $entry);
             }
         }
     }

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -93,7 +93,7 @@ class CJsonEncoder extends JsonEncoder
         // all namespaces in any object in the result set. If a given namespace
         // is not used in a single object, we can skip custom fields entirely.
         if (!empty($customFields['data'])) {
-            $object['customFields'][] = $customFields;
+            $object['customFields'][$namespace] = $customFields;
         }
     }
 }

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -16,20 +16,21 @@ class CJsonEncoder extends JsonEncoder
     {
         $decoded = parent::decode($data, $format, $context);
         if (isset($decoded['$xmlns'])) {
-            $decoded = $this->decodeCustomFields($decoded);
+            $this->decodeCustomFields($decoded);
         }
 
-        return $this->cleanup($decoded);
+        $this->cleanup($decoded);
+        return $decoded;
     }
 
     /**
      * Recursively filter an array, removing null and empty string values.
      *
-     * @param array $data The data to filter.
+     * @param array &$data The data to filter.
      *
      * @return array The filtered array.
      */
-    protected function cleanup(array $data)
+    protected function cleanup(array &$data)
     {
         foreach ($data as &$value) {
             if (is_array($value)) {
@@ -55,11 +56,9 @@ class CJsonEncoder extends JsonEncoder
      * there is a 'namespace' key with the fully-qualified mpx namespace URI,
      * and a 'data' key with an array of the custom field values.
      *
-     * @param array $decoded The data to decode.
-     *
-     * @return array The decoded data.
+     * @param array &$decoded The data to decode.
      */
-    protected function decodeCustomFields($decoded)
+    protected function decodeCustomFields(&$decoded)
     {
         // @todo This is O(namespaces * entries) and can be optimized.
         foreach ($decoded['$xmlns'] as $prefix => $namespace) {
@@ -71,8 +70,6 @@ class CJsonEncoder extends JsonEncoder
                 $this->decodeObject($prefix, $namespace, $decoded);
             }
         }
-
-        return $decoded;
     }
 
     /**

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -28,18 +28,16 @@ class CJsonEncoder extends JsonEncoder
      * Recursively filter an array, removing null and empty string values.
      *
      * @param array &$data The data to filter.
-     *
-     * @return array The filtered array.
      */
     protected function cleanup(array &$data)
     {
         foreach ($data as &$value) {
             if (is_array($value)) {
-                $value = $this->cleanup($value);
+                $this->cleanup($value);
             }
         }
 
-        return array_filter($data, function ($value) {
+        $data = array_filter($data, function ($value) {
             return null !== $value;
         });
     }

--- a/src/Normalizer/CustomFieldsNormalizer.php
+++ b/src/Normalizer/CustomFieldsNormalizer.php
@@ -50,6 +50,10 @@ class CustomFieldsNormalizer implements DenormalizerInterface
     public function denormalize($data, $class, $format = null, array $context = [])
     {
         // This is the annotated custom field class defining all custom fields.
+        if (!isset($this->customFields[$data['namespace']])) {
+            return new MissingCustomFieldsClass($data['namespace']);
+        }
+
         $concreteClass = $this->customFields[$data['namespace']]->getClass();
 
         if (!$this->serializer instanceof DenormalizerInterface) {

--- a/src/Normalizer/CustomFieldsNormalizer.php
+++ b/src/Normalizer/CustomFieldsNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Lullabot\Mpx\Normalizer;
+
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+use Lullabot\Mpx\DataService\DiscoveredCustomField;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\SerializerAwareTrait;
+
+/**
+ * Normalize custom fields into their implementing classes.
+ *
+ * To normalize these fields we need context from the whole mpx response which
+ * is tricky to pass through the Serializer:
+ *   - The array of discovered custom field classes is needed so we can know
+ *     what class to denormalize the custom data into.
+ *   - The decoded data must be all in a single top-level property, so it can
+ *     be denormalized at once.
+ *
+ * This normalizer requires the response data be altered to meet these
+ * requirements, which is done in the CJsonEncoder.
+ *
+ * @see \Lullabot\Mpx\Encoder\CJsonEncoder
+ */
+class CustomFieldsNormalizer implements DenormalizerInterface
+{
+    use SerializerAwareTrait;
+
+    /**
+     * The array of discovered custom field classes, indexed by namespace.
+     *
+     * @var DiscoveredCustomField[]
+     */
+    private $customFields;
+
+    /**
+     * CustomFieldsNormalizer constructor.
+     *
+     * @param DiscoveredCustomField[] $customFields An array of discovered custom field classes, indexed by namespace.
+     */
+    public function __construct(array $customFields)
+    {
+        $this->customFields = $customFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        // This is the annotated custom field class defining all custom fields.
+        $concreteClass = $this->customFields[$data['namespace']]->getClass();
+
+        if (!$this->serializer instanceof DenormalizerInterface) {
+            throw new LogicException(sprintf('Cannot denormalize class "%s" because injected serializer is not a denormalizer', $class));
+        }
+
+        return $this->serializer->denormalize($data['data'], $concreteClass);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return CustomFieldInterface::class == $type;
+    }
+}

--- a/src/Normalizer/MissingCustomFieldsClass.php
+++ b/src/Normalizer/MissingCustomFieldsClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lullabot\Mpx\Normalizer;
+
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+
+/**
+ * Stub class for when no custom fields class exists.
+ *
+ * mpx may be configured to return custom fields that the consumer has no need
+ * or interest in, or that the developer simply hasn't implemented yet. The
+ * serializer doesn't know if a given custom field is set until it's actually
+ * denormalizing the individual property. This class is used so a value is
+ * returned and a notice is logged, alerting the developer to implement the
+ * class if they choose.
+ */
+class MissingCustomFieldsClass implements CustomFieldInterface
+{
+    public function __construct(string $namespace)
+    {
+        @trigger_error(sprintf('No custom field class implementation for namespace % was found.'), E_USER_NOTICE);
+    }
+}

--- a/tests/fixtures/account-object.json
+++ b/tests/fixtures/account-object.json
@@ -1,0 +1,25 @@
+{
+  "id": "http://mps.theplatform.com/data/Account/108634",
+  "guid": "BgAJ_wDmqwA2UwCqjUAp4sBN4Dwbc1al",
+  "title": "thePlatform documentation",
+  "description": "Demo account for documentation",
+  "added": 1310073366000,
+  "ownerId": "urn:theplatform:auth:root",
+  "updated": 1319652154000,
+  "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/2499148",
+  "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/2499148",
+  "version": 0,
+  "locked": false,
+  "disabled": false,
+  "featureRoleIds": [
+    "http://access.auth.theplatform.com/access/data/Role/1",
+    "http://access.auth.theplatform.com/data/Role/319336",
+    "http://access.auth.theplatform.com/data/Role/374602",
+    "http://access.auth.theplatform.com/data/Role/389281"
+  ],
+  "domainRoleIds": [
+    "http://access.auth.theplatform.com/data/Role/271914"
+  ],
+  "pid": "abc123",
+  "region": "US1"
+}

--- a/tests/src/Unit/DataService/Access/AccountTest.php
+++ b/tests/src/Unit/DataService/Access/AccountTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Access;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\DataServiceExtractor;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+
+/**
+ * Test the Account data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Access\Account
+ */
+class AccountTest extends ObjectTestBase
+{
+    protected $class = Account::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $dataServiceExtractor = new DataServiceExtractor();
+        $dataServiceExtractor->setClass($this->class);
+        $this->loadFixture('account-object.json', $dataServiceExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return array
+     */
+    public function getSetMethods()
+    {
+        $tests = parent::getSetMethods();
+        $tests['added'] = ['added', \DateTime::createFromFormat('U.u', '1310073366.000')];
+        $tests['updated'] = ['updated', \DateTime::createFromFormat('U.u', '1319652154.000')];
+
+        return $tests;
+    }
+}

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -32,7 +32,10 @@ class DataObjectFactoryTest extends TestCase
     /**
      * Tests loading a URI to an mpx object.
      *
+     * @covers ::__construct()
      * @covers ::load()
+     * @covers ::getObjectSerializer()
+     * @covers ::deserialize()
      */
     public function testLoad()
     {
@@ -101,6 +104,7 @@ class DataObjectFactoryTest extends TestCase
      *
      * @covers ::selectRequest()
      * @covers ::getBaseUri()
+     * @covers ::getEntriesSerializer()
      */
     public function testSelectRequest()
     {

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -11,6 +11,7 @@ use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
 use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\ObjectList;
+use Lullabot\Mpx\DataService\ObjectListIterator;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Lullabot\Mpx\Tests\JsonResponse;
@@ -65,6 +66,7 @@ class DataObjectFactoryTest extends TestCase
      * Tests the correct path when loading by ID.
      *
      * @covers ::loadByNumericId()
+     * @covers ::getBaseUri()
      */
     public function testLoadByNumericId()
     {
@@ -98,6 +100,7 @@ class DataObjectFactoryTest extends TestCase
      * Tests fetching a list of objects.
      *
      * @covers ::selectRequest()
+     * @covers ::getBaseUri()
      */
     public function testSelectRequest()
     {
@@ -123,5 +126,54 @@ class DataObjectFactoryTest extends TestCase
         $account = $objectList->current();
         $this->assertInstanceOf(Account::class, $account);
         $this->assertEquals('http://access.auth.theplatform.com/data/Account/55555', $account->getId());
+    }
+
+    /**
+     * @covers ::select()
+     */
+    public function testSelect()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Access Data Service', 'Account', '1.0');
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'select-account.json'),
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $session = new UserSession($user, $client, $store, $tokenCachePool);
+        $authenticatedClient = new AuthenticatedClient($client, $session);
+        $factory = new DataObjectFactory($service, $authenticatedClient);
+        $iterator = $factory->select(new ByFields());
+        $this->assertInstanceOf(ObjectListIterator::class, $iterator);
+    }
+
+    /**
+     * Tests loading an object without specifying an account.
+     *
+     * @covers ::getBaseUri()
+     */
+    public function testNullAccount()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
+        $client = $this->getMockClient([
+            new JsonResponse(200, [], 'signin-success.json'),
+            new JsonResponse(200, [], 'resolveAllUrls.json'),
+            new JsonResponse(200, [], 'media-object.json'),
+        ]);
+        $user = new User('username', 'password');
+        $tokenCachePool = new TokenCachePool(new ArrayCachePool());
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $session = new UserSession($user, $client, $store, $tokenCachePool);
+        $authenticatedClient = new AuthenticatedClient($client, $session);
+        $factory = new DataObjectFactory($service, $authenticatedClient);
+        /** @var ObjectList $objectList */
+        $media = $factory->loadByNumericId(2602559)->wait();
+        $this->assertInstanceOf(Media::class, $media);
+        $this->assertEquals('http://data.media.theplatform.com/media/data/Media/2602559', $media->getId());
     }
 }

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -104,7 +104,6 @@ class DataObjectFactoryTest extends TestCase
      *
      * @covers ::selectRequest()
      * @covers ::getBaseUri()
-     * @covers ::getEntriesSerializer()
      */
     public function testSelectRequest()
     {

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -50,6 +50,8 @@ abstract class ObjectTestBase extends TestCase
             $tests[$property->getName()] = [$property->getName()];
         }
 
+        unset($tests['customFields']);
+
         return $tests;
     }
 

--- a/tests/src/Unit/Encoder/CJsonEncoderTest.php
+++ b/tests/src/Unit/Encoder/CJsonEncoderTest.php
@@ -15,6 +15,7 @@ class CJsonEncoderTest extends TestCase
      *
      * @covers ::decode()
      * @covers ::decodeCustomFields()
+     * @covers ::decodeObject()
      */
     public function testDecodeCustomFields()
     {
@@ -44,5 +45,73 @@ class CJsonEncoderTest extends TestCase
                         ],
                 ],
             ], $decoded['customFields']);
+    }
+
+    public function testDecodeEntries()
+    {
+        $data = [
+            '$xmlns' => [
+                'prefix1' => 'http://example.com/ns1',
+                'prefix2' => 'http://example.com/ns2',
+            ],
+            'entries' => [
+                [
+                    'prefix1$kittens' => 'Highly recommended',
+                    'prefix2$puppies' => 'Also worth considering',
+                ],
+                [
+                    'prefix2$puppies' => 'Highly recommended',
+                    'prefix1$kittens' => 'Also worth considering',
+                ],
+            ],
+        ];
+
+        $encoder = new CJsonEncoder();
+        $decoded = $encoder->decode(json_encode($data), 'json');
+        $this->assertEquals(
+            [
+                '$xmlns' => [
+                    'prefix1' => 'http://example.com/ns1',
+                    'prefix2' => 'http://example.com/ns2',
+                ],
+                'entries' => [
+                    0 => [
+                        'prefix1$kittens' => 'Highly recommended',
+                        'prefix2$puppies' => 'Also worth considering',
+                        'customFields' => [
+                            0 => [
+                                'namespace' => 'http://example.com/ns1',
+                                'data' => [
+                                    'kittens' => 'Highly recommended',
+                                ],
+                            ],
+                            1 => [
+                                'namespace' => 'http://example.com/ns2',
+                                'data' => [
+                                    'puppies' => 'Also worth considering',
+                                ],
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        'prefix2$puppies' => 'Highly recommended',
+                        'prefix1$kittens' => 'Also worth considering',
+                        'customFields' => [
+                            0 => [
+                                'namespace' => 'http://example.com/ns1',
+                                'data' => [
+                                    'kittens' => 'Also worth considering',
+                                ],
+                            ],
+                            1 => [
+                                'namespace' => 'http://example.com/ns2',
+                                'data' => [
+                                    'puppies' => 'Highly recommended',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], $decoded);
     }
 }

--- a/tests/src/Unit/Encoder/CJsonEncoderTest.php
+++ b/tests/src/Unit/Encoder/CJsonEncoderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Encoder;
+
+use Lullabot\Mpx\Encoder\CJsonEncoder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Lullabot\Mpx\Encoder\CJsonEncoder
+ */
+class CJsonEncoderTest extends TestCase
+{
+    /**
+     * Tests decoding custom fields into their own key.
+     *
+     * @covers ::decode()
+     * @covers ::decodeCustomFields()
+     */
+    public function testDecodeCustomFields()
+    {
+        $data = [
+            '$xmlns' => [
+                'prefix1' => 'http://example.com/ns1',
+                'prefix2' => 'http://example.com/ns2',
+            ],
+            'prefix1$kittens' => 'Highly recommended',
+            'prefix2$puppies' => 'Also worth considering',
+        ];
+
+        $encoder = new CJsonEncoder();
+        $decoded = $encoder->decode(json_encode($data), 'json');
+        $this->assertEquals(
+            [
+                [
+                    'namespace' => 'http://example.com/ns1',
+                    'data' => [
+                            'kittens' => 'Highly recommended',
+                        ],
+                ],
+                [
+                    'namespace' => 'http://example.com/ns2',
+                    'data' => [
+                            'puppies' => 'Also worth considering',
+                        ],
+                ],
+            ], $decoded['customFields']);
+    }
+}

--- a/tests/src/Unit/Encoder/CJsonEncoderTest.php
+++ b/tests/src/Unit/Encoder/CJsonEncoderTest.php
@@ -32,17 +32,17 @@ class CJsonEncoderTest extends TestCase
         $decoded = $encoder->decode(json_encode($data), 'json');
         $this->assertEquals(
             [
-                [
+                'http://example.com/ns1' => [
                     'namespace' => 'http://example.com/ns1',
                     'data' => [
-                            'kittens' => 'Highly recommended',
-                        ],
+                        'kittens' => 'Highly recommended',
+                    ],
                 ],
-                [
+                'http://example.com/ns2' => [
                     'namespace' => 'http://example.com/ns2',
                     'data' => [
-                            'puppies' => 'Also worth considering',
-                        ],
+                        'puppies' => 'Also worth considering',
+                    ],
                 ],
             ], $decoded['customFields']);
     }
@@ -79,13 +79,13 @@ class CJsonEncoderTest extends TestCase
                         'prefix1$kittens' => 'Highly recommended',
                         'prefix2$puppies' => 'Also worth considering',
                         'customFields' => [
-                            0 => [
+                            'http://example.com/ns1' => [
                                 'namespace' => 'http://example.com/ns1',
                                 'data' => [
                                     'kittens' => 'Highly recommended',
                                 ],
                             ],
-                            1 => [
+                            'http://example.com/ns2' => [
                                 'namespace' => 'http://example.com/ns2',
                                 'data' => [
                                     'puppies' => 'Also worth considering',
@@ -97,13 +97,13 @@ class CJsonEncoderTest extends TestCase
                         'prefix2$puppies' => 'Highly recommended',
                         'prefix1$kittens' => 'Also worth considering',
                         'customFields' => [
-                            0 => [
+                            'http://example.com/ns1' => [
                                 'namespace' => 'http://example.com/ns1',
                                 'data' => [
                                     'kittens' => 'Also worth considering',
                                 ],
                             ],
-                            1 => [
+                            'http://example.com/ns2' => [
                                 'namespace' => 'http://example.com/ns2',
                                 'data' => [
                                     'puppies' => 'Highly recommended',

--- a/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Normalizer;
+
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+use Lullabot\Mpx\DataService\DiscoveredCustomField;
+use Lullabot\Mpx\DataService\Media\Media;
+use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\Normalizer\CustomFieldsNormalizer;
+use Lullabot\Mpx\Normalizer\MissingCustomFieldsClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Tests denormalizing custom fields.
+ *
+ * @coversDefaultClass \Lullabot\Mpx\Normalizer\CustomFieldsNormalizer
+ */
+class CustomFieldsNormalizerTest extends TestCase
+{
+    /**
+     * Tests denormalizing custom data from a single namespace.
+     *
+     * @covers ::__construct()
+     * @covers ::denormalize()
+     */
+    public function testDenormalize()
+    {
+        $data = [
+            'namespace' => 'http://example.com/ns1',
+            'data' => [
+                'kittens' => 'Highly recommended',
+            ],
+        ];
+
+        $annotation = new CustomField();
+        $annotation->namespace = 'http://example.com/ns1';
+        $annotation->objectType = 'Media';
+        $annotation->service = 'Media Data Service';
+
+        $normalizer = new CustomFieldsNormalizer([
+            $annotation->namespace => new DiscoveredCustomField(DummyCustomFields::class, $annotation),
+        ]);
+
+        /** @var SerializerInterface|MockObject|DenormalizerInterface $serializer */
+        $serializer = $this->getMockBuilder([SerializerInterface::class, DenormalizerInterface::class])
+            ->getMock();
+        $serializer->expects($this->once())->method('denormalize')
+            ->with($data['data'], DummyCustomFields::class)
+            ->willReturn(new DummyCustomFields());
+        $normalizer->setSerializer($serializer);
+
+        $object = $normalizer->denormalize($data, Media::class, 'json');
+        $this->assertInstanceOf(DummyCustomFields::class, $object);
+    }
+
+    /**
+     * Tests when an appropriate serializer has not been injected.
+     *
+     * @covers ::denormalize()
+     */
+    public function testNotDeormalizable()
+    {
+        $annotation = new CustomField();
+        $annotation->namespace = 'http://example.com/ns1';
+        $annotation->objectType = 'Media';
+        $annotation->service = 'Media Data Service';
+        $normalizer = new CustomFieldsNormalizer([
+            $annotation->namespace => new DiscoveredCustomField(DummyCustomFields::class, $annotation),
+        ]);
+        $data = [
+            'namespace' => 'http://example.com/ns1',
+            'data' => [
+                'kittens' => 'Highly recommended',
+            ],
+        ];
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot denormalize class "Lullabot\Mpx\DataService\Media\Media" because injected serializer is not a denormalizer');
+        $object = $normalizer->denormalize($data, Media::class, 'json');
+    }
+
+    /**
+     * Tests when no custom field class is available.
+     *
+     * @covers ::denormalize()
+     */
+    public function testMissingCustomFieldsClass()
+    {
+        $normalizer = new CustomFieldsNormalizer([]);
+        $data = [
+            'namespace' => 'http://example.com/ns1',
+            'data' => [
+                'kittens' => 'Highly recommended',
+            ],
+        ];
+        $object = $normalizer->denormalize($data, Media::class, 'json');
+        $this->assertInstanceOf(MissingCustomFieldsClass::class, $object);
+    }
+
+    /**
+     * Tests in what cases this is a valid normalizer.
+     *
+     * @covers ::supportsDenormalization()
+     */
+    public function testSupportsDenormalization()
+    {
+        $normalizer = new CustomFieldsNormalizer([]);
+        $this->assertTrue($normalizer->supportsDenormalization([], CustomFieldInterface::class));
+        $this->assertFalse($normalizer->supportsDenormalization([], static::class));
+    }
+}
+
+class DummyCustomFields extends ObjectBase implements CustomFieldInterface
+{
+}


### PR DESCRIPTION
This PR resolves #92 .

The goal is straightforward; custom fields should be discoverable to developers in IDEs and treated as much as like regular fields as possible. However, there's a few complexities:

- Each object can have one or more namespaces of fields attached to it, and those namespaces may share property names. We can't just flatten them directly into an object like Media.
- Namespace prefixes may change between requests, if a specific namespace prefix has not been set with the custom fields configuration. There's no guarantee that a prefix of `pl1` is consistent between requests.
- The format mpx returns custom fields in does not match what the Symfony serializer expects. If namespace prefixes were consistent, we could implement a type extractor for them as root-level properties, but since they aren't we need to store them in a subobject. Luckily, the CJsonEncoder is the perfect spot to alter this incoming data.

I have this working with production data with custom fields; ping me if you want to see a demo of that.

TODOs:

- [x] If custom fields are set in mpx, but no class is available to contain those fields, we currently fail with an undefined index. I think we need to add a default "UnimplementedCustomFields" class to handle these cases.
- [x] Update the README with docs on how to implement custom fields.
- [x] Update the CHANGELOG, especially noting we made `deserialize` protected.