### PR TITLE
Create 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2018-05-16
 
 ### Added
 


### PR DESCRIPTION
We deleted the fix-nextlist branch, and media_mpx should really point to a tag anyways.