### PR TITLE
Support Link and Image types

### DIFF
--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -5,6 +5,8 @@ namespace Lullabot\Mpx\Command;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\Client;
+use Lullabot\Mpx\DataService\DataType\Image;
+use Lullabot\Mpx\DataService\DataType\Link;
 use Lullabot\Mpx\DataService\ObjectListQuery;
 use Lullabot\Mpx\DataService\CustomFieldInterface;
 use Lullabot\Mpx\DataService\DataObjectFactory;
@@ -37,9 +39,9 @@ class CreateCustomFieldClassCommand extends Command {
         'DateTime' => '\\' . \DateTime::class,
         'Duration' => 'int',
         'Decimal' => 'float',
-        'Image' => '\\' . UriInterface::class,
+        'Image' => '\\' . Image::class,
         'Integer' => 'int',
-        'Link' => '\\' . UriInterface::class,
+        'Link' => '\\' . Link::class,
         'String' => 'string',
         'Time' => '\\' . \DateTime::class,
         'URI' => '\\' . UriInterface::class,

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -185,7 +185,9 @@ EOD;
             $classType = reset($array);
             $classFile = new StreamOutput(fopen($classType->getName().'.php', 'w'));
             $classFile->write("<?php\n\n");
-            $classFile->write((string) $namespaceClass);
+            // Replace extra newlines until php-generator supports it.
+            // @see https://github.com/nette/php-generator/pull/30
+            $classFile->write(str_replace("\n\n\n", "\n\n", (string) $namespaceClass));
             fclose($classFile->getStream());
         }
     }

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -175,7 +175,7 @@ EOD;
                 $set->addComment('Set ' . lcfirst($field->getDescription()));
                 $set->addComment('');
             }
-            $set->addComment('@param ' . $field->getDataType());
+            $set->addComment('@param ' . static::TYPE_MAP[$field->getDataType()]);
             $set->addParameter($field->getFieldName());
             $set->addBody('$this->' . $field->getFieldName() . ' = ' . '$' . $field->getFieldName() . ';');
         }

--- a/src/DataService/DataType/Image.php
+++ b/src/DataService/DataType/Image.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\DataType;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Represents a Link to an Image.
+ *
+ * @see https://docs.theplatform.com/help/wsf-index-of-supported-data-types#tp-toc9
+ */
+class Image extends Link
+{
+    /**
+     * @var UriInterface
+     */
+    protected $anchorHref;
+
+    /**
+     * @return UriInterface
+     */
+    public function getAnchorHref(): UriInterface
+    {
+        return $this->anchorHref;
+    }
+
+    /**
+     * @param UriInterface $anchorHref
+     */
+    public function setAnchorHref(UriInterface $anchorHref)
+    {
+        $this->anchorHref = $anchorHref;
+    }
+}

--- a/src/DataService/DataType/Link.php
+++ b/src/DataService/DataType/Link.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\DataType;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Represents a URL along with a target, title, and mime type.
+ *
+ * @see https://docs.theplatform.com/help/wsf-index-of-supported-data-types#tp-toc7
+ */
+class Link
+{
+    /**
+     * @var UriInterface
+     */
+    protected $href;
+
+    /**
+     * @var string
+     */
+    protected $target;
+
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @return UriInterface
+     */
+    public function getHref(): UriInterface
+    {
+        return $this->href;
+    }
+
+    /**
+     * @param UriInterface $href
+     */
+    public function setHref(UriInterface $href)
+    {
+        $this->href = $href;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    /**
+     * @param string $target
+     */
+    public function setTarget(string $target)
+    {
+        $this->target = $target;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType(string $type)
+    {
+        $this->type = $type;
+    }
+}

--- a/tests/src/Unit/DataService/DataType/ImageTest.php
+++ b/tests/src/Unit/DataService/DataType/ImageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\DataType;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\DataType\Image;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\DataService\DataType\Image
+ */
+class ImageTest extends TestCase
+{
+    /**
+     * Tests all basic get / set properties.
+     *
+     * @param string $property
+     * @param string $value
+     * @dataProvider getSetMethodDataProvider
+     */
+    public function testGetSet($property, $value)
+    {
+        $get = 'get'.ucfirst($property);
+        $set = 'set'.ucfirst($property);
+        $link = new Image();
+        $link->$set($value);
+        $this->assertSame($value, $link->$get());
+    }
+
+    public function getSetMethodDataProvider()
+    {
+        return [
+            'href' => [
+                'href',
+                new Uri('http://www.example.com'),
+            ],
+            'target' => [
+                'target',
+                '_blank',
+            ],
+            'title' => [
+                'title',
+                'link title',
+            ],
+            'mime type' => [
+                'type',
+                'text/html',
+            ],
+            'anchor href' => [
+                'anchorHref',
+                new Uri('http://www.example.com'),
+            ],
+        ];
+    }
+}

--- a/tests/src/Unit/DataService/DataType/LinkTest.php
+++ b/tests/src/Unit/DataService/DataType/LinkTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\DataType;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\DataType\Link;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\DataService\DataType\Link
+ */
+class LinkTest extends TestCase
+{
+    /**
+     * Tests all basic get / set properties.
+     *
+     * @param string $property
+     * @param string $value
+     * @dataProvider getSetMethodDataProvider
+     */
+    public function testGetSet($property, $value)
+    {
+        $get = 'get'.ucfirst($property);
+        $set = 'set'.ucfirst($property);
+        $link = new Link();
+        $link->$set($value);
+        $this->assertSame($value, $link->$get());
+    }
+
+    public function getSetMethodDataProvider()
+    {
+        return [
+            'href' => [
+                'href',
+                new Uri('http://www.example.com'),
+            ],
+            'target' => [
+                'target',
+                '_blank',
+            ],
+            'title' => [
+                'title',
+                'link title',
+            ],
+            'mime type' => [
+                'type',
+                'text/html',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR supports Link and Image data types, which are used in custom fields (but not in core mpx fields AFAICT). This also fixes some small bugs in the code generator for custom field classes.

https://github.com/nette/php-generator/pull/30 is the upstream issue for double-spaces between methods.

Resolves #130 .