### PR TITLE
Add a command to GET an arbitrary mpx object

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,7 @@
 
 use Lullabot\Mpx\Command\CreateCustomFieldClassCommand;
 use Lullabot\Mpx\Command\CreateDataServiceClassCommand;
+use Lullabot\Mpx\Command\GetCommand;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -11,6 +12,7 @@ $application = new Symfony\Component\Console\Application;
 
 $application->add(new CreateDataServiceClassCommand());
 $application->add(new CreateCustomFieldClassCommand());
+$application->add(new GetCommand());
 
 // Run it
 $application->run();

--- a/command/src/ClassGeneratorBase.php
+++ b/command/src/ClassGeneratorBase.php
@@ -9,9 +9,8 @@ use Lullabot\Mpx\DataService\Media\TransferInfo;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\Parameter;
 use Psr\Http\Message\UriInterface;
-use Symfony\Component\Console\Command\Command;
 
-abstract class ClassGenerator extends Command
+abstract class ClassGeneratorBase extends MpxCommandBase
 {
     /**
      * Maps custom mpx field types to PHP datatypes.
@@ -31,11 +30,11 @@ abstract class ClassGenerator extends Command
         'Decimal' => 'float',
         'Expression' => 'string',
         'Float' => 'float',
-        'Image' => '\\' . Image::class,
+        'Image' => '\\'.Image::class,
         'Map<String, String>' => 'array',
         'Map<String, Integer>' => 'array',
         'Integer' => 'int',
-        'Link' => '\\' . Link::class,
+        'Link' => '\\'.Link::class,
         'Long' => 'int',
         'Map' => 'array',
         'String (64, ASCII)' => 'string',
@@ -55,7 +54,7 @@ abstract class ClassGenerator extends Command
      */
     protected function isScalarType(string $dataType): bool
     {
-        return in_array($dataType, ['int', 'float', 'string', 'bool']);
+        return \in_array($dataType, ['int', 'float', 'string', 'bool']);
     }
 
     /**

--- a/command/src/CreateDataServiceClassCommand.php
+++ b/command/src/CreateDataServiceClassCommand.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\UriInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateDataServiceClassCommand extends ClassGenerator
+class CreateDataServiceClassCommand extends ClassGeneratorBase
 {
     protected function configure()
     {
@@ -23,14 +23,14 @@ class CreateDataServiceClassCommand extends ClassGenerator
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $handle = fopen('php://stdin', 'r');
+        $handle = fopen('php://stdin', 'rb');
         $index = 0;
 
         $output->write("<?php\n\n");
 
         // Extract the containing class namespace and the class name.
         $parts = explode('\\', $input->getArgument('fully-qualified-class-name'));
-        $namespace = new PhpNamespace(implode('\\', array_slice($parts, 0, -1)));
+        $namespace = new PhpNamespace(implode('\\', \array_slice($parts, 0, -1)));
         $class = $namespace->addClass(end($parts));
 
         // Loop over each row, which corresponds to each property.
@@ -47,7 +47,7 @@ class CreateDataServiceClassCommand extends ClassGenerator
                 continue;
             }
 
-            if (strrpos($description, '.') !== (strlen($description) - 1)) {
+            if (strrpos($description, '.') !== (\strlen($description) - 1)) {
                 $description .= '.';
             }
 

--- a/command/src/GetCommand.php
+++ b/command/src/GetCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Lullabot\Mpx\Command;
+
+use GuzzleHttp\Psr7\Uri;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Execute a GET request on an mpx data service object.
+ */
+class GetCommand extends MpxCommandBase
+{
+    protected function configure()
+    {
+        parent::configure();
+        $help = <<<EOD
+This command loads an mpx data service object.
+
+An mpx username and password is required. They will be requested interactively,
+or MPX_USERNAME, and MPX_PASSWORD environment variables will be used.
+
+If debug logging is enabled (-vvv) then each request and response will be
+printed to the console.
+EOD;
+        $this->setName('mpx:get')
+            ->setDescription('This command GETs an mpx object by ID.')
+            ->setHelp($help)
+            ->addUsage('mpx:get http://data.media.theplatform.com/media/data/Media/12345')
+            ->addArgument(
+                'id',
+                InputArgument::REQUIRED,
+                'The full ID of the mpx object to load.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $client = $this->getAuthenticatedClient($input, $output);
+
+        $id = new Uri($input->getArgument('id'));
+        $parts = explode('/', $id->getPath());
+        if ('data' != $parts[2]) {
+            throw new \RuntimeException('The URL is not a data service URL');
+        }
+        $s = $parts[3];
+        $service_name = ucfirst($s).' Data Service';
+
+        $manager = DataServiceManager::basicDiscovery();
+        $service = null;
+        $services = $manager->getDataServices();
+        if (isset($services[$service_name][$s])) {
+            $service = reset($services[$service_name][$s]);
+        } else {
+            throw new \RuntimeException('No data service was found for the URL');
+        }
+
+        $dof = new DataObjectFactory($service->getAnnotation()->getFieldDataService(), $client);
+        $loaded = $dof->load($id)->wait();
+        $output->write(var_export($loaded, true));
+    }
+}

--- a/command/src/MpxCommandBase.php
+++ b/command/src/MpxCommandBase.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Lullabot\Mpx\Command;
+
+use Cache\Adapter\PHPArray\ArrayCachePool;
+use Concat\Http\Middleware\Logger;
+use GuzzleHttp\MessageFormatter;
+use Lullabot\Mpx\AuthenticatedClient;
+use Lullabot\Mpx\Client;
+use Lullabot\Mpx\DataService\DataObjectFactory;
+use Lullabot\Mpx\DataService\DataServiceManager;
+use Lullabot\Mpx\Service\IdentityManagement\User;
+use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\TokenCachePool;
+use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Lock\Store\FlockStore;
+
+abstract class MpxCommandBase extends Command
+{
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return DataObjectFactory
+     */
+    protected function getDataObjectFactory(InputInterface $input, OutputInterface $output): DataObjectFactory
+    {
+        $authenticatedClient = $this->getAuthenticatedClient($input, $output);
+        $manager = DataServiceManager::basicDiscovery();
+        $dataService = $manager->getDataService(
+            $input->getArgument('data-service'),
+            $input->getArgument('data-object'),
+            $input->getArgument('schema')
+        );
+        $dof = new DataObjectFactory($dataService->getAnnotation()
+            ->getFieldDataService(), $authenticatedClient);
+
+        return $dof;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return \Lullabot\Mpx\AuthenticatedClient
+     */
+    protected function getAuthenticatedClient(InputInterface $input, OutputInterface $output): \Lullabot\Mpx\AuthenticatedClient
+    {
+        $helper = $this->getHelper('question');
+        if (!$username = getenv('MPX_USERNAME')) {
+            $question = new Question('Enter the mpx user name, such as mpx/you@example.com: ');
+            $username = $helper->ask($input, $output, $question);
+        }
+        if (!$password = getenv('MPX_PASSWORD')) {
+            $question = new Question('Enter the mpx password: ');
+            $question->setHidden(true)
+                ->setHiddenFallback(false);
+            $password = $helper->ask($input, $output, $question);
+        }
+
+        $config = Client::getDefaultConfiguration();
+
+        $cl = new ConsoleLogger($output);
+        /** @var $handler \GuzzleHttp\HandlerStack */
+        $handler = $config['handler'];
+        $handler->after('cookies', new CurlFormatterMiddleware($cl));
+
+        $responseLogger = new Logger($cl);
+        $responseLogger->setLogLevel(LogLevel::DEBUG);
+        $responseLogger->setFormatter(new MessageFormatter(MessageFormatter::DEBUG));
+        $handler->after('cookies', $responseLogger);
+
+        $client = new Client(new \GuzzleHttp\Client($config));
+
+        $store = new FlockStore();
+        $user = new User($username, $password);
+        $userSession = new UserSession($user, $client, $store, new TokenCachePool(new ArrayCachePool()));
+        $authenticatedClient = new AuthenticatedClient(
+            $client,
+            $userSession
+        );
+
+        return $authenticatedClient;
+    }
+}


### PR DESCRIPTION
I was getting annoyed with hacking functional tests to load mpx objects for debugging, so I wrote a console command to do so.

```
Usage:
  mpx:get <id>
  mpx:get http://data.media.theplatform.com/media/data/Media/12345

Arguments:
  id                    The full ID of the mpx object to load.

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  This command loads an mpx data service object.

  An mpx username and password is required. They will be requested interactively,
  or MPX_USERNAME, and MPX_PASSWORD environment variables will be used.

  If debug logging is enabled (-vvv) then each request and response will be
  printed to the console.
```