### PR TITLE
Allow any public identifier for player URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Added
+
+- Allow any object with a public ID to be used for player URLs #152
+
 ## [0.8.3] - 2018-11-05
 
 ### Added

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -4,8 +4,6 @@ namespace Lullabot\Mpx\Service\Player;
 
 use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;
-use Lullabot\Mpx\DataService\Media\Media;
-use Lullabot\Mpx\DataService\Player\Player;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
@@ -33,14 +31,14 @@ class Url implements ToUriInterface
     /**
      * The player object the URL is being generated for.
      *
-     * @var Player
+     * @var PublicIdentifierInterface
      */
     private $player;
 
     /**
      * The media that is being played.
      *
-     * @var Media
+     * @var PublicIdentifierInterface
      */
     private $media;
 
@@ -71,10 +69,10 @@ class Url implements ToUriInterface
      * Url constructor.
      *
      * @param PublicIdentifierInterface $account The account the player is owned by.
-     * @param Player                    $player  The player to play $media with.
-     * @param Media                     $media   The media to play.
+     * @param PublicIdentifierInterface $player  The player to play $media with.
+     * @param PublicIdentifierInterface $media   The media to play.
      */
-    public function __construct(PublicIdentifierInterface $account, Player $player, Media $media)
+    public function __construct(PublicIdentifierInterface $account, PublicIdentifierInterface $player, PublicIdentifierInterface $media)
     {
         $this->player = $player;
         $this->media = $media;


### PR DESCRIPTION
Since all we call is getPid, there's no need to enforce a whole concrete object. Interfaces FTW!