### PR TITLE
Allow callers of guzzle requests to retrieve the internal list object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - YYYY-MM-DD
 
+### Added
+
+- `\Lullabot\Mpx\DataService\ObjectListIterator.php` now allows the caller to
+  get the total number of mpx results, via `::getTotalResults()` method.
+
 ### Changed
 
 - New interfaces have been added, which ObjectInterface now inherits from.

--- a/src/DataService/ObjectListIterator.php
+++ b/src/DataService/ObjectListIterator.php
@@ -133,5 +133,4 @@ class ObjectListIterator extends \NoRewindIterator
     {
         return $this->list->getTotalResults();
     }
-
 }

--- a/src/DataService/ObjectListIterator.php
+++ b/src/DataService/ObjectListIterator.php
@@ -123,4 +123,15 @@ class ObjectListIterator extends \NoRewindIterator
         // not exist.
         return false;
     }
+
+    /**
+     * Returns the current object list page.
+     *
+     * @return \Lullabot\Mpx\DataService\ObjectList
+     */
+    public function getList(): \Lullabot\Mpx\DataService\ObjectList
+    {
+        return $this->list;
+    }
+
 }

--- a/src/DataService/ObjectListIterator.php
+++ b/src/DataService/ObjectListIterator.php
@@ -125,13 +125,14 @@ class ObjectListIterator extends \NoRewindIterator
     }
 
     /**
-     * Returns the current object list page.
+     * Returns the number total results.
      *
-     * @return \Lullabot\Mpx\DataService\ObjectList
+     * @return int
+     *   The number of total results.
      */
-    public function getList(): \Lullabot\Mpx\DataService\ObjectList
+    public function getTotalResults(): int
     {
-        return $this->list;
+        return $this->list->getTotalResults();
     }
 
 }

--- a/src/DataService/ObjectListIterator.php
+++ b/src/DataService/ObjectListIterator.php
@@ -128,7 +128,6 @@ class ObjectListIterator extends \NoRewindIterator
      * Returns the number total results.
      *
      * @return int
-     *   The number of total results.
      */
     public function getTotalResults(): int
     {

--- a/tests/src/Unit/DataService/ObjectListIteratorTest.php
+++ b/tests/src/Unit/DataService/ObjectListIteratorTest.php
@@ -20,6 +20,7 @@ class ObjectListIteratorTest extends TestCase
      * @covers ::current
      * @covers ::next
      * @covers ::valid
+     * @covers ::getTotalResults
      */
     public function testCurrent()
     {

--- a/tests/src/Unit/DataService/ObjectListIteratorTest.php
+++ b/tests/src/Unit/DataService/ObjectListIteratorTest.php
@@ -46,6 +46,7 @@ class ObjectListIteratorTest extends TestCase
         $iterator->valid();
         $this->assertSame($second, $iterator->current());
         $this->assertEquals(1, $iterator->key());
+        $this->assertEquals(2, $iterator->getTotalResults());
     }
 
     /**


### PR DESCRIPTION
# Description

Allows callers of guzzle requests to fetch the internal DataObject list. This is related to https://github.com/Lullabot/media_mpx/pull/122, which adds a UI form to queue items through batches, and having the total count of items at the batch processing level is rather convenient.