### PR TITLE
Support setting HTTP options in load requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+
+- Methods that load data from mpx now support passing in HTTP client options to
+  Guzzle. This is primarily useful for implementations wishing to pass custom
+  headers in the request, such as `Cache-Control: no-cache` to intermediate
+  proxies.
+
 ## [0.6.0] - 2018-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Methods that load data from mpx now support passing in HTTP client options to
   Guzzle. This is primarily useful for implementations wishing to pass custom
   headers in the request, such as `Cache-Control: no-cache` to intermediate
-  proxies.
+  proxies. #138
 
 ## [0.6.0] - 2018-07-05
 

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -159,9 +159,9 @@ class DataObjectFactory
     /**
      * Load an object from mpx.
      *
-     * @param \Psr\Http\Message\UriInterface $uri The URI to load from. This URI will always be converted to https,
-     *                                            making it safe to use directly from the ID of an mpx object.
-     * @param array           $options         (optional) An array of HTTP client options.
+     * @param \Psr\Http\Message\UriInterface $uri     The URI to load from. This URI will always be converted to https,
+     *                                                making it safe to use directly from the ID of an mpx object.
+     * @param array                          $options (optional) An array of HTTP client options.
      *
      * @return PromiseInterface A promise to return a \Lullabot\Mpx\DataService\ObjectInterface.
      */

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -84,17 +84,18 @@ class DataObjectFactory
      * @param int         $id       The numeric ID to load.
      * @param IdInterface $account
      * @param bool        $readonly (optional) Load from the read-only service.
+     * @param array       $options  (optional) An array of HTTP client options.
      *
      * @return PromiseInterface
      */
-    public function loadByNumericId(int $id, IdInterface $account = null, bool $readonly = false)
+    public function loadByNumericId(int $id, IdInterface $account = null, bool $readonly = false, array $options = [])
     {
         $annotation = $this->dataService->getAnnotation();
         $base = $this->getBaseUri($annotation, $account, $readonly);
 
         $uri = new Uri($base.'/'.$id);
 
-        return $this->load($uri);
+        return $this->load($uri, $options);
     }
 
     /**
@@ -160,18 +161,21 @@ class DataObjectFactory
      *
      * @param \Psr\Http\Message\UriInterface $uri The URI to load from. This URI will always be converted to https,
      *                                            making it safe to use directly from the ID of an mpx object.
+     * @param array           $options         (optional) An array of HTTP client options.
      *
      * @return PromiseInterface A promise to return a \Lullabot\Mpx\DataService\ObjectInterface.
      */
-    public function load(UriInterface $uri): PromiseInterface
+    public function load(UriInterface $uri, array $options = []): PromiseInterface
     {
         /** @var DataService $annotation */
         $annotation = $this->dataService->getAnnotation();
-        $options = [
-            'query' => [
-                'schema' => $annotation->schemaVersion,
-                'form' => 'cjson',
-            ],
+
+        if (!isset($options['query'])) {
+            $options['query'] = [];
+        }
+        $options['query'] = $options['query'] += [
+            'schema' => $annotation->schemaVersion,
+            'form' => 'cjson',
         ];
 
         if ('http' == $uri->getScheme()) {
@@ -194,10 +198,11 @@ class DataObjectFactory
      *                                         matches.
      * @param IdInterface     $account         (optional) The account context to use in the request. Defaults to the
      *                                         account associated with the authenticated client.
+     * @param array           $options         (optional) An array of HTTP client options.
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
-    public function select(ObjectListQuery $objectListQuery = null, IdInterface $account = null): ObjectListIterator
+    public function select(ObjectListQuery $objectListQuery = null, IdInterface $account = null, array $options = []): ObjectListIterator
     {
         return new ObjectListIterator($this->selectRequest($objectListQuery, $account));
     }
@@ -211,23 +216,27 @@ class DataObjectFactory
      *                                         matches.
      * @param IdInterface     $account         (optional) The account context to use in the request. Note that most
      *                                         requests require an account context.
+     * @param array           $options         (optional) An array of HTTP client options.
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */
-    public function selectRequest(ObjectListQuery $objectListQuery = null, IdInterface $account = null): PromiseInterface
+    public function selectRequest(ObjectListQuery $objectListQuery = null, IdInterface $account = null, array $options = []): PromiseInterface
     {
         if (!$objectListQuery) {
             $objectListQuery = new ObjectListQuery();
         }
 
         $annotation = $this->dataService->getAnnotation();
-        $options = [
-            'query' => $objectListQuery->toQueryParts() + [
+
+        if (!isset($options['query'])) {
+            $options['query'] = [];
+        }
+        $options['query'] = $options['query'] +
+            $objectListQuery->toQueryParts() + [
                 'schema' => $annotation->schemaVersion,
                 'form' => 'cjson',
                 'count' => true,
-            ],
-        ];
+            ];
 
         $uri = $this->getBaseUri($annotation, $account, true);
 


### PR DESCRIPTION
Implementations loading mpx objects may have a need to include custom headers in mpx requests. For example, some clients may be behind a proxy that force-caches mpx requests. Typically, to force a fresh load you would add the `Cache-Control: no-cache` header in the request. However, that isn't possible until this change is made.