### PR TITLE
Fix not using the adapter's cache item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   parameter. #135
 - A custom field class is loaded in objects even if the response data does not
   contain any fields in that namespace. #135
+- Fix not using the adapter's cache item #137
 
 ## [0.5.0] - 2018-06-21
 

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -2,7 +2,6 @@
 
 namespace Lullabot\Mpx\Service\AccessManagement;
 
-use Cache\Adapter\Common\CacheItem;
 use Lullabot\Mpx\DataService\IdInterface;
 use Lullabot\Mpx\Normalizer\UriNormalizer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -58,7 +57,6 @@ class ResolveDomain extends ResolveBase
         $serializer = new Serializer($normalizers, $encoders);
 
         $resolved = $serializer->deserialize($response->getBody(), ResolveDomainResponse::class, 'json');
-        $item = new CacheItem($key);
         $item->set($resolved);
 
         // thePlatform provides no guidance on how long we can cache this for.

--- a/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
@@ -88,10 +88,9 @@ class ResolveDomainTest extends TestCase
 
         $cache->expects($this->once())->method('save');
 
-        $item->expects($this->at(0))->method('isHit')
-            ->willReturn(false);
-        $item->expects($this->at(1))->method('isHit')
-            ->willReturn(true);
+        $item->expects($this->exactly(2))->method('isHit')
+            ->willReturnOnConsecutiveCalls(false, true);
+        $item->expects($this->at(0))->method('set');
 
         $resolveDomain = new ResolveDomain($authenticatedClient, $cache);
 


### PR DESCRIPTION
I discovered that the Drupal module wasn't caching any `resolveDomain` responses. It comes down to these lines in Symfony's cache library:

`\Symfony\Component\Cache\Adapter\AbstractAdapter::save`:

```php
    public function save(CacheItemInterface $item)
    {
        if (!$item instanceof \Symfony\Component\Cache\CacheItem) {
            return false;
        }
```

At first, I thought this was an obvious bug - why force a specific concrete implementation? Git led me to this issue and comment thread:

https://github.com/symfony/symfony/pull/17408#discussion-diff-49962560

In other words, what Symfony is doing is OK by the spec (though confusing PHP-wise). CacheItems should only be created by calling `get()` on the cache adapter, which ensures it's a compatible object.