### PR TITLE
Support the Feeds config object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- The FeedConfig object is now supported. #110
+
+## [0.6.2] - 2018-07-17
+
+### Added
+
 - Methods that load data from mpx now support passing in HTTP client options to
   Guzzle. This is primarily useful for implementations wishing to pass custom
   headers in the request, such as `Cache-Control: no-cache` to intermediate
   proxies. #138
 
+## [0.6.1] - 2018-07-05
 ## [0.6.0] - 2018-07-05
 
 ### Changed

--- a/command/csv/feedconfig-object.csv
+++ b/command/csv/feedconfig-object.csv
@@ -1,0 +1,43 @@
+FIELD NAME,ATTRIBUTES,DATA TYPE,DESCRIPTION
+adapterParameters,,String,The parameters that are passed to a custom feed adapter for processing at runtime
+added,,DateTime,The date and time that this object was created
+addedByUserId,,URI,The id of the user that created this object
+adminTags,,String[],The list of administrative workflow tags for the feed configuration
+adPolicyId,,URI,The id of the AdPolicythat is applied to the feed
+author,,String,The author of the feed content
+availableFields,,String[],The list of object fields that can be retrieved in a feed request. Feed clients can only request fields that are listed in this field
+baseQuery,,String,A filter applied to any items specified in the pinnedIds field and any items selected by the segmentQueriesfield
+cacheLifetime,,Duration,The minimum time that items in the cache are valid
+cacheRefreshStrategy,,String,The response behavior during a cache refresh
+defaultThumbnailAssetType,,String,The identifier for the default thumbnail for each item in the feed
+description,,String,The description of the feed
+disabled,,Boolean,Whether the feed is disabled
+endIndex,,Integer,The maximum number of items in the feed
+feedType,,String,The feed items' object type
+form,,String,The default format of the feed
+guid,,String,An alternate identifier for this object that is unique within the owning account
+id,,URI,The globally unique URI of this object
+itemLinkUrl,,String,The URL template that is used to create the value of each feed item's link field
+limitByAvailableDate,,Boolean,Whether to only include items that are currently available
+limitToApproved,,Boolean,Whether to only include items that are approved
+linkUrl,,String,The URL value of the feed's link field
+locked,,Boolean,Whether this object currently allows updates
+ownerId,,URI,The id of the account that owns this object
+pid,,URI Reference,The globally-unique public identifier that is used to request this feed
+pinnedIds,,Long[],"The IDs of specific items to include in the feed. These items are in addition to any selected by the segmentQueries field, and may be filtered by the baseQuery field"
+playerUrl,,String,The URL template that is used to create the value of each feed item's content.player.urlfield
+preferSortKeysOnSearch,,Boolean,Whether to use the sortKeys to sort items in the feed when a Q query is included in the FeedConfig or the feed request
+queryEngine,,String,The type of query engine used to retrieve the feed items
+releaseUrlParameters,,String,The list of key-value URL parameters that are appended to the feed item's content.urlfield
+restrictionId,,URI,The id of the Restriction that is applied to the feed
+schema,,String,The object schema version of the feed items
+segmentQueries,,String[],"A query used to select items for the feed. These items are in addition to any specified in the pinnedIds field, and may be filtered by the baseQuery field"
+sortKeys,,SortKey[],The list of fields and directions used to sort items in the feed
+subFeeds,,SubFeed[],"The sub feeds of the feed. Sub feeds contain all items of the specified SubFeed.feedType in the feed owner's account. Currently, only a Category sub feed of a Media feed is supported"
+thumbnailFilter,,String,The query or key names used to select the thumbnail files for each item in the feed
+title,,String,The title of the feed
+updated,,DateTime,The date and time this object was last modified
+updatedByUserId,,URI,The id of the user that last modified this object
+urlType,,UrlType,The type of URL that is returned in each feed item's content.urlfield
+validFeed,,Boolean,Whether to include the feed-level elements and any feed-level custom fields in the feed header
+version,,Long,"This object's modification version, used for optimistic locking"

--- a/command/csv/subfeed-object.csv
+++ b/command/csv/subfeed-object.csv
@@ -1,0 +1,9 @@
+FIELD NAME,ATTRIBUTES,DATA TYPE,DESCRIPTION
+adapterParameters,,String,"The parameters that are passed to a custom feed adapter for processing at runtime. For more information, see FeedConfig.adapterParameters."
+availableFields,,String[],"The list of object fields (that correspond to the SubFeed.feedType) that can be retrieved in a sub feed request. Feed clients can only request fields of the sub feed that are listed in this field. For more information, see FeedConfig.availableFields.
+To display a list of categories in an mpx Player, you must include the following category fields: fullTitle, id, label, order, parentId, and title."
+baseQuery,,String,Not currently used
+feedType,,String,The sub feed items' object type. This value must be unique within the FeedConfig.subFeedsarray. The only currently supported value is Category.
+form,,String,"The default format of the sub feed. For more information, see FeedConfig.form."
+limitByTitles,,String[],"The object titles that are included in the sub feed. For example, this can be used to limit a Category sub feed to a few specific categories. This array may contain a maximum of 2,000 titles. If this field is empty, all objects are returned."
+schema,,String,"The object schema version of the sub feed items. For more information, see FeedConfig.schema."

--- a/src/DataService/Feeds/FeedConfig.php
+++ b/src/DataService/Feeds/FeedConfig.php
@@ -1,0 +1,1189 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Feeds;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\Annotation\DataService;
+use Lullabot\Mpx\DataService\DateTime\NullDateTime;
+use Lullabot\Mpx\DataService\ObjectBase;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+
+/**
+ * FeedConfig represents the configuration of a feed.
+ *
+ * @see https://docs.theplatform.com/help/feeds-feedconfig-endpoint
+ *
+ * @DataService(
+ *     service="Feeds Data Service",
+ *     objectType="FeedConfig",
+ *     schemaVersion="2.2",
+ * )
+ */
+class FeedConfig extends ObjectBase implements PublicIdentifierInterface
+{
+    /**
+     * The parameters that are passed to a custom feed adapter for processing at runtime.
+     *
+     * @var string
+     */
+    protected $adapterParameters;
+
+    /**
+     * The date and time that this object was created.
+     *
+     * @var \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+     */
+    protected $added;
+
+    /**
+     * The id of the user that created this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $addedByUserId;
+
+    /**
+     * The list of administrative workflow tags for the feed configuration.
+     *
+     * @var string[]
+     */
+    protected $adminTags = [];
+
+    /**
+     * The id of the AdPolicythat is applied to the feed.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $adPolicyId;
+
+    /**
+     * The author of the feed content.
+     *
+     * @var string
+     */
+    protected $author;
+
+    /**
+     * The list of object fields that can be retrieved in a feed request. Feed clients can only request fields that are listed in this field.
+     *
+     * @var string[]
+     */
+    protected $availableFields = [];
+
+    /**
+     * A filter applied to any items specified in the pinnedIds field and any items selected by the segmentQueriesfield.
+     *
+     * @var string
+     */
+    protected $baseQuery;
+
+    /**
+     * The minimum time that items in the cache are valid.
+     *
+     * @var float
+     */
+    protected $cacheLifetime;
+
+    /**
+     * The response behavior during a cache refresh.
+     *
+     * @var string
+     */
+    protected $cacheRefreshStrategy;
+
+    /**
+     * The identifier for the default thumbnail for each item in the feed.
+     *
+     * @var string
+     */
+    protected $defaultThumbnailAssetType;
+
+    /**
+     * The description of the feed.
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * Whether the feed is disabled.
+     *
+     * @var bool
+     */
+    protected $disabled;
+
+    /**
+     * The maximum number of items in the feed.
+     *
+     * @var int
+     */
+    protected $endIndex;
+
+    /**
+     * The feed items' object type.
+     *
+     * @var string
+     */
+    protected $feedType;
+
+    /**
+     * The default format of the feed.
+     *
+     * @var string
+     */
+    protected $form;
+
+    /**
+     * An alternate identifier for this object that is unique within the owning account.
+     *
+     * @var string
+     */
+    protected $guid;
+
+    /**
+     * The globally unique URI of this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $id;
+
+    /**
+     * The URL template that is used to create the value of each feed item's link field.
+     *
+     * @var string
+     */
+    protected $itemLinkUrl;
+
+    /**
+     * Whether to only include items that are currently available.
+     *
+     * @var bool
+     */
+    protected $limitByAvailableDate;
+
+    /**
+     * Whether to only include items that are approved.
+     *
+     * @var bool
+     */
+    protected $limitToApproved;
+
+    /**
+     * The URL value of the feed's link field.
+     *
+     * @var string
+     */
+    protected $linkUrl;
+
+    /**
+     * Whether this object currently allows updates.
+     *
+     * @var bool
+     */
+    protected $locked;
+
+    /**
+     * The id of the account that owns this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $ownerId;
+
+    /**
+     * The globally-unique public identifier that is used to request this feed.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $pid;
+
+    /**
+     * The IDs of specific items to include in the feed. These items are in addition to any selected by the segmentQueries field, and may be filtered by the baseQuery field.
+     *
+     * @var int[]
+     */
+    protected $pinnedIds = [];
+
+    /**
+     * The URL template that is used to create the value of each feed item's content.player.urlfield.
+     *
+     * @var string
+     */
+    protected $playerUrl;
+
+    /**
+     * Whether to use the sortKeys to sort items in the feed when a Q query is included in the FeedConfig or the feed request.
+     *
+     * @var bool
+     */
+    protected $preferSortKeysOnSearch;
+
+    /**
+     * The type of query engine used to retrieve the feed items.
+     *
+     * @var string
+     */
+    protected $queryEngine;
+
+    /**
+     * The list of key-value URL parameters that are appended to the feed item's content.urlfield.
+     *
+     * @var string
+     */
+    protected $releaseUrlParameters;
+
+    /**
+     * The id of the Restriction that is applied to the feed.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $restrictionId;
+
+    /**
+     * The object schema version of the feed items.
+     *
+     * @var string
+     */
+    protected $schema;
+
+    /**
+     * A query used to select items for the feed. These items are in addition to any specified in the pinnedIds field, and may be filtered by the baseQuery field.
+     *
+     * @var string[]
+     */
+    protected $segmentQueries = [];
+
+    /**
+     * The list of fields and directions used to sort items in the feed.
+     *
+     * @var SortKey[]
+     */
+    protected $sortKeys = [];
+
+    /**
+     * The sub feeds of the feed. Sub feeds contain all items of the specified SubFeed.feedType in the feed owner's account. Currently, only a Category sub feed of a Media feed is supported.
+     *
+     * @var SubFeed[]
+     */
+    protected $subFeeds = [];
+
+    /**
+     * The query or key names used to select the thumbnail files for each item in the feed.
+     *
+     * @var string
+     */
+    protected $thumbnailFilter;
+
+    /**
+     * The title of the feed.
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * The date and time this object was last modified.
+     *
+     * @var \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+     */
+    protected $updated;
+
+    /**
+     * The id of the user that last modified this object.
+     *
+     * @var \Psr\Http\Message\UriInterface
+     */
+    protected $updatedByUserId;
+
+    /**
+     * The type of URL that is returned in each feed item's content.urlfield.
+     *
+     * @var string
+     */
+    protected $urlType;
+
+    /**
+     * Whether to include the feed-level elements and any feed-level custom fields in the feed header.
+     *
+     * @var bool
+     */
+    protected $validFeed;
+
+    /**
+     * This object's modification version, used for optimistic locking.
+     *
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * Returns the parameters that are passed to a custom feed adapter for processing at runtime.
+     *
+     * @return string
+     */
+    public function getAdapterParameters(): ?string
+    {
+        return $this->adapterParameters;
+    }
+
+    /**
+     * Set the parameters that are passed to a custom feed adapter for processing at runtime.
+     *
+     * @param string $adapterParameters
+     */
+    public function setAdapterParameters(?string $adapterParameters)
+    {
+        $this->adapterParameters = $adapterParameters;
+    }
+
+    /**
+     * Returns the date and time that this object was created.
+     *
+     * @return \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+     */
+    public function getAdded(): \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+    {
+        if (!$this->added) {
+            return new NullDateTime();
+        }
+
+        return $this->added;
+    }
+
+    /**
+     * Set the date and time that this object was created.
+     *
+     * @param \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface $added
+     */
+    public function setAdded(\Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface $added)
+    {
+        $this->added = $added;
+    }
+
+    /**
+     * Returns the id of the user that created this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAddedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->addedByUserId) {
+            return new Uri();
+        }
+
+        return $this->addedByUserId;
+    }
+
+    /**
+     * Set the id of the user that created this object.
+     *
+     * @param \Psr\Http\Message\UriInterface $addedByUserId
+     */
+    public function setAddedByUserId(\Psr\Http\Message\UriInterface $addedByUserId)
+    {
+        $this->addedByUserId = $addedByUserId;
+    }
+
+    /**
+     * Returns the list of administrative workflow tags for the feed configuration.
+     *
+     * @return string[]
+     */
+    public function getAdminTags(): array
+    {
+        return $this->adminTags;
+    }
+
+    /**
+     * Set the list of administrative workflow tags for the feed configuration.
+     *
+     * @param string[] $adminTags
+     */
+    public function setAdminTags(array $adminTags)
+    {
+        $this->adminTags = $adminTags;
+    }
+
+    /**
+     * Returns the id of the AdPolicy that is applied to the feed.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getAdPolicyId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->adPolicyId) {
+            return new Uri();
+        }
+
+        return $this->adPolicyId;
+    }
+
+    /**
+     * Set the id of the AdPolicy that is applied to the feed.
+     *
+     * @param \Psr\Http\Message\UriInterface $adPolicyId
+     */
+    public function setAdPolicyId(\Psr\Http\Message\UriInterface $adPolicyId)
+    {
+        $this->adPolicyId = $adPolicyId;
+    }
+
+    /**
+     * Returns the author of the feed content.
+     *
+     * @return string
+     */
+    public function getAuthor(): ?string
+    {
+        return $this->author;
+    }
+
+    /**
+     * Set the author of the feed content.
+     *
+     * @param string $author
+     */
+    public function setAuthor(?string $author)
+    {
+        $this->author = $author;
+    }
+
+    /**
+     * Returns the list of object fields that can be retrieved in a feed request. Feed clients can only request fields that are listed in this field.
+     *
+     * @return string[]
+     */
+    public function getAvailableFields(): array
+    {
+        return $this->availableFields;
+    }
+
+    /**
+     * Set the list of object fields that can be retrieved in a feed request. Feed clients can only request fields that are listed in this field.
+     *
+     * @param string[] $availableFields
+     */
+    public function setAvailableFields(array $availableFields)
+    {
+        $this->availableFields = $availableFields;
+    }
+
+    /**
+     * Returns a filter applied to any items specified in the pinnedIds field and any items selected by the segmentQueriesfield.
+     *
+     * @return string
+     */
+    public function getBaseQuery(): ?string
+    {
+        return $this->baseQuery;
+    }
+
+    /**
+     * Set a filter applied to any items specified in the pinnedIds field and any items selected by the segmentQueriesfield.
+     *
+     * @param string $baseQuery
+     */
+    public function setBaseQuery(?string $baseQuery)
+    {
+        $this->baseQuery = $baseQuery;
+    }
+
+    /**
+     * Returns the minimum time that items in the cache are valid.
+     *
+     * @return float
+     */
+    public function getCacheLifetime(): ?float
+    {
+        return $this->cacheLifetime;
+    }
+
+    /**
+     * Set the minimum time that items in the cache are valid.
+     *
+     * @param float $cacheLifetime
+     */
+    public function setCacheLifetime(?float $cacheLifetime)
+    {
+        $this->cacheLifetime = $cacheLifetime;
+    }
+
+    /**
+     * Returns the response behavior during a cache refresh.
+     *
+     * @return string
+     */
+    public function getCacheRefreshStrategy(): ?string
+    {
+        return $this->cacheRefreshStrategy;
+    }
+
+    /**
+     * Set the response behavior during a cache refresh.
+     *
+     * @param string $cacheRefreshStrategy
+     */
+    public function setCacheRefreshStrategy(?string $cacheRefreshStrategy)
+    {
+        $this->cacheRefreshStrategy = $cacheRefreshStrategy;
+    }
+
+    /**
+     * Returns the identifier for the default thumbnail for each item in the feed.
+     *
+     * @return string
+     */
+    public function getDefaultThumbnailAssetType(): ?string
+    {
+        return $this->defaultThumbnailAssetType;
+    }
+
+    /**
+     * Set the identifier for the default thumbnail for each item in the feed.
+     *
+     * @param string $defaultThumbnailAssetType
+     */
+    public function setDefaultThumbnailAssetType(?string $defaultThumbnailAssetType)
+    {
+        $this->defaultThumbnailAssetType = $defaultThumbnailAssetType;
+    }
+
+    /**
+     * Returns the description of the feed.
+     *
+     * @return string
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set the description of the feed.
+     *
+     * @param string $description
+     */
+    public function setDescription(?string $description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Returns whether the feed is disabled.
+     *
+     * @return bool
+     */
+    public function getDisabled(): ?bool
+    {
+        return $this->disabled;
+    }
+
+    /**
+     * Set whether the feed is disabled.
+     *
+     * @param bool $disabled
+     */
+    public function setDisabled(?bool $disabled)
+    {
+        $this->disabled = $disabled;
+    }
+
+    /**
+     * Returns the maximum number of items in the feed.
+     *
+     * @return int
+     */
+    public function getEndIndex(): ?int
+    {
+        return $this->endIndex;
+    }
+
+    /**
+     * Set the maximum number of items in the feed.
+     *
+     * @param int $endIndex
+     */
+    public function setEndIndex(?int $endIndex)
+    {
+        $this->endIndex = $endIndex;
+    }
+
+    /**
+     * Returns the feed items' object type.
+     *
+     * @return string
+     */
+    public function getFeedType(): ?string
+    {
+        return $this->feedType;
+    }
+
+    /**
+     * Set the feed items' object type.
+     *
+     * @param string $feedType
+     */
+    public function setFeedType(?string $feedType)
+    {
+        $this->feedType = $feedType;
+    }
+
+    /**
+     * Returns the default format of the feed.
+     *
+     * @return string
+     */
+    public function getForm(): ?string
+    {
+        return $this->form;
+    }
+
+    /**
+     * Set the default format of the feed.
+     *
+     * @param string $form
+     */
+    public function setForm(?string $form)
+    {
+        $this->form = $form;
+    }
+
+    /**
+     * Returns an alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): ?string
+    {
+        return $this->guid;
+    }
+
+    /**
+     * Set an alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string $guid
+     */
+    public function setGuid(?string $guid)
+    {
+        $this->guid = $guid;
+    }
+
+    /**
+     * Returns the globally unique URI of this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->id) {
+            return new Uri();
+        }
+
+        return $this->id;
+    }
+
+    /**
+     * Set the globally unique URI of this object.
+     *
+     * @param \Psr\Http\Message\UriInterface $id
+     */
+    public function setId(\Psr\Http\Message\UriInterface $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * Returns the URL template that is used to create the value of each feed item's link field.
+     *
+     * @return string
+     */
+    public function getItemLinkUrl(): ?string
+    {
+        return $this->itemLinkUrl;
+    }
+
+    /**
+     * Set the URL template that is used to create the value of each feed item's link field.
+     *
+     * @param string $itemLinkUrl
+     */
+    public function setItemLinkUrl(?string $itemLinkUrl)
+    {
+        $this->itemLinkUrl = $itemLinkUrl;
+    }
+
+    /**
+     * Returns whether to only include items that are currently available.
+     *
+     * @return bool
+     */
+    public function getLimitByAvailableDate(): ?bool
+    {
+        return $this->limitByAvailableDate;
+    }
+
+    /**
+     * Set whether to only include items that are currently available.
+     *
+     * @param bool $limitByAvailableDate
+     */
+    public function setLimitByAvailableDate(?bool $limitByAvailableDate)
+    {
+        $this->limitByAvailableDate = $limitByAvailableDate;
+    }
+
+    /**
+     * Returns whether to only include items that are approved.
+     *
+     * @return bool
+     */
+    public function getLimitToApproved(): ?bool
+    {
+        return $this->limitToApproved;
+    }
+
+    /**
+     * Set whether to only include items that are approved.
+     *
+     * @param bool $limitToApproved
+     */
+    public function setLimitToApproved(?bool $limitToApproved)
+    {
+        $this->limitToApproved = $limitToApproved;
+    }
+
+    /**
+     * Returns the URL value of the feed's link field.
+     *
+     * @return string
+     */
+    public function getLinkUrl(): ?string
+    {
+        return $this->linkUrl;
+    }
+
+    /**
+     * Set the URL value of the feed's link field.
+     *
+     * @param string $linkUrl
+     */
+    public function setLinkUrl(?string $linkUrl)
+    {
+        $this->linkUrl = $linkUrl;
+    }
+
+    /**
+     * Returns whether this object currently allows updates.
+     *
+     * @return bool
+     */
+    public function getLocked(): ?bool
+    {
+        return $this->locked;
+    }
+
+    /**
+     * Set whether this object currently allows updates.
+     *
+     * @param bool $locked
+     */
+    public function setLocked(?bool $locked)
+    {
+        $this->locked = $locked;
+    }
+
+    /**
+     * Returns the id of the account that owns this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getOwnerId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->ownerId) {
+            return new Uri();
+        }
+
+        return $this->ownerId;
+    }
+
+    /**
+     * Set the id of the account that owns this object.
+     *
+     * @param \Psr\Http\Message\UriInterface $ownerId
+     */
+    public function setOwnerId(\Psr\Http\Message\UriInterface $ownerId)
+    {
+        $this->ownerId = $ownerId;
+    }
+
+    /**
+     * Returns the globally-unique public identifier that is used to request this feed.
+     *
+     * @return string
+     */
+    public function getPid(): ?string
+    {
+        return $this->pid;
+    }
+
+    /**
+     * Set the globally-unique public identifier that is used to request this feed.
+     *
+     * @param string $pid
+     */
+    public function setPid(?string $pid)
+    {
+        $this->pid = $pid;
+    }
+
+    /**
+     * Returns the IDs of specific items to include in the feed. These items are in addition to any selected by the segmentQueries field, and may be filtered by the baseQuery field.
+     *
+     * @return int[]
+     */
+    public function getPinnedIds(): array
+    {
+        return $this->pinnedIds;
+    }
+
+    /**
+     * Set the IDs of specific items to include in the feed. These items are in addition to any selected by the segmentQueries field, and may be filtered by the baseQuery field.
+     *
+     * @param int[] $pinnedIds
+     */
+    public function setPinnedIds(array $pinnedIds)
+    {
+        $this->pinnedIds = $pinnedIds;
+    }
+
+    /**
+     * Returns the URL template that is used to create the value of each feed item's content.player.urlfield.
+     *
+     * @return string
+     */
+    public function getPlayerUrl(): ?string
+    {
+        return $this->playerUrl;
+    }
+
+    /**
+     * Set the URL template that is used to create the value of each feed item's content.player.urlfield.
+     *
+     * @param string $playerUrl
+     */
+    public function setPlayerUrl(?string $playerUrl)
+    {
+        $this->playerUrl = $playerUrl;
+    }
+
+    /**
+     * Returns whether to use the sortKeys to sort items in the feed when a Q query is included in the FeedConfig or the feed request.
+     *
+     * @return bool
+     */
+    public function getPreferSortKeysOnSearch(): ?bool
+    {
+        return $this->preferSortKeysOnSearch;
+    }
+
+    /**
+     * Set whether to use the sortKeys to sort items in the feed when a Q query is included in the FeedConfig or the feed request.
+     *
+     * @param bool $preferSortKeysOnSearch
+     */
+    public function setPreferSortKeysOnSearch(?bool $preferSortKeysOnSearch)
+    {
+        $this->preferSortKeysOnSearch = $preferSortKeysOnSearch;
+    }
+
+    /**
+     * Returns the type of query engine used to retrieve the feed items.
+     *
+     * @return string
+     */
+    public function getQueryEngine(): ?string
+    {
+        return $this->queryEngine;
+    }
+
+    /**
+     * Set the type of query engine used to retrieve the feed items.
+     *
+     * @param string $queryEngine
+     */
+    public function setQueryEngine(?string $queryEngine)
+    {
+        $this->queryEngine = $queryEngine;
+    }
+
+    /**
+     * Returns the list of key-value URL parameters that are appended to the feed item's content.urlfield.
+     *
+     * @return string
+     */
+    public function getReleaseUrlParameters(): ?string
+    {
+        return $this->releaseUrlParameters;
+    }
+
+    /**
+     * Set the list of key-value URL parameters that are appended to the feed item's content.urlfield.
+     *
+     * @param string $releaseUrlParameters
+     */
+    public function setReleaseUrlParameters(?string $releaseUrlParameters)
+    {
+        $this->releaseUrlParameters = $releaseUrlParameters;
+    }
+
+    /**
+     * Returns the id of the Restriction that is applied to the feed.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getRestrictionId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->restrictionId) {
+            return new Uri();
+        }
+
+        return $this->restrictionId;
+    }
+
+    /**
+     * Set the id of the Restriction that is applied to the feed.
+     *
+     * @param \Psr\Http\Message\UriInterface $restrictionId
+     */
+    public function setRestrictionId(\Psr\Http\Message\UriInterface $restrictionId)
+    {
+        $this->restrictionId = $restrictionId;
+    }
+
+    /**
+     * Returns the object schema version of the feed items.
+     *
+     * @return string
+     */
+    public function getSchema(): ?string
+    {
+        return $this->schema;
+    }
+
+    /**
+     * Set the object schema version of the feed items.
+     *
+     * @param string $schema
+     */
+    public function setSchema(?string $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * Returns a query used to select items for the feed. These items are in addition to any specified in the pinnedIds field, and may be filtered by the baseQuery field.
+     *
+     * @return string[]
+     */
+    public function getSegmentQueries(): array
+    {
+        return $this->segmentQueries;
+    }
+
+    /**
+     * Set a query used to select items for the feed. These items are in addition to any specified in the pinnedIds field, and may be filtered by the baseQuery field.
+     *
+     * @param string[] $segmentQueries
+     */
+    public function setSegmentQueries(array $segmentQueries)
+    {
+        $this->segmentQueries = $segmentQueries;
+    }
+
+    /**
+     * Returns the list of fields and directions used to sort items in the feed.
+     *
+     * @return SortKey[]
+     */
+    public function getSortKeys(): array
+    {
+        return $this->sortKeys;
+    }
+
+    /**
+     * Set the list of fields and directions used to sort items in the feed.
+     *
+     * @param SortKey[] $sortKeys
+     */
+    public function setSortKeys(array $sortKeys)
+    {
+        $this->sortKeys = $sortKeys;
+    }
+
+    /**
+     * Returns the sub feeds of the feed. Sub feeds contain all items of the specified SubFeed.feedType in the feed owner's account. Currently, only a Category sub feed of a Media feed is supported.
+     *
+     * @return SubFeed[]
+     */
+    public function getSubFeeds(): array
+    {
+        return $this->subFeeds;
+    }
+
+    /**
+     * Set the sub feeds of the feed. Sub feeds contain all items of the specified SubFeed.feedType in the feed owner's account. Currently, only a Category sub feed of a Media feed is supported.
+     *
+     * @param SubFeed[] $subFeeds
+     */
+    public function setSubFeeds(array $subFeeds)
+    {
+        $this->subFeeds = $subFeeds;
+    }
+
+    /**
+     * Returns the query or key names used to select the thumbnail files for each item in the feed.
+     *
+     * @return string
+     */
+    public function getThumbnailFilter(): ?string
+    {
+        return $this->thumbnailFilter;
+    }
+
+    /**
+     * Set the query or key names used to select the thumbnail files for each item in the feed.
+     *
+     * @param string $thumbnailFilter
+     */
+    public function setThumbnailFilter(?string $thumbnailFilter)
+    {
+        $this->thumbnailFilter = $thumbnailFilter;
+    }
+
+    /**
+     * Returns the title of the feed.
+     *
+     * @return string
+     */
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Set the title of the feed.
+     *
+     * @param string $title
+     */
+    public function setTitle(?string $title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Returns the date and time this object was last modified.
+     *
+     * @return \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+     */
+    public function getUpdated(): \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+    {
+        if (!$this->updated) {
+            return new NullDateTime();
+        }
+
+        return $this->updated;
+    }
+
+    /**
+     * Set the date and time this object was last modified.
+     *
+     * @param \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface $updated
+     */
+    public function setUpdated(\Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface $updated)
+    {
+        $this->updated = $updated;
+    }
+
+    /**
+     * Returns the id of the user that last modified this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    {
+        if (!$this->updatedByUserId) {
+            return new Uri();
+        }
+
+        return $this->updatedByUserId;
+    }
+
+    /**
+     * Set the id of the user that last modified this object.
+     *
+     * @param \Psr\Http\Message\UriInterface $updatedByUserId
+     */
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId)
+    {
+        $this->updatedByUserId = $updatedByUserId;
+    }
+
+    /**
+     * Returns the type of URL that is returned in each feed item's content.urlfield.
+     *
+     * @return string
+     */
+    public function getUrlType(): ?string
+    {
+        return $this->urlType;
+    }
+
+    /**
+     * Set the type of URL that is returned in each feed item's content.urlfield.
+     *
+     * @param string $urlType
+     */
+    public function setUrlType(?string $urlType)
+    {
+        $this->urlType = $urlType;
+    }
+
+    /**
+     * Returns whether to include the feed-level elements and any feed-level custom fields in the feed header.
+     *
+     * @return bool
+     */
+    public function getValidFeed(): ?bool
+    {
+        return $this->validFeed;
+    }
+
+    /**
+     * Set whether to include the feed-level elements and any feed-level custom fields in the feed header.
+     *
+     * @param bool $validFeed
+     */
+    public function setValidFeed(?bool $validFeed)
+    {
+        $this->validFeed = $validFeed;
+    }
+
+    /**
+     * Returns this object's modification version, used for optimistic locking.
+     *
+     * @return int
+     */
+    public function getVersion(): ?int
+    {
+        return $this->version;
+    }
+
+    /**
+     * Set this object's modification version, used for optimistic locking.
+     *
+     * @param int $version
+     */
+    public function setVersion(?int $version)
+    {
+        $this->version = $version;
+    }
+}

--- a/src/DataService/Feeds/SortKey.php
+++ b/src/DataService/Feeds/SortKey.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Feeds;
+
+/**
+ * The SortKey object is a dependent object that stores information about the sorting criteria for items in a feed.
+ *
+ * @see https://docs.theplatform.com/help/feeds-sortkey-object
+ */
+class SortKey
+{
+    /**
+     * The name of the field on which to sort.
+     *
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * Whether the objects are sorted in descending order.
+     *
+     * @var bool
+     */
+    protected $descending;
+
+    /**
+     * Get the name of the field on which to sort.
+     *
+     * @return string
+     */
+    public function getField(): ?string
+    {
+        return $this->field;
+    }
+
+    /**
+     * Set the name of the field on which to sort.
+     *
+     * @param string $field
+     */
+    public function setField(?string $field): void
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * Get whether the objects are sorted in descending order.
+     *
+     * @return bool
+     */
+    public function getDescending(): ?bool
+    {
+        return $this->descending;
+    }
+
+    /**
+     * Set whether the objects are sorted in descending order.
+     *
+     * @param bool $descending
+     */
+    public function setDescending(?bool $descending): void
+    {
+        $this->descending = $descending;
+    }
+}

--- a/src/DataService/Feeds/SubFeed.php
+++ b/src/DataService/Feeds/SubFeed.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Lullabot\Mpx\DataService\Feeds;
+
+/**
+ * The SubFeed object is a dependent object that defines a secondary feed related to the parent feed configuration.
+ *
+ * @see https://docs.theplatform.com/help/feeds-subfeed-object
+ */
+class SubFeed
+{
+    /**
+     * The parameters that are passed to a custom feed adapter for processing at runtime. For more information, see FeedConfig.adapterParameters.
+     *
+     * @var string
+     */
+    protected $adapterParameters;
+
+    /**
+     * The list of object fields (that correspond to the SubFeed.feedType) that can be retrieved in a sub feed request. Feed clients can only request fields of the sub feed that are listed in this field. For more information, see FeedConfig.availableFields.
+     * To display a list of categories in an mpx Player, you must include the following category fields: fullTitle, id, label, order, parentId, and title.
+     *
+     * @var string[]
+     */
+    protected $availableFields = [];
+
+    /**
+     * Not currently used.
+     *
+     * @var string
+     */
+    protected $baseQuery;
+
+    /**
+     * The sub feed items' object type. This value must be unique within the FeedConfig.subFeedsarray. The only currently supported value is Category.
+     *
+     * @var string
+     */
+    protected $feedType;
+
+    /**
+     * The default format of the sub feed. For more information, see FeedConfig.form.
+     *
+     * @var string
+     */
+    protected $form;
+
+    /**
+     * The object titles that are included in the sub feed. For example, this can be used to limit a Category sub feed to a few specific categories. This array may contain a maximum of 2,000 titles. If this field is empty, all objects are returned.
+     *
+     * @var string[]
+     */
+    protected $limitByTitles = [];
+
+    /**
+     * The object schema version of the sub feed items. For more information, see FeedConfig.schema.
+     *
+     * @var string
+     */
+    protected $schema;
+
+    /**
+     * Returns the parameters that are passed to a custom feed adapter for processing at runtime. For more information, see FeedConfig.adapterParameters.
+     *
+     * @return string
+     */
+    public function getAdapterParameters(): ?string
+    {
+        return $this->adapterParameters;
+    }
+
+    /**
+     * Set the parameters that are passed to a custom feed adapter for processing at runtime. For more information, see FeedConfig.adapterParameters.
+     *
+     * @param string $adapterParameters
+     */
+    public function setAdapterParameters(?string $adapterParameters)
+    {
+        $this->adapterParameters = $adapterParameters;
+    }
+
+    /**
+     * Returns the list of object fields (that correspond to the SubFeed.feedType) that can be retrieved in a sub feed request. Feed clients can only request fields of the sub feed that are listed in this field. For more information, see FeedConfig.availableFields.
+     * To display a list of categories in an mpx Player, you must include the following category fields: fullTitle, id, label, order, parentId, and title.
+     *
+     * @return string[]
+     */
+    public function getAvailableFields(): array
+    {
+        return $this->availableFields;
+    }
+
+    /**
+     * Set the list of object fields (that correspond to the SubFeed.feedType) that can be retrieved in a sub feed request. Feed clients can only request fields of the sub feed that are listed in this field. For more information, see FeedConfig.availableFields.
+     * To display a list of categories in an mpx Player, you must include the following category fields: fullTitle, id, label, order, parentId, and title.
+     *
+     * @param string[] $availableFields
+     */
+    public function setAvailableFields(array $availableFields)
+    {
+        $this->availableFields = $availableFields;
+    }
+
+    /**
+     * Returns not currently used.
+     *
+     * @return string
+     */
+    public function getBaseQuery(): ?string
+    {
+        return $this->baseQuery;
+    }
+
+    /**
+     * Set not currently used.
+     *
+     * @param string $baseQuery
+     */
+    public function setBaseQuery(?string $baseQuery)
+    {
+        $this->baseQuery = $baseQuery;
+    }
+
+    /**
+     * Returns the sub feed items' object type. This value must be unique within the FeedConfig.subFeedsarray. The only currently supported value is Category.
+     *
+     * @return string
+     */
+    public function getFeedType(): ?string
+    {
+        return $this->feedType;
+    }
+
+    /**
+     * Set the sub feed items' object type. This value must be unique within the FeedConfig.subFeedsarray. The only currently supported value is Category.
+     *
+     * @param string $feedType
+     */
+    public function setFeedType(?string $feedType)
+    {
+        $this->feedType = $feedType;
+    }
+
+    /**
+     * Returns the default format of the sub feed. For more information, see FeedConfig.form.
+     *
+     * @return string
+     */
+    public function getForm(): ?string
+    {
+        return $this->form;
+    }
+
+    /**
+     * Set the default format of the sub feed. For more information, see FeedConfig.form.
+     *
+     * @param string $form
+     */
+    public function setForm(?string $form)
+    {
+        $this->form = $form;
+    }
+
+    /**
+     * Returns the object titles that are included in the sub feed. For example, this can be used to limit a Category sub feed to a few specific categories. This array may contain a maximum of 2,000 titles. If this field is empty, all objects are returned.
+     *
+     * @return string[]
+     */
+    public function getLimitByTitles(): array
+    {
+        return $this->limitByTitles;
+    }
+
+    /**
+     * Set the object titles that are included in the sub feed. For example, this can be used to limit a Category sub feed to a few specific categories. This array may contain a maximum of 2,000 titles. If this field is empty, all objects are returned.
+     *
+     * @param string[] $limitByTitles
+     */
+    public function setLimitByTitles(array $limitByTitles)
+    {
+        $this->limitByTitles = $limitByTitles;
+    }
+
+    /**
+     * Returns the object schema version of the sub feed items. For more information, see FeedConfig.schema.
+     *
+     * @return string
+     */
+    public function getSchema(): ?string
+    {
+        return $this->schema;
+    }
+
+    /**
+     * Set the object schema version of the sub feed items. For more information, see FeedConfig.schema.
+     *
+     * @param string $schema
+     */
+    public function setSchema(?string $schema)
+    {
+        $this->schema = $schema;
+    }
+}

--- a/tests/fixtures/feedconfig-object.json
+++ b/tests/fixtures/feedconfig-object.json
@@ -1,0 +1,83 @@
+{
+    "id": "http://data.feed.theplatform.com/feed/data/FeedConfig/12345",
+    "guid": "toe2Mt10g42hayPv6nlOkn5X3qiJawyY",
+    "updated": 1342817557000,
+    "title": "Title-sorted racing feed.",
+    "author": "My company",
+    "description": "This feed returns auto racing media sorted by title.",
+    "added": 1342817557000,
+    "ownerId": "http://access.auth.theplatform.com/data/Account/54321",
+    "addedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/5",
+    "updatedByUserId": "http://identity.auth.theplatform.com/idm/data/User/mps/5",
+    "version": 0,
+    "locked": false,
+    "adapterParameters": "a=b",
+    "disabled": false,
+    "adPolicyId": null,
+    "cacheLifetime": 0.0,
+    "baseQuery": "byCategories=AutoRacing",
+    "defaultThumbnailAssetType": "mainThumb",
+    "endIndex": 100,
+    "form": "atom",
+    "limitByAvailableDate": true,
+    "limitToApproved": true,
+    "linkUrl": "http://www.feedlink.com/feed/",
+    "availableFields": [
+        "author",
+        "description",
+        "guid",
+        "link",
+        "pubDate",
+        "title",
+        "media:",
+        "content",
+        "content.media:",
+        "thumbnails",
+        "thumbnails.media:"
+    ],
+    "pinnedIds": [
+  "25478"        
+    ],
+    "pid": "uy4aTomGaVKC",
+    "playerUrl": "http://www.linktoplayer.com/player",
+    "preferSortKeysOnSearch": true,
+    "queryEngine": "search",
+    "releaseUrlParameters": "network=SPEED&Format=SMIL",
+    "restrictionId": "https://data.delivery.theplatform.com/delivery/data/Restriction/11111",
+    "segmentQueries": [
+        "&byContentFormat=FLV"
+    ],
+    "sortKeys": [
+        {
+            "field": "title",
+            "descending": true
+        }
+    ],
+    "subFeeds": [
+        {
+            "feedType": "Category",
+            "adapterParameters": "",
+            "availableFields": [
+                
+            ],
+            "form": "atom",
+            "baseQuery": "byCategories=championship",
+            "limitByTitles": [
+                
+            ],
+            "schema": ""
+        }
+    ],
+    "thumbnailFilter": "byFormat=jpeg",
+    "urlType": "release",
+    "cacheRefreshStrategy": "uponRequest",
+    "feedType": "Media",
+    "schema": "1.3",
+    "validFeed": true,
+    "itemLinkUrl": "http://linktoitem",
+    "adminTags": [
+        "championship",
+        "rally",
+        "sports"
+    ]
+}

--- a/tests/fixtures/sortkey-object.json
+++ b/tests/fixtures/sortkey-object.json
@@ -1,0 +1,4 @@
+{
+  "field": "title",
+  "descending": true
+}

--- a/tests/fixtures/subfeed-object.json
+++ b/tests/fixtures/subfeed-object.json
@@ -1,0 +1,13 @@
+        {
+            "feedType": "Category",
+            "adapterParameters": "",
+            "availableFields": [
+                
+            ],
+            "form": "atom",
+            "baseQuery": "byCategories=championship",
+            "limitByTitles": [
+                
+            ],
+            "schema": ""
+        }

--- a/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\UriInterface;
  */
 class FeedConfigTest extends FunctionalTestBase
 {
-
     /**
      * Tests loading two FeedConfig objects.
      */

--- a/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Functional\DataService\Feeds;
+
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use PHPUnit\Framework\TestCase;
+
+class FeedConfigTest extends TestCase
+{
+
+}

--- a/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
@@ -2,10 +2,36 @@
 
 namespace Lullabot\Mpx\Tests\Functional\DataService\Feeds;
 
-use Lullabot\Mpx\DataService\Feeds\FeedConfig;
-use PHPUnit\Framework\TestCase;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\DataService\ObjectListQuery;
+use Lullabot\Mpx\Tests\Functional\FunctionalTestBase;
+use Psr\Http\Message\UriInterface;
 
-class FeedConfigTest extends TestCase
+/**
+ * Tests loading feed configuration objects.
+ */
+class FeedConfigTest extends FunctionalTestBase
 {
 
+    /**
+     * Tests loading two FeedConfig objects.
+     */
+    public function testQueryFeeds()
+    {
+        $manager = DataServiceManager::basicDiscovery();
+        $service = $manager->getDataService('Feeds Data Service', 'FeedConfig', '2.2');
+        $dof = new DataObjectFactory($service, $this->authenticatedClient);
+        $filter = new ObjectListQuery();
+        $filter->getRange()->setStartIndex(1)
+            ->setEndIndex(2);
+        $results = $dof->select($filter, $this->account);
+
+        foreach ($results as $index => $result) {
+            $this->assertInstanceOf(UriInterface::class, $result->getId());
+            if ($index + 1 > 2) {
+                break;
+            }
+        }
+    }
 }

--- a/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Feeds;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\DateTime\ConcreteDateTime;
+use Lullabot\Mpx\DataService\DataServiceExtractor;
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+
+/**
+ * Test the FeedConfig data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Feeds\FeedConfig
+ */
+class FeedConfigTest extends ObjectTestBase
+{
+    protected $class = FeedConfig::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $dataServiceExtractor = new DataServiceExtractor();
+        $dataServiceExtractor->setClass($this->class);
+        $this->loadFixture('feedconfig-object.json', $dataServiceExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on FeedConfig to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+
+    public function getSetMethods()
+    {
+        $tests = parent::getSetMethods();
+
+        $tests['added'] = ['added', new ConcreteDateTime(\DateTime::createFromFormat('U.u', '1342817557.000'))];
+        $tests['updated'] = ['updated', new ConcreteDateTime(\DateTime::createFromFormat('U.u', '1342817557.000'))];
+        $tests['adPolicyId'] = ['adPolicyId', new Uri()];
+
+        unset($tests['sortKeys']);
+        unset($tests['subFeeds']);
+
+        return $tests;
+    }
+}

--- a/tests/src/Unit/DataService/Feeds/SortKeyTest.php
+++ b/tests/src/Unit/DataService/Feeds/SortKeyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Feeds;
+
+use Lullabot\Mpx\DataService\DataServiceExtractor;
+use Lullabot\Mpx\DataService\Feeds\SortKey;
+use Lullabot\Mpx\DataService\Media\Rating;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+
+/**
+ * Test the SortKey data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Feeds\SortKey
+ */
+class SortKeyTest extends ObjectTestBase
+{
+    protected $class = SortKey::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $dataServiceExtractor = new DataServiceExtractor();
+        $dataServiceExtractor->setClass($this->class);
+        $this->loadFixture('sortkey-object.json', $dataServiceExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+}

--- a/tests/src/Unit/DataService/Feeds/SortKeyTest.php
+++ b/tests/src/Unit/DataService/Feeds/SortKeyTest.php
@@ -4,7 +4,6 @@ namespace Lullabot\Mpx\Tests\Unit\DataService\Feeds;
 
 use Lullabot\Mpx\DataService\DataServiceExtractor;
 use Lullabot\Mpx\DataService\Feeds\SortKey;
-use Lullabot\Mpx\DataService\Media\Rating;
 use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
 
 /**

--- a/tests/src/Unit/DataService/Feeds/SubFeedTest.php
+++ b/tests/src/Unit/DataService/Feeds/SubFeedTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Feeds;
+
+use Lullabot\Mpx\DataService\DataServiceExtractor;
+use Lullabot\Mpx\DataService\Feeds\SortKey;
+use Lullabot\Mpx\DataService\Feeds\SubFeed;
+use Lullabot\Mpx\DataService\Media\Rating;
+use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
+
+/**
+ * Test the SubFeed data object.
+ *
+ * @covers \Lullabot\Mpx\DataService\Feeds\SubFeed
+ */
+class SubFeedTest extends ObjectTestBase
+{
+    protected $class = SubFeed::class;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $dataServiceExtractor = new DataServiceExtractor();
+        $dataServiceExtractor->setClass($this->class);
+        $this->loadFixture('subfeed-object.json', $dataServiceExtractor);
+    }
+
+    /**
+     * Test get / set methods.
+     *
+     * @param string $field    The field on Player to test.
+     * @param mixed  $expected (optional) Override the assertion if data is converted, such as with timestamps.
+     *
+     * @dataProvider getSetMethods
+     */
+    public function testGetSet(string $field, $expected = null)
+    {
+        $this->assertObjectClass($this->class, $field, $expected);
+    }
+}

--- a/tests/src/Unit/DataService/Feeds/SubFeedTest.php
+++ b/tests/src/Unit/DataService/Feeds/SubFeedTest.php
@@ -3,9 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit\DataService\Feeds;
 
 use Lullabot\Mpx\DataService\DataServiceExtractor;
-use Lullabot\Mpx\DataService\Feeds\SortKey;
 use Lullabot\Mpx\DataService\Feeds\SubFeed;
-use Lullabot\Mpx\DataService\Media\Rating;
 use Lullabot\Mpx\Tests\Unit\DataService\ObjectTestBase;
 
 /**


### PR DESCRIPTION
Resolves #110 .

This is almost all entirely generated code and corresponding tests. [This functional test](https://github.com/Lullabot/mpx-php/pull/139/files#diff-bb4719ee4950cda4405fe22d8c801863) shows an example of loading feeds - it's identical to other data service objects.