### PR TITLE
Feed url support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - The FeedConfig object is now supported. #110
+- New classes have been added to support feed URL generation. See
+  `\Lullabot\Mpx\Service\Feeds` for details. #111
 
 ## [0.6.2] - 2018-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New classes have been added to support feed URL generation. See
   `\Lullabot\Mpx\Service\Feeds` for details. #111
 
+### Changed
+
+- The `\Lullabot\Mpx\Player\Url` has been moved to
+  `\Lullabot\Mpx\Service\Player\Url`. #111
+
 ## [0.6.2] - 2018-07-17
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,6 @@
     }
   },
   "extra": {
-    "composer-version": "^1.6.3",
-    "branch-alias": {
-        "dev-feed-url": "0.6.x-dev"
-    }
+    "composer-version": "^1.6.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
     }
   },
   "extra": {
-    "composer-version": "^1.6.3"
+    "composer-version": "^1.6.3",
+    "branch-alias": {
+        "dev-feed-url": "0.6.x-dev"
+    }
   }
 }

--- a/src/Service/Feeds/GuidMediaFeedUrl.php
+++ b/src/Service/Feeds/GuidMediaFeedUrl.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Lullabot\Mpx\Service\Feeds;
+
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Psr\Http\Message\UriInterface;
+
+class GuidMediaFeedUrl extends MediaFeedUrl
+{
+    /**
+     * A comma-separated list of GUIDs for individual items in the feed.
+     *
+     * This path segment cannot be used with the ID path segment.
+     *
+     * @var string[]
+     */
+    protected $guids;
+
+    /**
+     * Contains either an owner ID or a dash (—).
+     *
+     * GUIDs are only guaranteed to be unique within an account. Because some
+     * feeds can be configured to include inherited objects from other accounts,
+     * it is possible that 2 objects in a feed could have the same GUID. You
+     * can include the object's ownerId to uniquely identify the object.
+     * Alternatively, you can include a dash (—) to specify that the owner ID is
+     * the owner ID of the FeedConfig.
+     *
+     * @var string
+     */
+    protected $ownerId;
+
+    public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig, array $guids, string $ownerId = '-')
+    {
+        parent::__construct($account, $feedConfig);
+        $this->setGuids($guids);
+        $this->ownerId = $ownerId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGuids(): array
+    {
+        return $this->guids;
+    }
+
+    /**
+     * @param string[] $guids
+     */
+    public function setGuids(array $guids): void
+    {
+        if (empty($guids)) {
+            throw new \InvalidArgumentException('At least one GUID must be specified');
+        }
+        $this->guids = $guids;
+    }
+
+    public function toUri(): UriInterface
+    {
+        $uri = $this->uriToFeedComponent();
+        $uri = $uri->withPath($uri->getPath() . '/guid/' . implode(',', $this->guids));
+        $uri = $this->appendSeoTerms($uri);
+
+        return $uri;
+    }
+}

--- a/src/Service/Feeds/GuidMediaFeedUrl.php
+++ b/src/Service/Feeds/GuidMediaFeedUrl.php
@@ -78,7 +78,7 @@ class GuidMediaFeedUrl extends MediaFeedUrl
     public function toUri(): UriInterface
     {
         $uri = $this->uriToFeedComponent();
-        $uri = $uri->withPath($uri->getPath().'/guid/'.implode(',', $this->guids));
+        $uri = $uri->withPath($uri->getPath().'/guid/'.$this->ownerId.'/'.implode(',', $this->guids));
         $uri = $this->appendSeoTerms($uri);
 
         return $uri;

--- a/src/Service/Feeds/GuidMediaFeedUrl.php
+++ b/src/Service/Feeds/GuidMediaFeedUrl.php
@@ -6,6 +6,9 @@ use Lullabot\Mpx\DataService\Feeds\FeedConfig;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * A feed URL with a list of feed items by GUID.
+ */
 class GuidMediaFeedUrl extends MediaFeedUrl
 {
     /**
@@ -18,19 +21,20 @@ class GuidMediaFeedUrl extends MediaFeedUrl
     protected $guids;
 
     /**
-     * Contains either an owner ID or a dash (—).
-     *
-     * GUIDs are only guaranteed to be unique within an account. Because some
-     * feeds can be configured to include inherited objects from other accounts,
-     * it is possible that 2 objects in a feed could have the same GUID. You
-     * can include the object's ownerId to uniquely identify the object.
-     * Alternatively, you can include a dash (—) to specify that the owner ID is
-     * the owner ID of the FeedConfig.
+     * The owner ID or a dash.
      *
      * @var string
      */
     protected $ownerId;
 
+    /**
+     * GuidMediaFeedUrl constructor.
+     *
+     * @param PublicIdentifierInterface $account    The account the feed is associated with.
+     * @param FeedConfig                $feedConfig The feed the URL is being generated for.
+     * @param array                     $guids      An array of GUIDs.
+     * @param string                    $ownerId    (optional) The owner ID of the associated GUIDs. Defaults to a '-' which uses the owner of the FeedConfig object.
+     */
     public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig, array $guids, string $ownerId = '-')
     {
         parent::__construct($account, $feedConfig);
@@ -39,6 +43,8 @@ class GuidMediaFeedUrl extends MediaFeedUrl
     }
 
     /**
+     * Return the GUIDs.
+     *
      * @return string[]
      */
     public function getGuids(): array
@@ -47,6 +53,15 @@ class GuidMediaFeedUrl extends MediaFeedUrl
     }
 
     /**
+     * Set either an owner ID or a dash (—).
+     *
+     * GUIDs are only guaranteed to be unique within an account. Because some
+     * feeds can be configured to include inherited objects from other accounts,
+     * it is possible that 2 objects in a feed could have the same GUID. You
+     * can include the object's ownerId to uniquely identify the object.
+     * Alternatively, you can include a dash (—) to specify that the owner ID is
+     * the owner ID of the FeedConfig.
+     *
      * @param string[] $guids
      */
     public function setGuids(array $guids): void
@@ -57,10 +72,13 @@ class GuidMediaFeedUrl extends MediaFeedUrl
         $this->guids = $guids;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toUri(): UriInterface
     {
         $uri = $this->uriToFeedComponent();
-        $uri = $uri->withPath($uri->getPath() . '/guid/' . implode(',', $this->guids));
+        $uri = $uri->withPath($uri->getPath().'/guid/'.implode(',', $this->guids));
         $uri = $this->appendSeoTerms($uri);
 
         return $uri;

--- a/src/Service/Feeds/IdMediaFeedUrl.php
+++ b/src/Service/Feeds/IdMediaFeedUrl.php
@@ -6,17 +6,25 @@ use Lullabot\Mpx\DataService\Feeds\FeedConfig;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * A feed URL with a list of items by their ID.
+ */
 class IdMediaFeedUrl extends MediaFeedUrl
 {
     /**
      * A comma-separated list of numeric IDs for individual items in the feed.
      *
-     * This path segment cannot be used with the guid/<owner ID>/<GUIDs> path segment.
-     *
      * @var int[]
      */
     protected $ids;
 
+    /**
+     * IdMediaFeedUrl constructor.
+     *
+     * @param PublicIdentifierInterface $account    The account the feed is associated with.
+     * @param FeedConfig                $feedConfig The feed the URL is being generated for.
+     * @param array                     $ids        An array of IDs.
+     */
     public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig, array $ids = [])
     {
         parent::__construct($account, $feedConfig);
@@ -32,6 +40,8 @@ class IdMediaFeedUrl extends MediaFeedUrl
     }
 
     /**
+     * A comma-separated list of numeric IDs for individual items in the feed.
+     *
      * @param int[] $ids
      */
     public function setIds(array $ids): void
@@ -43,10 +53,13 @@ class IdMediaFeedUrl extends MediaFeedUrl
         $this->ids = $ids;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function toUri(): UriInterface
     {
         $uri = $this->uriToFeedComponent();
-        $uri = $uri->withPath($uri->getPath() . '/' . implode(',', $this->ids));
+        $uri = $uri->withPath($uri->getPath().'/'.implode(',', $this->ids));
         $uri = $this->appendSeoTerms($uri);
 
         return $uri;

--- a/src/Service/Feeds/IdMediaFeedUrl.php
+++ b/src/Service/Feeds/IdMediaFeedUrl.php
@@ -50,6 +50,12 @@ class IdMediaFeedUrl extends MediaFeedUrl
             throw new \InvalidArgumentException('At least one ID must be specified');
         }
 
+        foreach ($ids as $id) {
+            if (!is_int($id)) {
+                throw new \InvalidArgumentException('All IDs must be integers');
+            }
+        }
+
         $this->ids = $ids;
     }
 

--- a/src/Service/Feeds/IdMediaFeedUrl.php
+++ b/src/Service/Feeds/IdMediaFeedUrl.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Lullabot\Mpx\Service\Feeds;
+
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Psr\Http\Message\UriInterface;
+
+class IdMediaFeedUrl extends MediaFeedUrl
+{
+    /**
+     * A comma-separated list of numeric IDs for individual items in the feed.
+     *
+     * This path segment cannot be used with the guid/<owner ID>/<GUIDs> path segment.
+     *
+     * @var int[]
+     */
+    protected $ids;
+
+    public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig, array $ids = [])
+    {
+        parent::__construct($account, $feedConfig);
+        $this->setIds($ids);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getIds(): array
+    {
+        return $this->ids;
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    public function setIds(array $ids): void
+    {
+        if (empty($ids)) {
+            throw new \InvalidArgumentException('At least one ID must be specified');
+        }
+
+        $this->ids = $ids;
+    }
+
+    public function toUri(): UriInterface
+    {
+        $uri = $this->uriToFeedComponent();
+        $uri = $uri->withPath($uri->getPath() . '/' . implode(',', $this->ids));
+        $uri = $this->appendSeoTerms($uri);
+
+        return $uri;
+    }
+}

--- a/src/Service/Feeds/MediaFeedUrl.php
+++ b/src/Service/Feeds/MediaFeedUrl.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Lullabot\Mpx\Service\Feeds;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\DataService\Feeds\SubFeed;
+use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Class MediaFeedUrl
+ *
+ * @code
+ *      http[s]://feed.media.theplatform.com/f/<account PID>/<feed PID>[/<feed type>][/feed][/<ID>][/guid/<owner ID>/<GUIDs>][/<SEO terms>][?<query parameters>]
+ * @endcode
+ *
+ * @see https://docs.theplatform.com/help/feeds-requesting-media-feeds
+ */
+class MediaFeedUrl
+{
+
+    const BASE_URL = 'https://feed.media.theplatform.com/f/';
+
+    /**
+     * @var PublicIdentifierInterface
+     */
+    protected $account;
+
+    /**
+     * @var FeedConfig
+     */
+    protected $feedConfig;
+
+    /**
+     * @var SubFeed
+     */
+    protected $feedTypeSubFeed;
+
+    /**
+     * Forces the response to be in feed format.
+     *
+     * @var bool
+     */
+    protected $returnsFeed = false;
+
+    /**
+     * A list of SEO terms for the feed.
+     *
+     * @var string[]
+     */
+    protected $seoTerms = [];
+
+    public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig)
+    {
+        $this->account = $account;
+        $this->feedConfig = $feedConfig;
+    }
+
+    /**
+     * Get the subfeed that specifies the feed type.
+     *
+     * @return SubFeed
+     */
+    public function getFeedType(): ?SubFeed
+    {
+        return $this->feedTypeSubFeed;
+    }
+
+    /**
+     * Specifies a subfeed of the main feed.
+     *
+     * This corresponds to a SubFeed.FeedType value of an item in the FeedConfig.subFeeds field.
+     *
+     * @param SubFeed $subFeed
+     */
+    public function setFeedType(?SubFeed $subFeed): void
+    {
+        if ($subFeed && !$subFeed->getFeedType()) {
+            throw new \InvalidArgumentException('The feedType field must be specified on the subfeed.');
+        }
+        $this->feedTypeSubFeed = $subFeed;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isReturnsFeed(): bool
+    {
+        return $this->returnsFeed;
+    }
+
+    /**
+     * @param bool $returnsFeed
+     */
+    public function setReturnsFeed(bool $returnsFeed): void
+    {
+        $this->returnsFeed = $returnsFeed;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSeoTerms(): array
+    {
+        return $this->seoTerms;
+    }
+
+    /**
+     * @param string[] $seoTerms
+     */
+    public function setSeoTerms(array $seoTerms): void
+    {
+        $this->seoTerms = $seoTerms;
+    }
+
+
+    public function toUri(): UriInterface
+    {
+        $uri = $this->uriToFeedComponent();
+
+        $uri = $this->appendSeoTerms($uri);
+
+        return $uri;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->toUri();
+    }
+
+    /**
+     * @return Uri
+     */
+    protected function uriToFeedComponent()
+    {
+        $uri = new Uri(static::BASE_URL.$this->account->getPid().'/'.$this->feedConfig->getPid());
+
+        if ($this->feedTypeSubFeed) {
+            $uri = $uri->withPath($uri->getPath().'/'.$this->feedTypeSubFeed->getFeedType());
+        }
+
+        if ($this->isReturnsFeed()) {
+            $uri = $uri->withPath($uri->getPath().'/feed');
+        }
+
+        return $uri;
+    }
+
+    /**
+     * @param $uri
+     *
+     * @return mixed
+     */
+    protected function appendSeoTerms($uri)
+    {
+        if (!empty($this->seoTerms)) {
+            $uri = $uri->withPath($uri->getPath().'/'.implode('/', $this->seoTerms));
+        }
+
+        return $uri;
+}
+}

--- a/src/Service/Feeds/MediaFeedUrl.php
+++ b/src/Service/Feeds/MediaFeedUrl.php
@@ -45,7 +45,7 @@ class MediaFeedUrl implements ToUriInterface
     /**
      * The feed being rendered.
      *
-     * @var FeedConfig
+     * @var PublicIdentifierInterface
      */
     protected $feedConfig;
 
@@ -74,9 +74,9 @@ class MediaFeedUrl implements ToUriInterface
      * MediaFeedUrl constructor.
      *
      * @param PublicIdentifierInterface $account    The account the feed is associated with.
-     * @param FeedConfig                $feedConfig The feed the URL is being generated for.
+     * @param PublicIdentifierInterface $feedConfig The feed the URL is being generated for.
      */
-    public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig)
+    public function __construct(PublicIdentifierInterface $account, PublicIdentifierInterface $feedConfig)
     {
         if (empty($account->getPid())) {
             throw new \InvalidArgumentException('Account must have a public identifier set');

--- a/src/Service/Feeds/MediaFeedUrl.php
+++ b/src/Service/Feeds/MediaFeedUrl.php
@@ -78,6 +78,13 @@ class MediaFeedUrl implements ToUriInterface
      */
     public function __construct(PublicIdentifierInterface $account, FeedConfig $feedConfig)
     {
+        if (empty($account->getPid())) {
+            throw new \InvalidArgumentException('Account must have a public identifier set');
+        }
+        if (empty($feedConfig->getPid())) {
+            throw new \InvalidArgumentException('Feed config must have a public identifier set');
+        }
+
         $this->account = $account;
         $this->feedConfig = $feedConfig;
     }
@@ -195,9 +202,9 @@ class MediaFeedUrl implements ToUriInterface
      *
      * @param UriInterface $uri The URI to append to.
      *
-     * @return Uri
+     * @return UriInterface
      */
-    protected function appendSeoTerms(UriInterface $uri): Uri
+    protected function appendSeoTerms(UriInterface $uri): UriInterface
     {
         if (!empty($this->seoTerms)) {
             $uri = $uri->withPath($uri->getPath().'/'.implode('/', $this->seoTerms));

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lullabot\Mpx\Player;
+namespace Lullabot\Mpx\Service\Player;
 
 use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\Player\Player;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -15,7 +16,7 @@ use Psr\Http\Message\UriInterface;
  * @see https://docs.theplatform.com/help/displaying-mpx-players-to-your-audience
  * @see https://docs.theplatform.com/help/generate-a-player-url-for-a-media
  */
-class Url
+class Url implements ToUriInterface
 {
     /**
      * The base URL for all players.

--- a/src/ToUriInterface.php
+++ b/src/ToUriInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lullabot\Mpx;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Interface representing classes that can be rendered as a URI.
+ */
+interface ToUriInterface
+{
+    /**
+     * Return this object as a URI.
+     *
+     * @return UriInterface
+     */
+    public function toUri(): UriInterface;
+
+    /**
+     * Return this object as a URI string.
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/tests/src/Unit/DataService/Annotation/DataServiceTest.php
+++ b/tests/src/Unit/DataService/Annotation/DataServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\DataService\Annotation;
+
+use Lullabot\Mpx\DataService\Annotation\DataService;
+use Lullabot\Mpx\DataService\Field;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\DataService\Annotation\DataService
+ */
+class DataServiceTest extends TestCase
+{
+
+    /**
+     * @param $property
+     * @param $get
+     * @param $value
+     * @dataProvider getSetDataProvider
+     */
+    public function testGetSet($property, $get, $value, $return)
+    {
+        $annotation = new DataService();
+        $annotation->$property = $value;
+        $this->assertEquals($return, $annotation->$get());
+    }
+
+    public function getSetDataProvider() {
+        return [
+            'object type' => ['objectType', 'getObjectType', '/data/Player', '/data/Player'],
+            'schema version' => ['schemaVersion', 'getSchemaVersion', '1.23', '1.23'],
+            'base uri' => ['baseUri', 'getBaseUri', 'http://www.example.com/', 'http://www.example.com/'],
+            'has base uri' => ['baseUri', 'hasBaseUri', 'http://www.example.com/', true],
+            'has empty base uri' => ['baseUri', 'hasBaseUri', '', ''],
+            'service' => ['service', 'getService', 'Access Data Service', 'Access Data Service'],
+            'path' => ['objectType', 'getPath', 'Media', '/data/Media'],
+        ];
+    }
+
+    public function testGetFieldDataService()
+    {
+        $annotation = new DataService();
+        $annotation->service = 'Access Data Service';
+        $annotation->baseUri = 'http://www.example.com/';
+        $discovered = $annotation->getFieldDataService();
+        $this->assertEquals(Field::class, $discovered->getClass());
+        $discoveredAnnotation = $discovered->getAnnotation();
+        $this->assertEquals($annotation->getService(), $discoveredAnnotation->getService());
+        $this->assertEquals($annotation->getBaseUri(), $discoveredAnnotation->getBaseUri());
+        $this->assertEquals('/Field', $discoveredAnnotation->getObjectType());
+        $this->assertEquals('1.2', $discoveredAnnotation->getSchemaVersion());
+    }
+}

--- a/tests/src/Unit/DataService/Annotation/DataServiceTest.php
+++ b/tests/src/Unit/DataService/Annotation/DataServiceTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
  */
 class DataServiceTest extends TestCase
 {
-
     /**
      * @param $property
      * @param $get
@@ -25,7 +24,8 @@ class DataServiceTest extends TestCase
         $this->assertEquals($return, $annotation->$get());
     }
 
-    public function getSetDataProvider() {
+    public function getSetDataProvider()
+    {
         return [
             'object type' => ['objectType', 'getObjectType', '/data/Player', '/data/Player'],
             'schema version' => ['schemaVersion', 'getSchemaVersion', '1.23', '1.23'],

--- a/tests/src/Unit/Service/Feeds/GuidMediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/GuidMediaFeedUrlTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Service\Feeds;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\Service\Feeds\GuidMediaFeedUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\Service\Feeds\GuidMediaFeedUrl
+ */
+class GuidMediaFeedUrlTest extends TestCase
+{
+    public function testToUri()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+        $url = new GuidMediaFeedUrl($account, $feedConfig, ['first', 'second']);
+        $this->assertEquals(['first', 'second'], $url->getGuids());
+        $this->assertEquals('https://feed.media.theplatform.com/f/account-pid/feed-pid/guid/-/first,second', (string) $url->toUri());
+    }
+}

--- a/tests/src/Unit/Service/Feeds/IdMediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/IdMediaFeedUrlTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Service\Feeds;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\Service\Feeds\IdMediaFeedUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\Service\Feeds\IdMediaFeedUrl
+ */
+class IdMediaFeedUrlTest extends TestCase
+{
+    public function testToUri()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+        $url = new IdMediaFeedUrl($account, $feedConfig, [1, 2]);
+        $this->assertEquals([1, 2], $url->getIds());
+        $this->assertEquals('https://feed.media.theplatform.com/f/account-pid/feed-pid/1,2', (string) $url->toUri());
+    }
+}

--- a/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Unit\Service\Feeds;
+
+use Lullabot\Mpx\DataService\Access\Account;
+use Lullabot\Mpx\DataService\Feeds\FeedConfig;
+use Lullabot\Mpx\DataService\Feeds\SubFeed;
+use Lullabot\Mpx\Service\Feeds\MediaFeedUrl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lullabot\Mpx\Service\Feeds\MediaFeedUrl
+ */
+class MediaFeedUrlTest extends TestCase
+{
+    /**
+     * @param string $property
+     * @param mixed  $value
+     * @dataProvider getSetDataProvider
+     */
+    public function testGetSet($get, $set, $value)
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+
+        $url = new MediaFeedUrl($account, $feedConfig);
+        $url->$set($value);
+        $this->assertEquals($value, $url->$get());
+    }
+
+    public function getSetDataProvider()
+    {
+        $subfeed = new SubFeed();
+        $subfeed->setFeedType('Category');
+
+        return [
+            'seo terms' => ['getSeoTerms', 'setSeoTerms', [random_bytes(8), random_bytes(8)]],
+            'feed type' => ['getFeedType', 'setFeedType', $subfeed],
+            'returns feed' => ['isReturnsFeed', 'setReturnsFeed', true],
+            'does not return feed' => ['isReturnsFeed', 'setReturnsFeed', false],
+        ];
+    }
+
+    public function testToString()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+
+        $url = new MediaFeedUrl($account, $feedConfig);
+        $this->assertEquals('https://feed.media.theplatform.com/f/account-pid/feed-pid', (string) $url);
+    }
+
+    public function testToUri()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+
+        $url = new MediaFeedUrl($account, $feedConfig);
+        $uri = $url->toUri();
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('feed.media.theplatform.com', $uri->getHost());
+        $this->assertEquals('/f/account-pid/feed-pid', $uri->getPath());
+    }
+}

--- a/tests/src/Unit/Service/Player/UrlTest.php
+++ b/tests/src/Unit/Service/Player/UrlTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Lullabot\Mpx\Tests\Unit\Player;
+namespace Lullabot\Mpx\Tests\Unit\Service\Player;
 
 use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\Player\Player;
-use Lullabot\Mpx\Player\Url;
+use Lullabot\Mpx\Service\Player\Url;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Tests generating player URLs for embedding.
  *
- * @coversDefaultClass \Lullabot\Mpx\Player\Url
+ * @coversDefaultClass \Lullabot\Mpx\Service\Player\Url
  */
 class UrlTest extends TestCase
 {


### PR DESCRIPTION
Depends on #139 and resolves #111 .

This PR adds support for generating feed URLs. Since ID and GUIDs are not possible to include in the same URL, I've split those into two classes so it's impossible to get them mixed up. I've also added an interface shared with Player URLs for returning a rendered URI.

I thought about decorating the classes instead with `UriInterface`, but that leads to quite a bit of boilerplate without an obvious benefit.