### PR TITLE
Set the account context when listening for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - YYYY-MM-DD
 
+### Added
+
+- `Notification` now has an `isSyncResponse()` method to determine if no
+  further notifications are available. #154
+
 ### Changed
 
 - Setting an account context for requests is now done by setting the account

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Changed
+
+- Setting an account context for requests is now done by setting the account
+  parameter in the `AuthenticatedClient` constructor. The account parameter has
+  been removed from all methods in `DataObjectFactory`. #154
+- `NotificationListener` now supports sets an account context to limit
+  notifications to a single account only. #154
+
 ## [0.9.0] - 2018-12-12
 
 ### Added

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -5,6 +5,7 @@ namespace Lullabot\Mpx;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
+use Lullabot\Mpx\DataService\IdInterface;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Psr\Http\Message\RequestInterface;
@@ -26,6 +27,15 @@ class AuthenticatedClient implements ClientInterface
     protected $client;
 
     /**
+     * An optional account to use as the account context for requests.
+     *
+     * @see https://docs.theplatform.com/help/wsf-introduction-to-theplatforms-web-services#IntroductiontothePlatform%27sWebservices-Accountcontext
+     *
+     * @var \Lullabot\Mpx\DataService\IdInterface
+     */
+    protected $account;
+
+    /**
      * The duration for authentication tokens to last for, or null for no
      * specific expiry.
      *
@@ -41,11 +51,16 @@ class AuthenticatedClient implements ClientInterface
      *
      * @param Client      $client      The client used to access MPX.
      * @param UserSession $userSession The user associated with this client.
+     * @param IdInterface $account     (optional) The account to use as the account context for requests.
      */
-    public function __construct(Client $client, UserSession $userSession)
+    public function __construct(Client $client, UserSession $userSession, IdInterface $account = null)
     {
         $this->client = $client;
         $this->userSession = $userSession;
+
+        if ($account) {
+            $this->account = $account;
+        }
     }
 
     /**
@@ -96,6 +111,32 @@ class AuthenticatedClient implements ClientInterface
     public function setTokenDuration(int $duration = null)
     {
         $this->duration = $duration;
+    }
+
+    /**
+     * Return if this client has an account context.
+     *
+     * @return bool
+     */
+    public function hasAccount(): bool
+    {
+        return isset($this->account);
+    }
+
+    /**
+     * Return the account to use as the context for requests.
+     *
+     * @throws \LogicException Thrown if an account context is not set.
+     *
+     * @return \Lullabot\Mpx\DataService\IdInterface
+     */
+    public function getAccount(): IdInterface
+    {
+        if (!$this->account) {
+            throw new \LogicException('hasAccount() must return TRUE before calling getAccount()');
+        }
+
+        return $this->account;
     }
 
     /**

--- a/src/DataService/Notification.php
+++ b/src/DataService/Notification.php
@@ -3,7 +3,7 @@
 namespace Lullabot\Mpx\DataService;
 
 /**
- * Represents an MPX notification.
+ * Represents an mpx notification.
  *
  * @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications
  */
@@ -91,5 +91,17 @@ class Notification
     public function setType(string $type)
     {
         $this->type = $type;
+    }
+
+    /**
+     * Return if this notification is a sync response, containing only an ID.
+     *
+     * @see https://docs.theplatform.com/help/wsf-subscribing-to-change-notifications#tp-toc10
+     *
+     * @return bool
+     */
+    public function isSyncResponse(): bool
+    {
+        return !($this->method || $this->type || $this->entry);
     }
 }

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -94,12 +94,18 @@ class NotificationListener
     public function sync()
     {
         // @todo Add support for filtering.
+        $query = [
+            'clientId' => $this->clientId,
+            'form' => 'cjson',
+            'schema' => '1.10',
+        ];
+
+        if ($this->authenticatedClient->hasAccount()) {
+            $query['account'] = (string) $this->authenticatedClient->getAccount()->getMpxId();
+        }
+
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
-            'query' => [
-                'clientId' => $this->clientId,
-                'form' => 'cjson',
-                'schema' => '1.10',
-            ],
+            'query' => $query,
         ])->then(function (ResponseInterface $response) {
             $data = \GuzzleHttp\json_decode($response->getBody(), true);
 
@@ -127,16 +133,22 @@ class NotificationListener
      */
     public function listen(int $since, int $maximum = 500)
     {
+        $query = [
+            'clientId' => $this->clientId,
+            'since' => $since,
+            'block' => 'true',
+            'form' => 'cjson',
+            'schema' => '1.10',
+            'filter' => $this->service->getAnnotation()->getObjectType(),
+            'size' => $maximum,
+        ];
+
+        if ($this->authenticatedClient->hasAccount()) {
+            $query['account'] = (string) $this->authenticatedClient->getAccount()->getMpxId();
+        }
+
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
-            'query' => [
-                'clientId' => $this->clientId,
-                'since' => $since,
-                'block' => 'true',
-                'form' => 'cjson',
-                'schema' => '1.10',
-                'filter' => $this->service->getAnnotation()->getObjectType(),
-                'size' => $maximum,
-            ],
+            'query' => $query,
         ])->then(function (ResponseInterface $response) {
             // First, we need an encoder that filters out null values.
             $encoders = [new JsonEncoder()];

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -150,22 +150,33 @@ class NotificationListener
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
             'query' => $query,
         ])->then(function (ResponseInterface $response) {
-            // First, we need an encoder that filters out null values.
-            $encoders = [new JsonEncoder()];
-
-            // Attempt normalizing each key in this order, including denormalizing recursively.
-            $extractor = new NotificationTypeExtractor();
-            $extractor->setClass($this->service->getClass());
-            $normalizers = [
-                new UnixMillisecondNormalizer(),
-                new UriNormalizer(),
-                new ObjectNormalizer(null, null, null, $extractor),
-                new ArrayDenormalizer(),
-            ];
-
-            $serializer = new Serializer($normalizers, $encoders);
-            // @todo Handle exception returns.
-            return $serializer->deserialize($response->getBody(), Notification::class.'[]', 'json');
+            return $this->deserializeResponse($response);
         });
+    }
+
+    /**
+     * Deserialize a notification response.
+     *
+     * @param ResponseInterface $response
+     *
+     * @return Notification
+     */
+    protected function deserializeResponse(ResponseInterface $response) {
+        // First, we need an encoder that filters out null values.
+        $encoders = [new JsonEncoder()];
+
+        // Attempt normalizing each key in this order, including denormalizing recursively.
+        $extractor = new NotificationTypeExtractor();
+        $extractor->setClass($this->service->getClass());
+        $normalizers = [
+            new UnixMillisecondNormalizer(),
+            new UriNormalizer(),
+            new ObjectNormalizer(null, null, null, $extractor),
+            new ArrayDenormalizer(),
+        ];
+
+        $serializer = new Serializer($normalizers, $encoders);
+        // @todo Handle exception returns.
+        return $serializer->deserialize($response->getBody(), Notification::class.'[]', 'json');
     }
 }

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -161,7 +161,8 @@ class NotificationListener
      *
      * @return Notification
      */
-    protected function deserializeResponse(ResponseInterface $response) {
+    protected function deserializeResponse(ResponseInterface $response)
+    {
         // First, we need an encoder that filters out null values.
         $encoders = [new JsonEncoder()];
 

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -4,7 +4,6 @@ namespace Lullabot\Mpx\DataService;
 
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use Lullabot\Mpx\DataService\Access\Account;
 
 /**
  * An ObjectList represents a list of data service objects from a search query.
@@ -72,13 +71,6 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      * @var DataObjectFactory
      */
     protected $dataObjectFactory;
-
-    /**
-     * The account context used for this list.
-     *
-     * @var Account
-     */
-    protected $account;
 
     /**
      * The original JSON of this object list.
@@ -214,12 +206,10 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      * Set the objects needed to generate a next request.
      *
      * @param DataObjectFactory $dataObjectFactory The factory used to load the next ObjectList.
-     * @param IdInterface       $account           (optional) The account context to use for the request.
      */
-    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory, IdInterface $account = null)
+    public function setDataObjectFactory(DataObjectFactory $dataObjectFactory)
     {
         $this->dataObjectFactory = $dataObjectFactory;
-        $this->account = $account;
     }
 
     /**
@@ -257,7 +247,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
         $range = Range::nextRange($this);
         $byFields->setRange($range);
 
-        return $this->dataObjectFactory->selectRequest($byFields, $this->account);
+        return $this->dataObjectFactory->selectRequest($byFields);
     }
 
     /**
@@ -284,7 +274,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
         foreach ($ranges as $range) {
             $byFields = clone $this->objectListQuery;
             $byFields->setRange($range);
-            yield $this->dataObjectFactory->selectRequest($byFields, $this->account);
+            yield $this->dataObjectFactory->selectRequest($byFields);
         }
     }
 

--- a/tests/src/Functional/DataService/Access/AccountQueryTest.php
+++ b/tests/src/Functional/DataService/Access/AccountQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Lullabot\Mpx\Tests\Functional\DataService\Account;
 
+use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\ObjectListQuery;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DataServiceManager;
@@ -13,6 +14,21 @@ use Psr\Http\Message\UriInterface;
  */
 class AccountQueryTest extends FunctionalTestBase
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Override the client to not include an account context, since the
+        // access data service does not support it.
+        $this->authenticatedClient = new AuthenticatedClient(
+            $this->client,
+            $this->userSession
+        );
+    }
+
     /**
      * Test loading two Account objects.
      */

--- a/tests/src/Functional/DataService/CustomFieldTest.php
+++ b/tests/src/Functional/DataService/CustomFieldTest.php
@@ -27,7 +27,7 @@ class CustomFieldTest extends FunctionalTestBase
         $range->setStartIndex(1)
             ->setEndIndex(2);
         $filter->setRange($range);
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
         foreach ($results as $index => $field) {
             $this->assertInstanceOf(Field::class, $field);
 

--- a/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Functional/DataService/Feeds/FeedConfigTest.php
@@ -24,7 +24,7 @@ class FeedConfigTest extends FunctionalTestBase
         $filter = new ObjectListQuery();
         $filter->getRange()->setStartIndex(1)
             ->setEndIndex(2);
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
 
         foreach ($results as $index => $result) {
             $this->assertInstanceOf(UriInterface::class, $result->getId());

--- a/tests/src/Functional/DataService/FieldsTest.php
+++ b/tests/src/Functional/DataService/FieldsTest.php
@@ -20,7 +20,7 @@ class FieldsTest extends FunctionalTestBase
         $fields = (new Fields())->addField('title');
         $filter->add($fields);
         $filter->setRange((new Range())->setStartIndex(1)->setEndIndex(1));
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
         $results->valid();
         $result = $results->current();
         $json = $result->getJson();

--- a/tests/src/Functional/DataService/Media/MediaFileTest.php
+++ b/tests/src/Functional/DataService/Media/MediaFileTest.php
@@ -24,7 +24,7 @@ class MediaFileTest extends FunctionalTestBase
         $filter = new ObjectListQuery();
         $filter->getRange()->setStartIndex(1)
             ->setEndIndex(2);
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
 
         foreach ($results as $index => $result) {
             $this->assertInstanceOf(UriInterface::class, $result->getId());

--- a/tests/src/Functional/DataService/Media/MediaQueryTest.php
+++ b/tests/src/Functional/DataService/Media/MediaQueryTest.php
@@ -27,7 +27,7 @@ class MediaQueryTest extends FunctionalTestBase
         $filter->getRange()
             ->setStartIndex(1)
             ->setEndIndex(2);
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
 
         foreach ($results as $index => $result) {
             $this->assertInstanceOf(UriInterface::class, $result->getId());
@@ -65,12 +65,12 @@ class MediaQueryTest extends FunctionalTestBase
             ->setStartIndex(1)
             ->setEndIndex(2);
         /** @var ObjectList $list */
-        $list = $dof->selectRequest($filter, $this->account)->wait();
+        $list = $dof->selectRequest($filter)->wait();
 
         // Determine the end of the list of ranges.
         $ranges = Range::nextRanges($list);
         $filter->setRange(end($ranges));
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
 
         foreach ($results as $index => $result) {
             $this->assertInstanceOf(UriInterface::class, $result->getId());

--- a/tests/src/Functional/DataService/Player/PlayerQueryTest.php
+++ b/tests/src/Functional/DataService/Player/PlayerQueryTest.php
@@ -24,7 +24,7 @@ class PlayerQueryTest extends FunctionalTestBase
         $filter->getRange()
             ->setStartIndex(1)
             ->setEndIndex(2);
-        $results = $dof->select($filter, $this->account);
+        $results = $dof->select($filter);
 
         foreach ($results as $index => $result) {
             $this->assertInstanceOf(UriInterface::class, $result->getId());

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -85,12 +85,13 @@ abstract class FunctionalTestBase extends TestCase
 
         $user = new User($username, $password);
         $this->userSession = new UserSession($user, $this->client, $store, new TokenCachePool(new ArrayCachePool()));
-        $this->authenticatedClient = new AuthenticatedClient(
-            $this->client,
-            $this->userSession
-        );
 
         $this->account = new Account();
         $this->account->setId(new Uri($account_id));
+        $this->authenticatedClient = new AuthenticatedClient(
+            $this->client,
+            $this->userSession,
+            $this->account
+        );
     }
 }

--- a/tests/src/Functional/ReadmeTest.php
+++ b/tests/src/Functional/ReadmeTest.php
@@ -52,7 +52,7 @@ class ReadmeTest extends FunctionalTestBase
         $filter->getRange()
             ->setStartIndex(1)
             ->setEndIndex(1);
-        $results = $mediaFactory->select($filter, $account);
+        $results = $mediaFactory->select($filter);
         foreach ($results as $media) {
             // Replace the ID to the media item to load. You can find it under "History -> ID" in the MPX console.
             $id = $media->getId();
@@ -93,7 +93,7 @@ class ReadmeTest extends FunctionalTestBase
         $termGroup->and(new Term('dogs'));
         $query->add($termGroup);
         $query->getRange()->setEndIndex(1);
-        $results = $mediaFactory->select($query, $account);
+        $results = $mediaFactory->select($query);
 
         foreach ($results as $media) {
             $this->assertInstanceOf(UriInterface::class, $media->getId());

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -242,6 +242,7 @@ class AuthenticatedClientTest extends TestCase
     }
 
     /**
+     * @covers ::hasAccount
      * @covers ::getAccount
      */
     public function testGetAccount()
@@ -258,6 +259,7 @@ class AuthenticatedClientTest extends TestCase
 
         $account = new Account();
         $authenticatedClient = new AuthenticatedClient($client, $userSession, $account);
+        $this->assertTrue($authenticatedClient->hasAccount());
 
         $this->assertSame($account, $authenticatedClient->getAccount());
     }

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\Client;
+use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Lullabot\Mpx\Tests\JsonResponse;
@@ -238,6 +239,27 @@ class AuthenticatedClientTest extends TestCase
             ->willReturn(new Token('mpx/USER-ID', 'abcdef', $duration));
         $authenticatedClient->setTokenDuration($duration);
         $authenticatedClient->request('GET', 'https://www.example.com/');
+    }
+
+    /**
+     * @covers ::getAccount
+     */
+    public function testGetAccount()
+    {
+        /** @var Client|\PHPUnit\Framework\MockObject\MockObject $client */
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var UserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
+        $userSession = $this->getMockBuilder(UserSession::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $account = new Account();
+        $authenticatedClient = new AuthenticatedClient($client, $userSession, $account);
+
+        $this->assertSame($account, $authenticatedClient->getAccount());
     }
 
     /**

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -97,12 +97,12 @@ class DataObjectFactoryTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
         $session = new UserSession($user, $client, $store, $tokenCachePool);
-        $authenticatedClient = new AuthenticatedClient($client, $session);
-        $factory = new DataObjectFactory($service, $authenticatedClient);
-
         $account = new Account();
         $account->setId(new Uri('http://example.com/1'));
-        $media = $factory->loadByNumericId(12345, $account)->wait();
+        $authenticatedClient = new AuthenticatedClient($client, $session, $account);
+        $factory = new DataObjectFactory($service, $authenticatedClient);
+
+        $media = $factory->loadByNumericId(12345)->wait();
         $this->assertInstanceOf(Media::class, $media);
     }
 

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -75,6 +75,7 @@ class NotificationListenerTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::listen
+     * @covers ::deserializeResponse
      */
     public function testListen()
     {

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -47,4 +47,20 @@ class NotificationTest extends ObjectTestBase
             }
         }
     }
+
+    public function testIsSyncResponse()
+    {
+        /** @var Notification[] $notifications */
+        $notifications = $this->serializer->deserialize('[{"id": 12345 }]', Notification::class.'[]', 'json');
+        $this->assertCount(1, $notifications);
+        $this->assertTrue($notifications[0]->isSyncResponse());
+    }
+
+    public function testIsNotSyncResponse()
+    {
+        /** @var Notification[] $notifications */
+        $notifications = $this->serializer->deserialize('[{"id": 12345, "method": "get" }]', Notification::class.'[]', 'json');
+        $this->assertCount(1, $notifications);
+        $this->assertFalse($notifications[0]->isSyncResponse());
+    }
 }

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -108,7 +108,7 @@ class ObjectListTest extends TestCase
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();
-        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setDataObjectFactory($dof);
         $this->list->setObjectListQuery(new ObjectListQuery());
 
         $this->assertInstanceOf(PromiseInterface::class, $this->list->nextList());
@@ -127,7 +127,7 @@ class ObjectListTest extends TestCase
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();
-        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setDataObjectFactory($dof);
         $this->list->setObjectListQuery(new ObjectListQuery());
         $this->assertFalse($this->list->nextList());
     }
@@ -161,7 +161,7 @@ class ObjectListTest extends TestCase
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();
-        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setDataObjectFactory($dof);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('setByFields must be called before calling nextList.');
         $this->list->nextList();
@@ -245,7 +245,7 @@ class ObjectListTest extends TestCase
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();
-        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setDataObjectFactory($dof);
         $this->list->setObjectListQuery(new ObjectListQuery());
         $y = $this->list->yieldLists();
         foreach ($y as $l) {
@@ -275,7 +275,7 @@ class ObjectListTest extends TestCase
         /** @var DataObjectFactory $dof */
         $dof = $this->getMockBuilder(DataObjectFactory::class)->disableOriginalConstructor()->getMock();
         $account = new Account();
-        $this->list->setDataObjectFactory($dof, $account);
+        $this->list->setDataObjectFactory($dof);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('setByFields must be called before calling nextList.');
         $this->list->yieldLists()->current();

--- a/tests/src/Unit/Service/Feeds/IdMediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/IdMediaFeedUrlTest.php
@@ -12,6 +12,28 @@ use PHPUnit\Framework\TestCase;
  */
 class IdMediaFeedUrlTest extends TestCase
 {
+    public function testEmptyIds()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one ID must be specified');
+        new IdMediaFeedUrl($account, $feedConfig, []);
+    }
+
+    public function testInvalidIds()
+    {
+        $account = new Account();
+        $account->setPid('account-pid');
+        $feedConfig = new FeedConfig();
+        $feedConfig->setPid('feed-pid');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('All IDs must be integers');
+        new IdMediaFeedUrl($account, $feedConfig, [34, '45']);
+    }
+
     public function testToUri()
     {
         $account = new Account();


### PR DESCRIPTION
When listening for notifications, there is no way to set the account context, which means that for mpx users that have multiple accounts all objects will be imported.

I ended up doing some refactoring to help limit this type of bug in the future. Before, you could pass an account context into a variety of methods. That could make for confusing bugs, if the same objects are used to load data from different accounts. Instead, I've put the account context onto the `AuthenticatedClient` itself. If you need to query with a different account context (or none at all), you would create a different client object to work with.

As well, some mpx APIs don't support account contexts and throw an error if one is provided. Since there's no way for us to know that automatically, we leave it to the developer to create a client with a `null` account context in the constructor.

If I'm lucky, this should actually reduce some of the code complexity by removing a parameter from more methods than it is added to.

TODOs:

- [x] Update the CHANGELOG