### PR TITLE
Fix for player url

### DIFF
--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -79,7 +79,7 @@ class Url implements ToUriInterface
      */
     public function toUri(): UriInterface
     {
-        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/'.$this->media->getPid());
+        $uri = new Uri($this::BASE_URL.$this->account->getPid().'/'.$this->player->getPid().'/select/media/'.$this->media->getPid());
         $query_parts = [];
 
         if ($this->autoplay) {

--- a/tests/src/Unit/Service/Player/UrlTest.php
+++ b/tests/src/Unit/Service/Player/UrlTest.php
@@ -36,10 +36,10 @@ class UrlTest extends TestCase
         $media->setPid('media-pid');
         $player_url = new Url($account, $player, $media);
 
-        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media-pid', (string) $player_url->toUri());
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid', (string) $player_url->toUri());
 
         $player_url->setAutoplay(true);
         $player_url->setPlayAll(true);
-        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media-pid?autoplay=1&playAll=1', (string) $player_url);
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid?autoplay=1&playAll=1', (string) $player_url);
     }
 }


### PR DESCRIPTION
@deviantintegral 
- The player does not currently play the expected video. The generated iframe says "release with PID was not found; ignoring /select/" for the src"
- Adding /media to the url fixes the issue. 
- Our original conversation can be found here for reference --> https://github.com/Lullabot/media_mpx/issues/57