### PR TITLE
Add a method / interface for fetching the raw JSON response

### DIFF
--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -105,7 +105,7 @@ class DataObjectFactory
      * @param string $data  The JSON string to deserialize.
      * @param string $class The full class name to create.
      *
-     * @return IdInterface
+     * @return mixed An object matching the $class parameter.
      */
     protected function deserialize($data, string $class)
     {

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -126,7 +126,13 @@ class DataObjectFactory
         $p = new PropertyInfoExtractor([], [$dataServiceExtractor], [], []);
         $cached = new PropertyInfoCacheExtractor($p, $this->cacheItemPool);
 
-        return $this->getObjectSerializer($cached)->deserialize($data, $class, 'json');
+        $object = $this->getObjectSerializer($cached)->deserialize($data, $class, 'json');
+
+        if ($object instanceof JsonInterface) {
+            $object->setJson($data);
+        }
+
+        return $object;
     }
 
     /**

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -207,28 +207,42 @@ class DataObjectFactory
 
         $request = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
             function (ResponseInterface $response) use ($byFields, $account) {
-                $data = $response->getBody();
-
-                /** @var ObjectList $list */
-                $list = $this->deserialize($data, ObjectList::class);
-
-                // Set the json representation of each entry in the list.
-                $decoded = \GuzzleHttp\json_decode($data, true);
-                foreach ($list as $index => $item) {
-                    $entry = $decoded['entries'][$index];
-                    if (isset($decoded['$xmlns'])) {
-                        $entry['$xmlns'] = $decoded['$xmlns'];
-                    }
-                    $item->setJson(\GuzzleHttp\json_encode($entry));
-                }
-                $list->setByFields($byFields);
-                $list->setDataObjectFactory($this, $account);
-
-                return $list;
+                return $this->deserializeObjectList($response, $byFields, $account);
             }
         );
 
         return $request;
+    }
+
+    /**
+     * Deserialize an object list response.
+     *
+     * @param ResponseInterface $response The response to deserialize.
+     * @param ByFields          $byFields The fields used to limit the response.
+     * @param IdInterface       $account  (optional) The account used to fetch the object list.
+     *
+     * @return ObjectList The deserialized list.
+     */
+    private function deserializeObjectList(ResponseInterface $response, ByFields $byFields, IdInterface $account = null): ObjectList
+    {
+        $data = $response->getBody();
+
+        /** @var ObjectList $list */
+        $list = $this->deserialize($data, ObjectList::class);
+
+        // Set the json representation of each entry in the list.
+        $decoded = \GuzzleHttp\json_decode($data, true);
+        foreach ($list as $index => $item) {
+            $entry = $decoded['entries'][$index];
+            if (isset($decoded['$xmlns'])) {
+                $entry['$xmlns'] = $decoded['$xmlns'];
+            }
+            $item->setJson(\GuzzleHttp\json_encode($entry));
+        }
+        $list->setByFields($byFields);
+        $list->setDataObjectFactory($this, $account);
+
+        return $list;
     }
 
     /**

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -211,6 +211,16 @@ class DataObjectFactory
 
                 /** @var ObjectList $list */
                 $list = $this->deserialize($data, ObjectList::class);
+
+                // Set the json representation of each entry in the list.
+                $decoded = \GuzzleHttp\json_decode($data, true);
+                foreach ($list as $index => $item) {
+                    $entry = $decoded['entries'][$index];
+                    if (isset($decoded['$xmlns'])) {
+                        $entry['$xmlns'] = $decoded['$xmlns'];
+                    }
+                    $item->setJson(\GuzzleHttp\json_encode($entry));
+                }
                 $list->setByFields($byFields);
                 $list->setDataObjectFactory($this, $account);
 

--- a/src/DataService/JsonInterface.php
+++ b/src/DataService/JsonInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Interface for objects supporting an attached JSON representation.
+ *
+ * There are times that client applications may need the original JSON response
+ * data. For example, when loading an object list, they may want to cache the
+ * results individually. In general, use the typed methods directly on each
+ * class instead of these methods.
+ */
+interface JsonInterface
+{
+    /**
+     * Set the original JSON representation of this object.
+     *
+     * @param string $json
+     */
+    public function setJson(string $json);
+
+    /**
+     * Return the JSON of this object as an array.
+     *
+     * @throws \LogicException Thrown if no json representation is available.
+     *
+     * @return array
+     */
+    public function getJson();
+}

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * Base class for common data used by all mpx objects.
  */
-abstract class ObjectBase implements ObjectInterface
+abstract class ObjectBase implements ObjectInterface, JsonInterface
 {
     /**
      * The date and time that this object was created.
@@ -41,6 +41,13 @@ abstract class ObjectBase implements ObjectInterface
      * @var CustomFieldInterface[]
      */
     protected $customFields;
+
+    /**
+     * The original JSON representation of this object.
+     *
+     * @var array
+     */
+    protected $json;
 
     /**
      * {@inheritdoc}
@@ -120,5 +127,25 @@ abstract class ObjectBase implements ObjectInterface
     public function setCustomFields(array $customFields)
     {
         $this->customFields = $customFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setJson(string $json)
+    {
+        $this->json = \GuzzleHttp\json_decode($json);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJson()
+    {
+        if (!$this->json) {
+            throw new \LogicException('This object has no original JSON representation available');
+        }
+
+        return $this->json;
     }
 }

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -134,7 +134,7 @@ abstract class ObjectBase implements ObjectInterface, JsonInterface
      */
     public function setJson(string $json)
     {
-        $this->json = \GuzzleHttp\json_decode($json);
+        $this->json = \GuzzleHttp\json_decode($json, true);
     }
 
     /**

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * Base class for common data used by all mpx objects.
  */
-abstract class ObjectBase implements ObjectInterface, JsonInterface
+abstract class ObjectBase implements ObjectInterface
 {
     /**
      * The date and time that this object was created.

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * Defines an interface object properties common to all mpx objects.
  */
-interface ObjectInterface extends IdInterface
+interface ObjectInterface extends IdInterface, JsonInterface
 {
     /**
      * Returns the date and time that this object was created.

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -12,7 +12,7 @@ use Lullabot\Mpx\DataService\Access\Account;
  * @see https://docs.theplatform.com/help/wsf-retrieving-data-objects#tp-toc11
  * @see https://docs.theplatform.com/help/wsf-cjson-format#cJSONformat-cJSONobjectlistpayloads
  */
-class ObjectList implements \ArrayAccess, \Iterator
+class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
 {
     /**
      * An array of namespaces in the results.
@@ -79,6 +79,13 @@ class ObjectList implements \ArrayAccess, \Iterator
      * @var Account
      */
     protected $account;
+
+    /**
+     * The original JSON of this object list.
+     *
+     * @var array
+     */
+    protected $json;
 
     /**
      * @return string[]
@@ -351,5 +358,25 @@ class ObjectList implements \ArrayAccess, \Iterator
     public function next()
     {
         ++$this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setJson(string $json)
+    {
+        $this->json = \GuzzleHttp\json_encode($json);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJson()
+    {
+        if (!$this->json) {
+            throw new \LogicException('This object has no original JSON representation available');
+        }
+
+        return $this->json;
     }
 }

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -365,7 +365,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      */
     public function setJson(string $json)
     {
-        $this->json = \GuzzleHttp\json_encode($json);
+        $this->json = \GuzzleHttp\json_decode($json);
     }
 
     /**

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -365,7 +365,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      */
     public function setJson(string $json)
     {
-        $this->json = \GuzzleHttp\json_decode($json);
+        $this->json = \GuzzleHttp\json_decode($json, true);
     }
 
     /**

--- a/tests/fixtures/media-object.json
+++ b/tests/fixtures/media-object.json
@@ -1,4 +1,8 @@
 {
+  "$xmlns": {
+    "prefix1": "http://www.example.com/xml"
+  },
+  "prefix1$series": "A series",
   "id": "http://data.media.theplatform.com/media/data/Media/2602559",
   "guid": "zYO7XMrWyix_9UCMurLYEWJPrWYHavMM",
   "title": "thePlatform's History",

--- a/tests/fixtures/select-media.json
+++ b/tests/fixtures/select-media.json
@@ -1,0 +1,375 @@
+{
+  "totalResults" : 1,
+  "$xmlns": {
+    "prefix1": "http://www.example.com/xml"
+  },
+  "entries" : [
+    {
+      "prefix1$series": "A series",
+      "id": "http://data.media.theplatform.com/media/data/Media/2602559",
+      "guid": "zYO7XMrWyix_9UCMurLYEWJPrWYHavMM",
+      "title": "thePlatform's History",
+      "author": "thePlatform",
+      "description": "Our CEO Ian Blaine discusses a bit of thePlatform's history",
+      "added": 1299622592000,
+      "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+      "updated": 1299624648000,
+      "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/58590342",
+      "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/58590342",
+      "version": 0,
+      "locked": false,
+      "availableDate": 1230796800000,
+      "expirationDate": 1609401600000,
+      "categories": [
+        {
+          "name": "thePlatform/Ian Blaine",
+          "scheme": "thePlatform",
+          "label": ""
+        },
+        {
+          "name": "Technology",
+          "scheme": "urn:cat-scheme",
+          "label": ""
+        }
+      ],
+      "copyright": "thePlatform",
+      "copyrightUrl": "http://theplatform.com/about/terms_of_service",
+      "credits": [
+        {
+          "role": "producer",
+          "scheme": "urn:ebu",
+          "value": "thePlatform"
+        },
+        {
+          "role": "director",
+          "scheme": "urn:ebu",
+          "value": "Steve Mack"
+        },
+        {
+          "role": "actor",
+          "scheme": "urn:ebu",
+          "value": "Ian Blaine"
+        },
+        {
+          "role": "author",
+          "scheme": "urn:ebu",
+          "value": "Melissa Tennant"
+        }
+      ],
+      "keywords": "thePlatform",
+      "ratings": [
+        {
+          "scheme": "urn:simple",
+          "rating": "non-adult"
+        }
+      ],
+      "countries": [
+        "cx"
+      ],
+      "excludeCountries": true,
+      "text": "",
+      "content": [
+        {
+          "audioChannels": 0,
+          "audioSampleRate": 0,
+          "bitrate": 30307523,
+          "checksums": {
+            "md5": "e2cac7082f0afc5f008c64a039880d27"
+          },
+          "contentType": "video",
+          "duration": 55.289,
+          "expression": "full",
+          "fileSize": 210243584,
+          "frameRate": 29.97,
+          "format": "AVI",
+          "height": 480,
+          "isDefault": false,
+          "language": "en",
+          "sourceTime": 0.0,
+          "url": "ftp://storage.theplatform.com/content/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+          "width": 720,
+          "id": "http://data.media.theplatform.com/media/data/MediaFile/2602561",
+          "guid": "qK6s9oXNUNkp7UP41_IV_QK5P2xmV3ml",
+          "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+          "added": 1299623075000,
+          "updated": 1299623887000,
+          "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "version": 1,
+          "locked": false,
+          "description": "",
+          "title": "ian_1_flexible_544309.avi",
+          "allowRelease": true,
+          "assetTypeIds": [
+            "http://data.media.theplatform.com/media/data/AssetType/2128951"
+          ],
+          "assetTypes": [
+            "mezzanine"
+          ],
+          "audioCodec": "",
+          "audioSampleSize": 0,
+          "downloadUrl": "",
+          "exists": true,
+          "failoverStreamingUrl": "",
+          "failoverSourceUrl": "",
+          "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+          "isProtected": false,
+          "isThumbnail": false,
+          "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+          "protectionKey": "",
+          "releases": [
+
+          ],
+          "serverId": "http://data.media.theplatform.com/media/data/Server/2600877",
+          "sourceMediaFileId": "",
+          "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/16/897/ian_1_flexible_544309.avi",
+          "storageUrl": "ftp://storage.theplatform.com/content/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_544309.avi",
+          "streamingUrl": "",
+          "transformId": "",
+          "videoCodec": "",
+          "approved": true,
+          "protectionScheme": "",
+          "aspectRatio": 1.5,
+          "previousLocations": [
+
+          ]
+        },
+        {
+          "audioChannels": 0,
+          "audioSampleRate": 0,
+          "bitrate": 600000,
+          "checksums": {
+            "md5": "26ac0a3e10717af6e7e881bddf73eef2"
+          },
+          "contentType": "video",
+          "duration": 55.333,
+          "expression": "full",
+          "fileSize": 4843251,
+          "frameRate": 0.0,
+          "format": "FLV",
+          "height": 420,
+          "isDefault": false,
+          "language": "en",
+          "sourceTime": 0.0,
+          "url": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+          "width": 560,
+          "id": "http://data.media.theplatform.com/media/data/MediaFile/2602603",
+          "guid": "d5xGaKF2JxmLf53QSL99DW4O6C8U6oni",
+          "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+          "added": 1299623178000,
+          "updated": 1299624648000,
+          "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "version": 1,
+          "locked": false,
+          "description": "",
+          "title": "ian_1_flexible.flv",
+          "allowRelease": true,
+          "assetTypeIds": [
+            "http://data.media.theplatform.com/media/data/AssetType/2128950"
+          ],
+          "assetTypes": [
+            "video"
+          ],
+          "audioCodec": "",
+          "audioSampleSize": 0,
+          "downloadUrl": "",
+          "exists": true,
+          "failoverStreamingUrl": "",
+          "failoverSourceUrl": "",
+          "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+          "isProtected": false,
+          "isThumbnail": false,
+          "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+          "protectionKey": "",
+          "releases": [
+            {
+              "id": "http://data.media.theplatform.com/media/data/Release/2602609",
+              "guid": "ZYmP6QQgCLz0OpNSoiJqnmNDmU_0nTyj",
+              "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+              "added": 1299624648000,
+              "updated": 1299624648000,
+              "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/9320345",
+              "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/9320345",
+              "version": 0,
+              "locked": false,
+              "description": "",
+              "approved": true,
+              "delivery": "streaming",
+              "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+              "fileId": "http://data.media.theplatform.com/media/data/MediaFile/2602603",
+              "pid": "UIYsTlf6Susa",
+              "parameters": "",
+              "url": "http://link.theplatform.com/s/MTYzMzY5NDE3/UIYsTlf6Susa",
+              "restrictionId": "",
+              "adPolicyId": ""
+            }
+          ],
+          "serverId": "http://data.media.theplatform.com/media/data/Server/2602560",
+          "sourceMediaFileId": "",
+          "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/226/426/ian_1_flexible.flv",
+          "storageUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+          "streamingUrl": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible.flv",
+          "transformId": "",
+          "videoCodec": "",
+          "approved": true,
+          "protectionScheme": "",
+          "aspectRatio": 1.33,
+          "previousLocations": [
+
+          ]
+        }
+      ],
+      "thumbnails": [
+        {
+          "audioChannels": 0,
+          "audioSampleRate": 0,
+          "bitrate": 0,
+          "checksums": {
+            "md5": "a9b5fdea0070fcabf0bbbabfd96f9036"
+          },
+          "contentType": "image",
+          "duration": 0.0,
+          "expression": "full",
+          "fileSize": 25819,
+          "frameRate": 0.0,
+          "format": "JPEG",
+          "height": 240,
+          "isDefault": true,
+          "language": "",
+          "sourceTime": 0.0,
+          "url": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+          "width": 320,
+          "id": "http://data.media.theplatform.com/media/data/MediaFile/2602653",
+          "guid": "D5JgEa2oXlnAdZ8jsKEpLXmYoRll8NV0",
+          "ownerId": "http://access.auth.theplatform.com/data/Account/55555",
+          "added": 1299623213000,
+          "updated": 1299624193000,
+          "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mpx/716262360",
+          "version": 1,
+          "locked": false,
+          "description": "",
+          "title": "ian_1_flexible_320x240.jpg",
+          "allowRelease": true,
+          "assetTypeIds": [
+            "http://data.media.theplatform.com/media/data/AssetType/2128952"
+          ],
+          "assetTypes": [
+            "thumbnail"
+          ],
+          "audioCodec": "",
+          "audioSampleSize": 0,
+          "downloadUrl": "",
+          "exists": true,
+          "failoverStreamingUrl": "",
+          "failoverSourceUrl": "",
+          "filePath": "thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+          "isProtected": false,
+          "isThumbnail": true,
+          "mediaId": "http://data.media.theplatform.com/media/data/Media/2602559",
+          "protectionKey": "",
+          "releases": [
+
+          ],
+          "serverId": "http://data.media.theplatform.com/media/data/Server/2602560",
+          "sourceMediaFileId": "",
+          "sourceUrl": "ftp://ftp2.edgecastcdn.net/mps/thePlatform_Documentation/226/426/ian_1_flexible_320x240.jpg",
+          "storageUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+          "streamingUrl": "http://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+          "transformId": "",
+          "videoCodec": "",
+          "approved": true,
+          "protectionScheme": "",
+          "aspectRatio": 1.33,
+          "previousLocations": [
+
+          ]
+        }
+      ],
+      "adminTags": [
+        "corp site content"
+      ],
+      "approved": true,
+      "categoryIds": [
+        "http://data.media.theplatform.com/media/data/Category/2127592",
+        "http://data.media.theplatform.com/media/data/Category/2127590"
+      ],
+      "chapters": [
+        {
+          "startTime": 0.0,
+          "endTime": 21.8,
+          "title": "Chapter 1",
+          "thumbnailUrl": ""
+        },
+        {
+          "startTime": 21.9,
+          "endTime": 55.0,
+          "title": "Chapter 2",
+          "thumbnailUrl": ""
+        }
+      ],
+      "link": "http://www.theplatform.com/about/",
+      "pubDate": 1256661120000,
+      "titleLocalized": {
+        "en-us": "thePlatform's History",
+        "es-mx": "Historia de thePlatform"
+      },
+      "descriptionLocalized": {
+
+      },
+      "authorLocalized": {
+
+      },
+      "copyrightLocalized": {
+
+      },
+      "copyrightUrlLocalized": {
+
+      },
+      "keywordsLocalized": {
+
+      },
+      "linkLocalized": {
+
+      },
+      "textLocalized": {
+
+      },
+      "defaultThumbnailUrl": "ftp://winnas01.theplatform.com/Content/Video/thePlatform_Documentation_-_SA/3/494/ian_1_flexible_320x240.jpg",
+      "originalOwnerIds": [
+
+      ],
+      "provider": "",
+      "providerId": "",
+      "restrictionId": "",
+      "adPolicyId": "",
+      "programId": "",
+      "seriesId": "",
+      "availabilityState": "available",
+      "pid": "Zy1n9JQPy6hw",
+      "publicUrl": "",
+      "availabilityTags": [
+      ],
+      "availabilityWindows": [
+        {
+          "targetAvailableDate": 1430722800000,
+          "targetExpirationDate": 1431932400000,
+          "targetAvailabilityTags": ["desktop"]
+        },
+        {
+          "targetAvailableDate": 1430722800000,
+          "targetAvailabilityTags": ["mobile"]
+        }
+      ],
+      "fileSourceMediaId": "http://example.com/reserved-for-future-use",
+      "originalMediaIds": [
+        "http://example.com/media-url"
+      ]
+    }
+  ],
+  "startIndex" : 1,
+  "entryCount" : 1,
+  "itemsPerPage" : 1
+}
+

--- a/tests/src/Functional/DataService/Access/AccountQueryTest.php
+++ b/tests/src/Functional/DataService/Access/AccountQueryTest.php
@@ -33,7 +33,14 @@ class AccountQueryTest extends FunctionalTestBase
 
             // Loading the object by itself.
             $reload = $dof->load($result->getId());
-            $this->assertEquals($result, $reload->wait());
+            $item = $reload->wait();
+
+            // We need to override the JSON strings. While the strings may be
+            // functionally identical, the namespace prefixes in the responses
+            // can change between requests.
+            $result->setJson('{}');
+            $item->setJson('{}');
+            $this->assertEquals($result, $item);
             if ($index + 1 > 2) {
                 break;
             }

--- a/tests/src/Functional/DataService/Media/MediaQueryTest.php
+++ b/tests/src/Functional/DataService/Media/MediaQueryTest.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx\Tests\Functional\DataService\Media;
 use Lullabot\Mpx\DataService\ByFields;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\ObjectInterface;
 use Lullabot\Mpx\DataService\ObjectList;
 use Lullabot\Mpx\DataService\Range;
 use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
@@ -34,7 +35,15 @@ class MediaQueryTest extends FunctionalTestBase
 
             // Loading the object by itself.
             $reload = $dof->load($result->getId());
-            $this->assertEquals($result, $reload->wait());
+            /** @var ObjectInterface $item */
+            $item = $reload->wait();
+
+            // We need to override the JSON strings. While the strings may be
+            // functionally identical, the namespace prefixes in the responses
+            // can change between requests.
+            $result->setJson('{}');
+            $item->setJson('{}');
+            $this->assertEquals($result, $item);
             if ($index + 1 > 2) {
                 break;
             }
@@ -70,7 +79,14 @@ class MediaQueryTest extends FunctionalTestBase
 
             // Loading the object by itself.
             $reload = $dof->load($result->getId());
-            $this->assertEquals($result, $reload->wait());
+            $item = $reload->wait();
+
+            // We need to override the JSON strings. While the strings may be
+            // functionally identical, the namespace prefixes in the responses
+            // can change between requests.
+            $result->setJson('{}');
+            $item->setJson('{}');
+            $this->assertEquals($result, $item);
         }
     }
 }

--- a/tests/src/Functional/DataService/Player/PlayerQueryTest.php
+++ b/tests/src/Functional/DataService/Player/PlayerQueryTest.php
@@ -33,7 +33,14 @@ class PlayerQueryTest extends FunctionalTestBase
 
             // Loading the object by itself.
             $reload = $dof->load($result->getId());
-            $this->assertEquals($result, $reload->wait());
+            $item = $reload->wait();
+
+            // We need to override the JSON strings. While the strings may be
+            // functionally identical, the namespace prefixes in the responses
+            // can change between requests.
+            $result->setJson('{}');
+            $item->setJson('{}');
+            $this->assertEquals($result, $item);
             if ($index + 1 > 2) {
                 break;
             }

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -105,6 +105,7 @@ class DataObjectFactoryTest extends TestCase
      *
      * @covers ::selectRequest
      * @covers ::getBaseUri
+     * @covers ::deserializeObjectList
      */
     public function testSelectRequest()
     {
@@ -137,6 +138,7 @@ class DataObjectFactoryTest extends TestCase
      *
      * @covers ::selectRequest
      * @covers ::getBaseUri
+     * @covers ::deserializeObjectList
      */
     public function testSelectRequestNS()
     {

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -126,7 +126,7 @@ class DataObjectFactoryTest extends TestCase
         $this->assertEquals(1, $objectList->getItemsPerPage());
         $this->assertEquals(1, $objectList->getStartIndex());
         $this->assertEquals(1, $objectList->getTotalResults());
-        $account = $objectList->current();
+        $account = $objectList[0];
         $this->assertInstanceOf(Account::class, $account);
         $this->assertEquals('http://access.auth.theplatform.com/data/Account/55555', $account->getId());
     }

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -43,10 +43,9 @@ class DataObjectFactoryTest extends TestCase
         $service = $manager->getDataService('Media Data Service', 'Media', '1.10');
         $client = $this->getMockClient([
             new JsonResponse(200, [], 'signin-success.json'),
-            new JsonResponse(200, [], 'resolveDomain.json'),
             function (\Psr\Http\Message\RequestInterface $request) {
                 $this->assertEquals('https', $request->getUri()->getScheme());
-                $this->assertEquals('/media/data/Media/12345', $request->getUri()->getPath());
+                $this->assertEquals('/media/data/Media/2602559', $request->getUri()->getPath());
 
                 return new JsonResponse(200, [], 'media-object.json');
             },
@@ -61,8 +60,10 @@ class DataObjectFactoryTest extends TestCase
 
         $account = new Account();
         $account->setId(new Uri('http://example.com/1'));
-        $media = $factory->load(new Uri('http://data.media.theplatform.com/media/data/Media/12345'))->wait();
+        $id = new Uri('http://data.media.theplatform.com/media/data/Media/2602559');
+        $media = $factory->load($id)->wait();
         $this->assertInstanceOf(Media::class, $media);
+        $this->assertEquals($id, $media->getId());
     }
 
     /**

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -131,7 +131,8 @@ class DataObjectFactoryTest extends TestCase
         $this->assertInstanceOf(Account::class, $account);
         $this->assertEquals('http://access.auth.theplatform.com/data/Account/55555', $account->getId());
     }
-/**
+
+    /**
      * Tests setting the namespace on subentries JSON representation.
      *
      * @covers ::selectRequest

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -241,7 +241,7 @@ class ObjectListTest extends TestCase
         $this->list->setStartIndex(30);
         $this->list->setEntryCount(10);
         $this->list->setItemsPerPage(10);
-        $this->list->setTotalResults(30);
+        $this->list->setTotalResults(50);
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -280,4 +280,23 @@ class ObjectListTest extends TestCase
         $this->expectExceptionMessage('setByFields must be called before calling nextList.');
         $this->list->yieldLists()->current();
     }
+
+    /**
+     * Test setting the JSON representation.
+     */
+    public function testGetJson()
+    {
+        $json = ['key' => 'value'];
+        $this->list->setJson(json_encode($json));
+        $this->assertEquals($json, $this->list->getJson());
+    }
+
+    /**
+     * Test an exception is thrown when no JSON is available.
+     */
+    public function testNoJson()
+    {
+        $this->expectException(\LogicException::class);
+        $this->list->getJson();
+    }
 }

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -256,4 +256,28 @@ class ObjectListTest extends TestCase
             }
         }
     }
+
+    /**
+     * Tests when no data object factory is set.
+     */
+    public function testNoDataObjectFactory()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('setDataObjectFactory must be called before calling nextList.');
+        $this->list->yieldLists()->current();
+    }
+
+    /**
+     * Tests when no ByFields object is set.
+     */
+    public function testNoByFields()
+    {
+        /** @var DataObjectFactory $dof */
+        $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
+        $account = new Account();
+        $this->list->setDataObjectFactory($dof, $account);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('setByFields must be called before calling nextList.');
+        $this->list->yieldLists()->current();
+    }
 }

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -51,6 +51,7 @@ abstract class ObjectTestBase extends TestCase
         }
 
         unset($tests['customFields']);
+        unset($tests['json']);
 
         return $tests;
     }


### PR DESCRIPTION
In adding HTTP-response level caching to the Drupal module, I realized two things:

1. There was no easy way to get the response body of an object for caching.
2. We needed some way to support taking a list of results, but then caching them as if each individual item had been requested individually.

This PR enables both, by including the JSON response on each object.

Currently, I'm writing response caching in the Drupal module. However, once I'm happy with it and it hasn't changed much, I'd like to pull it into the library. That way, these JSON methods won't be needed - but will be available so downstream authors aren't ever required to do double-http requests or serialization to get the JSON representation.