### PR TITLE
update object interface to include more common functions

### DIFF
--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -81,20 +81,6 @@ interface ObjectInterface extends IdInterface, JsonInterface
     public function setCustomFields(array $customFields);
 
     /**
-     * Returns the allowed values for this custom field.
-     *
-     * @return array
-     */
-    public function getAllowedValues(): array;
-
-    /**
-     * Set the allowed values for this custom field.
-     *
-     * @param array $allowedValues
-     */
-    public function setAllowedValues(array $allowedValues);
-
-    /**
      * Returns the description of this object.
      *
      * @return string

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -79,4 +79,117 @@ interface ObjectInterface extends IdInterface, JsonInterface
      * @param CustomFieldInterface[] $customFields The array of custom field implementations, keyed by their namespace.
      */
     public function setCustomFields(array $customFields);
+
+    /**
+     * Returns the allowed values for this custom field.
+     *
+     * @return array
+     */
+    public function getAllowedValues(): array;
+
+    /**
+     * Set the allowed values for this custom field.
+     *
+     * @param array $allowedValues
+     */
+    public function setAllowedValues(array $allowedValues);
+
+    /**
+     * Returns the description of this object.
+     *
+     * @return string
+     */
+    public function getDescription(): ?string;
+
+    /**
+     * Set the description of this object.
+     *
+     * @param string $description
+     */
+    public function setDescription(?string $description);
+
+    /**
+     * Returns an alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): ?string;
+
+    /**
+     * Set an alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string $guid
+     */
+    public function setGuid(?string $guid);
+
+    /**
+     * Returns whether this object currently allows updates.
+     *
+     * @return bool
+     */
+    public function getLocked(): ?bool;
+
+    /**
+     * Set whether this object currently allows updates.
+     *
+     * @param bool $locked
+     */
+    public function setLocked(?bool $locked);
+
+    /**
+     * Returns the name of this object.
+     *
+     * @return string
+     */
+    public function getTitle(): ?string;
+
+    /**
+     * Set the name of this object.
+     *
+     * @param string $title
+     */
+    public function setTitle(?string $title);
+
+    /**
+     * Returns the date and time this object was last modified.
+     *
+     * @return \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface
+     */
+    public function getUpdated(): DateTimeFormatInterface;
+
+    /**
+     * Set the date and time this object was last modified.
+     *
+     * @param \Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface $updated
+     */
+    public function setUpdated(DateTimeFormatInterface $updated);
+
+    /**
+     * Returns the id of the user that last modified this object.
+     *
+     * @return \Psr\Http\Message\UriInterface
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface;
+
+    /**
+     * Set the id of the user that last modified this object.
+     *
+     * @param \Psr\Http\Message\UriInterface $updatedByUserId
+     */
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId);
+
+    /**
+     * Returns this object's modification version, used for optimistic locking.
+     *
+     * @return int
+     */
+    public function getVersion(): ?int;
+
+    /**
+     * Set this object's modification version, used for optimistic locking.
+     *
+     * @param int $version
+     */
+    public function setVersion(?int $version);
+
 }

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -177,5 +177,4 @@ interface ObjectInterface extends IdInterface, JsonInterface
      * @param int $version
      */
     public function setVersion(?int $version);
-
 }

--- a/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
@@ -210,4 +210,74 @@ class DummyCustomFields extends ObjectBase implements CustomFieldInterface
     {
         $this->ownerId = $ownerId;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDescription(?string $description) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGuid(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGuid(?string $guid) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocked(): ?bool {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocked(?bool $locked) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTitle(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTitle(?string $title) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdated(): DateTimeFormatInterface {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdated(DateTimeFormatInterface $updated) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion(): ?int {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVersion(?int $version) {}
 }

--- a/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
@@ -214,70 +214,98 @@ class DummyCustomFields extends ObjectBase implements CustomFieldInterface
     /**
      * {@inheritdoc}
      */
-    public function getDescription(): ?string {}
+    public function getDescription(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setDescription(?string $description) {}
+    public function setDescription(?string $description)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getGuid(): ?string {}
+    public function getGuid(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setGuid(?string $guid) {}
+    public function setGuid(?string $guid)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getLocked(): ?bool {}
+    public function getLocked(): ?bool
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setLocked(?bool $locked) {}
+    public function setLocked(?bool $locked)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getTitle(): ?string {}
+    public function getTitle(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setTitle(?string $title) {}
+    public function setTitle(?string $title)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getUpdated(): DateTimeFormatInterface {}
+    public function getUpdated(): DateTimeFormatInterface
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setUpdated(DateTimeFormatInterface $updated) {}
+    public function setUpdated(DateTimeFormatInterface $updated)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface {}
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId) {}
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getVersion(): ?int {}
+    public function getVersion(): ?int
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setVersion(?int $version) {}
+    public function setVersion(?int $version)
+    {
+    }
 }

--- a/tests/src/Unit/ObjectBaseTest.php
+++ b/tests/src/Unit/ObjectBaseTest.php
@@ -115,4 +115,74 @@ class DummyObjectBase extends ObjectBase
     {
         $this->ownerId = $ownerId;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDescription(?string $description) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGuid(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGuid(?string $guid) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocked(): ?bool {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLocked(?bool $locked) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTitle(): ?string {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTitle(?string $title) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdated(): DateTimeFormatInterface {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdated(DateTimeFormatInterface $updated) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion(): ?int {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVersion(?int $version) {}
 }

--- a/tests/src/Unit/ObjectBaseTest.php
+++ b/tests/src/Unit/ObjectBaseTest.php
@@ -119,70 +119,98 @@ class DummyObjectBase extends ObjectBase
     /**
      * {@inheritdoc}
      */
-    public function getDescription(): ?string {}
+    public function getDescription(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setDescription(?string $description) {}
+    public function setDescription(?string $description)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getGuid(): ?string {}
+    public function getGuid(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setGuid(?string $guid) {}
+    public function setGuid(?string $guid)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getLocked(): ?bool {}
+    public function getLocked(): ?bool
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setLocked(?bool $locked) {}
+    public function setLocked(?bool $locked)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getTitle(): ?string {}
+    public function getTitle(): ?string
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setTitle(?string $title) {}
+    public function setTitle(?string $title)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getUpdated(): DateTimeFormatInterface {}
+    public function getUpdated(): DateTimeFormatInterface
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setUpdated(DateTimeFormatInterface $updated) {}
+    public function setUpdated(DateTimeFormatInterface $updated)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface {}
+    public function getUpdatedByUserId(): \Psr\Http\Message\UriInterface
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId) {}
+    public function setUpdatedByUserId(\Psr\Http\Message\UriInterface $updatedByUserId)
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function getVersion(): ?int {}
+    public function getVersion(): ?int
+    {
+    }
 
     /**
      * {@inheritdoc}
      */
-    public function setVersion(?int $version) {}
+    public function setVersion(?int $version)
+    {
+    }
 }


### PR DESCRIPTION
This was first motivated by https://github.com/Lullabot/media_mpx/pull/72#discussion_r226679801
I did a quick  pass through the Field object and pulled all the getters and setters that looked generic to all objects.

A couple things could still either be done here or be added as an issue for future improvement
- [ ] Clean up the comments so `@inheritdoc` is being used where needed
- [ ] Refactor some of this code, I have not confirmed it but I suspect a lot of these functions are the same and could be implemented in ObjectBase instead.
- [ ] Adjust tests to match refactoring