### PR TITLE
Add new interfaces to fix wrong typehint on Url missing getPid() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - YYYY-MM-DD
+
+### Changed
+
+- New interfaces have been added, which ObjectInterface now inherits from.
+   * `\Lullabot\Mpx\DataService\OwnerIdInterface` represents objects with an
+      owner.
+   * `\Lullabot\Mpx\DataService\GuidInterface` represents objects with a GUID.
+   * `\Lullabot\Mpx\DataService\PublicIdWithGuidInterface` represents objects
+     containing both a public ID and a GUID.
+- `\Lullabot\Mpx\Service\Player\Url::__construct()` now typehints to a
+  `PublicIdWithGuidInterface`, which is required for rendering URLs with a
+  GUID.
+
 ## [0.10.0] - 2019-01-13
 
 ### Added

--- a/src/DataService/Access/Account.php
+++ b/src/DataService/Access/Account.php
@@ -6,8 +6,8 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Lullabot\Mpx\DataService\IdInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 
 /**
  * @DataService(
@@ -17,7 +17,7 @@ use Lullabot\Mpx\DataService\IdInterface;
  *   objectType="Account"
  * )
  */
-class Account extends ObjectBase implements PublicIdentifierInterface, IdInterface
+class Account extends ObjectBase implements PublicIdWithGuidInterface, IdInterface
 {
     /**
      * The date and time that this object was created.

--- a/src/DataService/Feeds/FeedConfig.php
+++ b/src/DataService/Feeds/FeedConfig.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 
 /**
  * FeedConfig represents the configuration of a feed.
@@ -19,7 +19,7 @@ use Lullabot\Mpx\DataService\PublicIdentifierInterface;
  *     schemaVersion="2.2",
  * )
  */
-class FeedConfig extends ObjectBase implements PublicIdentifierInterface
+class FeedConfig extends ObjectBase implements PublicIdWithGuidInterface
 {
     /**
      * The parameters that are passed to a custom feed adapter for processing at runtime.

--- a/src/DataService/GuidInterface.php
+++ b/src/DataService/GuidInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Interface for mpx objects with a GUID field.
+ *
+ * Note that a "GUID" is not globally unique, but a string set on each asset
+ * that is only unique within the owning account.
+ */
+interface GuidInterface extends OwnerIdInterface
+{
+    /**
+     * Returns an alternate identifier for this object that is unique within the owning account.
+     *
+     * @return string
+     */
+    public function getGuid(): ?string;
+
+    /**
+     * Set an alternate identifier for this object that is unique within the owning account.
+     *
+     * @param string $guid
+     */
+    public function setGuid(?string $guid);
+}

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 
 /**
  * Implements the Media endpoint in the Media data service.
@@ -21,7 +21,7 @@ use Lullabot\Mpx\DataService\PublicIdentifierInterface;
  *   objectType="Media",
  * )
  */
-class Media extends ObjectBase implements PublicIdentifierInterface
+class Media extends ObjectBase implements PublicIdWithGuidInterface
 {
     /**
      * The id of the AdPolicy associated with this content.

--- a/src/DataService/Media/Release.php
+++ b/src/DataService/Media/Release.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 
 /**
  * @DataService(
@@ -15,7 +15,7 @@ use Lullabot\Mpx\DataService\PublicIdentifierInterface;
  *   objectType="Release",
  * )
  */
-class Release extends ObjectBase implements PublicIdentifierInterface
+class Release extends ObjectBase implements PublicIdWithGuidInterface
 {
     /**
      * The date and time that this object was created.

--- a/src/DataService/ObjectInterface.php
+++ b/src/DataService/ObjectInterface.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * Defines an interface object properties common to all mpx objects.
  */
-interface ObjectInterface extends IdInterface, JsonInterface
+interface ObjectInterface extends IdInterface, GuidInterface, JsonInterface
 {
     /**
      * Returns the globally unique URI of this object.
@@ -53,20 +53,6 @@ interface ObjectInterface extends IdInterface, JsonInterface
     public function setAddedByUserId(UriInterface $addedByUserId);
 
     /**
-     * Returns the id of the account that owns this object.
-     *
-     * @return UriInterface
-     */
-    public function getOwnerId(): UriInterface;
-
-    /**
-     * Set the id of the account that owns this object.
-     *
-     * @param UriInterface $ownerId
-     */
-    public function setOwnerId(UriInterface $ownerId);
-
-    /**
      * Return custom fields attached to this object.
      *
      * @return CustomFieldInterface[]
@@ -93,20 +79,6 @@ interface ObjectInterface extends IdInterface, JsonInterface
      * @param string $description
      */
     public function setDescription(?string $description);
-
-    /**
-     * Returns an alternate identifier for this object that is unique within the owning account.
-     *
-     * @return string
-     */
-    public function getGuid(): ?string;
-
-    /**
-     * Set an alternate identifier for this object that is unique within the owning account.
-     *
-     * @param string $guid
-     */
-    public function setGuid(?string $guid);
 
     /**
      * Returns whether this object currently allows updates.

--- a/src/DataService/OwnerIdInterface.php
+++ b/src/DataService/OwnerIdInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Interface for mpx objects with an owner.
+ */
+interface OwnerIdInterface
+{
+    /**
+     * Returns the id of the account that owns this object.
+     *
+     * @return UriInterface
+     */
+    public function getOwnerId(): UriInterface;
+
+    /**
+     * Set the id of the account that owns this object.
+     *
+     * @param UriInterface $ownerId
+     */
+    public function setOwnerId(UriInterface $ownerId);
+}

--- a/src/DataService/Player/Player.php
+++ b/src/DataService/Player/Player.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\Annotation\DataService;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
 use Lullabot\Mpx\DataService\ObjectBase;
-use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 
 /**
  * @DataService(
@@ -15,7 +15,7 @@ use Lullabot\Mpx\DataService\PublicIdentifierInterface;
  *     schemaVersion="1.6",
  * )
  */
-class Player extends ObjectBase implements PublicIdentifierInterface
+class Player extends ObjectBase implements PublicIdWithGuidInterface
 {
     /**
      * The date and time that this object was created.

--- a/src/DataService/PublicIdWithGuidInterface.php
+++ b/src/DataService/PublicIdWithGuidInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lullabot\Mpx\DataService;
+
+/**
+ * Interface for objects containing both a Public ID (pid) and a GUID.
+ */
+interface PublicIdWithGuidInterface extends PublicIdentifierInterface, GuidInterface
+{
+}

--- a/src/DataService/PublicIdentifierInterface.php
+++ b/src/DataService/PublicIdentifierInterface.php
@@ -4,6 +4,11 @@ namespace Lullabot\Mpx\DataService;
 
 /**
  * Interface definition for all mpx objects with a public identifier.
+ *
+ * Note that in practice, it appears that all mpx objects with a public ID also
+ * have a GUID. However, having a separate interface makes it easy for calling
+ * code to create simple stub objects with just a public identifier, such as
+ * when constructing URLs.
  */
 interface PublicIdentifierInterface
 {

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -4,8 +4,8 @@ namespace Lullabot\Mpx\Service\Player;
 
 use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;
-use Lullabot\Mpx\DataService\ObjectInterface;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
+use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -41,7 +41,7 @@ class Url implements ToUriInterface
     /**
      * The media that is being played.
      *
-     * @var PublicIdentifierInterface
+     * @var PublicIdWithGuidInterface
      */
     private $media;
 
@@ -80,9 +80,9 @@ class Url implements ToUriInterface
      *
      * @param PublicIdentifierInterface $account The account the player is owned by.
      * @param PublicIdentifierInterface $player  The player to play $media with.
-     * @param ObjectInterface           $media   The media to play.
+     * @param PublicIdWithGuidInterface $media   The media to play.
      */
-    public function __construct(PublicIdentifierInterface $account, PublicIdentifierInterface $player, ObjectInterface $media)
+    public function __construct(PublicIdentifierInterface $account, PublicIdentifierInterface $player, PublicIdWithGuidInterface $media)
     {
         $this->player = $player;
         $this->media = $media;


### PR DESCRIPTION
This fixes an error in calling `getPid` when generating URLs when the constructor parameter (but not the phpdocs on the private property) didn't the method. As well, this will make it simpler for Url consumers to generate URLs without having a full mpx "media" object available, since there are only three fields to implement.