### PR TITLE
Adjust tests to start from a new Url instance each time, fix double equal bug

### DIFF
--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -148,7 +148,7 @@ class Url implements ToUriInterface
      */
     public function withAutoplay(bool $autoPlay): self
     {
-        if ($this->autoPlay == $autoPlay) {
+        if ($this->autoPlay === $autoPlay) {
             return $this;
         }
 
@@ -167,7 +167,7 @@ class Url implements ToUriInterface
      */
     public function withPlayAll(bool $playAll): self
     {
-        if ($this->playAll == $playAll) {
+        if ($this->playAll === $playAll) {
             return $this;
         }
 
@@ -182,7 +182,7 @@ class Url implements ToUriInterface
      */
     public function withEmbed(bool $embed): self
     {
-        if ($this->embed == $embed) {
+        if ($this->embed === $embed) {
             return $this;
         }
 

--- a/tests/src/Unit/Service/Player/UrlTest.php
+++ b/tests/src/Unit/Service/Player/UrlTest.php
@@ -44,21 +44,32 @@ class UrlTest extends TestCase
 
         $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid', (string) $player_url->toUri());
 
+        $player_url = new Url($account, $player, $media);
         $player_url = $player_url->withAutoplay(true)
             ->withPlayAll(true);
         $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid?autoPlay=true&playAll=true', (string) $player_url);
 
+        $player_url = new Url($account, $player, $media);
         $player_url = $player_url->withAutoplay(false)
             ->withPlayAll(false);
         $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid?autoPlay=false&playAll=false', (string) $player_url);
 
+        $player_url = new Url($account, $player, $media);
         $player_url = $player_url->withEmbed(true);
-        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/embed/select/media/media-pid?autoPlay=false&playAll=false', (string) $player_url);
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/embed/select/media/media-pid', (string) $player_url);
 
+        $player_url = new Url($account, $player, $media);
         $player_url = $player_url->withMediaByGuid();
-        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/embed/select/media/guid/123456/the-guid?autoPlay=false&playAll=false', (string) $player_url);
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/guid/123456/the-guid', (string) $player_url);
 
+        $player_url = new Url($account, $player, $media);
         $player_url = $player_url->withMediaByPublicId();
+        $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/select/media/media-pid', (string) $player_url);
+
+        $player_url = new Url($account, $player, $media);
+        $player_url = $player_url->withEmbed(true)
+            ->withAutoplay(false)
+            ->withPlayAll(false);
         $this->assertEquals('https://player.theplatform.com/p/account-pid/player-pid/embed/select/media/media-pid?autoPlay=false&playAll=false', (string) $player_url);
     }
 }


### PR DESCRIPTION
Was seeing an issue where the `autoPlay=false` query string param wouldn't show in the player URL generated. Odd b/c there was a test that seemed to show it was working fine. Turns out the test setup was showing a false positive.