### PR TITLE
Always load custom fields in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Changed
+
+- `\Lullabot\Mpx\DataService\ObjectInterface::getCustomFields()` now returns
+  an array of all custom field classes and does not take a namespace
+  parameter. #135
+- A custom field class is loaded in objects even if the response data does not
+  contain any fields in that namespace. #135
+
 ## [0.5.0] - 2018-06-21
 
 ### Added

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -128,6 +128,28 @@ class DataObjectFactory
 
         $object = $this->getObjectSerializer($cached)->deserialize($data, $class, 'json');
 
+        // Adds any missing custom field classes. A given object may not
+        // contain any set fields in a given custom field namespace. In that
+        // case, the serializer will never create a field class. This is fine
+        // until calling code wants to check to see if a given field exists.
+        // By ensuring we add in any missing custom field definitions, we
+        // ensure a valid object is returned instead of null.
+        if ($object instanceof ObjectInterface) {
+            $customFields = $object->getCustomFields();
+            $remaining = array_diff_key($this->dataService->getCustomFields(), $customFields);
+
+            /**
+             * @var string
+             * @var DiscoveredCustomField $field
+             */
+            foreach ($remaining as $namespace => $field) {
+                $namespaceClass = $field->getClass();
+                $customFields[$namespace] = new $namespaceClass();
+            }
+
+            $object->setCustomFields($customFields);
+        }
+
         if ($object instanceof JsonInterface) {
             $object->setJson($data);
         }
@@ -170,9 +192,10 @@ class DataObjectFactory
     /**
      * Query for MPX data using with parameters.
      *
-     * @param ObjectListQuery $objectListQuery (optional) The fields and values to filter by. Note these are exact matches.
-     * @param IdInterface     $account         (optional) The account context to use in the request. Defaults to the account
-     *                                         associated with the authenticated client.
+     * @param ObjectListQuery $objectListQuery (optional) The fields and values to filter by. Note these are exact
+     *                                         matches.
+     * @param IdInterface     $account         (optional) The account context to use in the request. Defaults to the
+     *                                         account associated with the authenticated client.
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
@@ -186,9 +209,10 @@ class DataObjectFactory
      *
      * @see \Lullabot\Mpx\DataService\DataObjectFactory::select
      *
-     * @param ObjectListQuery $objectListQuery (optional) The fields and values to filter by. Note these are exact matches.
-     * @param IdInterface     $account         (optional) The account context to use in the request. Note that most requests require
-     *                                         an account context.
+     * @param ObjectListQuery $objectListQuery (optional) The fields and values to filter by. Note these are exact
+     *                                         matches.
+     * @param IdInterface     $account         (optional) The account context to use in the request. Note that most
+     *                                         requests require an account context.
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -138,10 +138,8 @@ class DataObjectFactory
             $customFields = $object->getCustomFields();
             $remaining = array_diff_key($this->dataService->getCustomFields(), $customFields);
 
-            /**
-             * @var string $namespace
-             * @var DiscoveredCustomField $field
-             */
+            /** @var string $namespace */
+            /** @var DiscoveredCustomField $field */
             foreach ($remaining as $namespace => $field) {
                 $namespaceClass = $field->getClass();
                 $customFields[$namespace] = new $namespaceClass();

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -139,7 +139,7 @@ class DataObjectFactory
             $remaining = array_diff_key($this->dataService->getCustomFields(), $customFields);
 
             /**
-             * @var string
+             * @var string $namespace
              * @var DiscoveredCustomField $field
              */
             foreach ($remaining as $namespace => $field) {

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -12,7 +12,7 @@ abstract class ObjectBase implements ObjectInterface
     /**
      * @var CustomFieldInterface[]
      */
-    protected $customFields;
+    protected $customFields = [];
 
     /**
      * The original JSON representation of this object.
@@ -24,9 +24,9 @@ abstract class ObjectBase implements ObjectInterface
     /**
      * {@inheritdoc}
      */
-    public function getCustomFields(string $namespace)
+    public function getCustomFields()
     {
-        return $this->customFields[$namespace];
+        return $this->customFields;
     }
 
     /**

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -69,11 +69,9 @@ interface ObjectInterface extends IdInterface, JsonInterface
     /**
      * Return custom fields attached to this object.
      *
-     * @param string $namespace The namespace of the fields to retrieve.
-     *
-     * @return CustomFieldInterface
+     * @return CustomFieldInterface[]
      */
-    public function getCustomFields(string $namespace);
+    public function getCustomFields();
 
     /**
      * Set the custom fields attached to this data object.

--- a/tests/src/Unit/DataService/CustomField/NeverUsedCustomField.php
+++ b/tests/src/Unit/DataService/CustomField/NeverUsedCustomField.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\CustomField;
+
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+
+/**
+ * Class NeverUsedCustomField.
+ *
+ * @CustomField(
+ *     namespace="http://www.example.com/never-used",
+ *     service="Media Data Service",
+ *     objectType="Media",
+ * )
+ */
+class NeverUsedCustomField implements CustomFieldInterface
+{
+    /**
+     * @var string
+     */
+    protected $neverUsed;
+
+    /**
+     * @return string
+     */
+    public function getNeverUsed(): ?string
+    {
+        return $this->neverUsed;
+    }
+
+    /**
+     * @param string $neverUsed
+     */
+    public function setNeverUsed(?string $neverUsed): void
+    {
+        $this->neverUsed = $neverUsed;
+    }
+}

--- a/tests/src/Unit/DataService/CustomField/SeriesCustomField.php
+++ b/tests/src/Unit/DataService/CustomField/SeriesCustomField.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\CustomField;
+
+use Lullabot\Mpx\DataService\Annotation\CustomField;
+use Lullabot\Mpx\DataService\CustomFieldInterface;
+
+/**
+ * Class SeriesCustomField.
+ *
+ * @CustomField(
+ *     namespace="http://www.example.com/xml",
+ *     service="Media Data Service",
+ *     objectType="Media",
+ * )
+ */
+class SeriesCustomField implements CustomFieldInterface
+{
+    /**
+     * @var string
+     */
+    protected $series;
+
+    /**
+     * @return string
+     */
+    public function getSeries(): ?string
+    {
+        return $this->series;
+    }
+
+    /**
+     * @param string $series
+     */
+    public function setSeries(?string $series): void
+    {
+        $this->series = $series;
+    }
+}

--- a/tests/src/Unit/ObjectBaseTest.php
+++ b/tests/src/Unit/ObjectBaseTest.php
@@ -25,7 +25,7 @@ class ObjectBaseTest extends TestCase
             'http://www.example.com/xml' => $this->createMock(CustomFieldInterface::class),
         ];
         $o->setCustomFields($customFields);
-        $this->assertEquals($customFields['http://www.example.com/xml'], $o->getCustomFields('http://www.example.com/xml'));
+        $this->assertEquals($customFields, $o->getCustomFields());
     }
 
     /**


### PR DESCRIPTION
This comes up if a Media object not only doesn't have a custom field value, but it doesn't have any other fields set in the whole custom field namespace. That means that no custom fields object is even created for that namespace, which leads to the null method calls in code working with custom fields.

This ensures that an empty custom field object is always created.