### PR TITLE
171: Update symfony depencencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ test_and_cover: &test_and_cover
       - run: composer update -n --prefer-dist
 
       - run: |
-          [ -f /usr/local/etc/php/conf.d/xdebug.ini] || rm /usr/local/etc/php/conf.d/xdebug.ini
+          rm -f /usr/local/etc/php/conf.d/xdebug.ini
 
       - run: |
           [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20200930/xdebug.so] || pecl install xdebug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ test_and_cover: &test_and_cover
       - run: composer update -n --prefer-dist
 
       - run: |
+          [ -f /usr/local/etc/php/conf.d/xdebug.ini] || rm /usr/local/etc/php/conf.d/xdebug.ini
+
+      - run: |
           [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20200930/xdebug.so] || pecl install xdebug
           echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
           echo 'xdebug.mode="coverage"' >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 vendor/
 coverage/
 .php_cs.cache
+/.idea

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,5 +15,6 @@ return PhpCsFixer\Config::create()
         PhpCsFixer\Finder::create()
             ->in(__DIR__.'/src')
             ->in(__DIR__.'/tests/src')
+            ->exclude('Fixtures')
     )
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+
+- Updated Symfony dependencies to allow for ^4.4.
+
 ## [1.0.3] - 2021-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.4] - 2021-07-21
 
 ### Changed
 
 - Updated Symfony dependencies to allow for ^4.4.
+- Updated \Lullabot\Mpx\DataService\NotificationTypeExtractor::getTypes to have
+  a nullable array typed return.
 
 ## [1.0.4] - 2021-07-10
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "namshi/cuzzle": "^2.0",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
-    "symfony/phpunit-bridge": "5.2.x-dev#448f9f36df6a9468ff4206adc98acbc1b3d2d3d6"
+    "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
-    "symfony/property-info": "^3.4",
+    "symfony/property-info": "^3.4 || ^4.4",
     "symfony/lock": "^3.4",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0",
     "phpdocumentor/reflection-docblock": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "psr/log": "^1.0",
     "cache/cache": "dev-master#83fabc5bad8b90f7981c97898345df8935b0bf55",
     "symfony/serializer": "^3.4 || ^4.4",
-    "symfony/property-access": "^3.4",
+    "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4",
     "symfony/lock": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4 || ^4.4",
-    "symfony/lock": "^3.4",
+    "symfony/lock": "^3.4 || ^4.4",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0",
     "phpdocumentor/reflection-docblock": "^5.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
     "namshi/cuzzle": "^2.0",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
-    "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968"
+    "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",
+    "phpstan/phpstan": "^0.12.82",
+    "phpstan/phpstan-deprecation-rules": "^0.12.6",
+    "phpstan/extension-installer": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
     "cache/cache": "dev-master#83fabc5bad8b90f7981c97898345df8935b0bf55",
-    "symfony/serializer": "^3.4",
+    "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "symfony/console": "^3.4",
     "namshi/cuzzle": "^2.0",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
-    "mockery/mockery": "^1.0"
+    "mockery/mockery": "^1.0",
+    "symfony/phpunit-bridge": "5.2.x-dev"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "namshi/cuzzle": "^2.0",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
-    "symfony/phpunit-bridge": "5.2.x-dev"
+    "symfony/phpunit-bridge": "5.2.x-dev#448f9f36df6a9468ff4206adc98acbc1b3d2d3d6"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,8 @@
              Note this will EXPOSE PASSWORDS AND TOKENS in logs, so
              this should only be enabled on local environments. -->
         <env name="MPX_LOG_CURL" value="false" />
+        <!-- To disable deprecation testing completely uncomment the next line. -->
+        <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     </php>
 
     <testsuites>
@@ -39,4 +41,7 @@
       <log type="junit" target="build/logs/results.xml"/>
       <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,8 +20,9 @@
              Note this will EXPOSE PASSWORDS AND TOKENS in logs, so
              this should only be enabled on local environments. -->
         <env name="MPX_LOG_CURL" value="false" />
-        <!-- To disable deprecation testing completely uncomment the next line. -->
-        <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+        <!-- Watch for deprecations, but only fail on direct deprecations,
+             not indirect ones. -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
     </php>
 
     <testsuites>

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -30,7 +30,7 @@ class NotificationTypeExtractor extends ReflectionExtractor
     /**
      * {@inheritdoc}
      */
-    public function getTypes($class, $property, array $context = [])
+    public function getTypes($class, $property, array $context = []): ?array
     {
         if ('entry' !== $property) {
             return parent::getTypes($class, $property, $context);

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lullabot\Mpx\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class Dummy extends ParentDummy
+{
+    /**
+     * @var string This is bar
+     */
+    private $bar;
+
+    /**
+     * Should be used.
+     *
+     * @var int Should be ignored
+     */
+    protected $baz;
+
+    /**
+     * @var \DateTime
+     */
+    public $bal;
+
+    /**
+     * @var ParentDummy
+     */
+    public $parent;
+
+    /**
+     * @var \DateTime[]
+     * @Groups({"a", "b"})
+     */
+    public $collection;
+
+    /**
+     * @var string[][]
+     */
+    public $nestedCollection;
+
+    /**
+     * @var mixed[]
+     */
+    public $mixedCollection;
+
+    /**
+     * @var ParentDummy
+     */
+    public $B;
+
+    /**
+     * @var int
+     */
+    protected $Id;
+
+    /**
+     * @var string
+     */
+    public $Guid;
+
+    /**
+     * Nullable array.
+     *
+     * @var array|null
+     */
+    public $g;
+
+    /**
+     * @var ?string
+     */
+    public $h;
+
+    /**
+     * @var ?string|int
+     */
+    public $i;
+
+    /**
+     * @var ?\DateTime
+     */
+    public $j;
+
+    /**
+     * @var array
+     */
+    private $xTotals;
+
+    /**
+     * @var string
+     */
+    private $YT;
+
+    /**
+     * This should not be removed.
+     *
+     * @var
+     */
+    public $emptyVar;
+
+    public static function getStatic()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public static function staticGetter()
+    {
+    }
+
+    public static function staticSetter(\DateTime $d)
+    {
+    }
+
+    /**
+     * A.
+     *
+     * @return int
+     */
+    public function getA()
+    {
+    }
+
+    /**
+     * B.
+     *
+     * @param ParentDummy|null $parent
+     */
+    public function setB(ParentDummy $parent = null)
+    {
+    }
+
+    /**
+     * Date of Birth.
+     *
+     * @return \DateTime
+     */
+    public function getDOB()
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+    }
+
+    public function get123()
+    {
+    }
+
+    /**
+     * @param self $self
+     */
+    public function setSelf(self $self)
+    {
+    }
+
+    /**
+     * @param parent $realParent
+     */
+    public function setRealParent(parent $realParent)
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function getXTotals()
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getYT()
+    {
+    }
+
+    public function setDate(\DateTime $date)
+    {
+    }
+
+    public function addDate(\DateTime $date)
+    {
+    }
+}

--- a/tests/src/Fixtures/ParentDummy.php
+++ b/tests/src/Fixtures/ParentDummy.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Lullabot\Mpx\Tests\Fixtures;
+
+/**
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+class ParentDummy
+{
+    /**
+     * Short description.
+     *
+     * Long description.
+     */
+    public $foo;
+
+    /**
+     * @var float
+     */
+    public $foo2;
+
+    /**
+     * @var callable
+     */
+    public $foo3;
+
+    /**
+     * @var void
+     */
+    public $foo4;
+
+    /**
+     * @var mixed
+     */
+    public $foo5;
+
+    /**
+     * @var \SplFileInfo[]|resource
+     */
+    public $files;
+
+    /**
+     * @return bool|null
+     */
+    public function isC()
+    {
+    }
+
+    /**
+     * @return bool
+     */
+    public function canD()
+    {
+    }
+
+    /**
+     * @param resource $e
+     */
+    public function addE($e)
+    {
+    }
+
+    /**
+     * @param \DateTime $f
+     */
+    public function removeF(\DateTime $f)
+    {
+    }
+}

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -82,6 +82,9 @@ abstract class FunctionalTestBase extends TestCase
         // for the lock to fail so we can stub out the entire class.
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
 
         $user = new User($username, $password);
         $this->userSession = new UserSession($user, $this->client, $store, new TokenCachePool(new ArrayCachePool()));

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -62,6 +62,9 @@ class AuthenticatedClientTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         $logger = $this->fetchTokenLogger(1);
@@ -104,6 +107,9 @@ class AuthenticatedClientTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         $logger = $this->fetchTokenLogger(2);
@@ -143,6 +149,9 @@ class AuthenticatedClientTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         $logger = $this->fetchTokenLogger(1);
@@ -180,6 +189,9 @@ class AuthenticatedClientTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         $logger = $this->fetchTokenLogger(1);

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -26,9 +26,9 @@ class CachingPhpDocExtractorTest extends TestCase
      */
     public function testExtract($property, array $type = null, $shortDescription, $longDescription)
     {
-        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
-        $this->assertSame($shortDescription, $this->extractor->getShortDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
-        $this->assertSame($longDescription, $this->extractor->getLongDescription('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $this->extractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
+        $this->assertSame($shortDescription, $this->extractor->getShortDescription('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
+        $this->assertSame($longDescription, $this->extractor->getLongDescription('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
     }
 
     public function testParamTagTypeIsOmitted()
@@ -43,7 +43,7 @@ class CachingPhpDocExtractorTest extends TestCase
     {
         $customExtractor = new CachingPhpDocExtractor(null, ['add', 'remove'], ['is', 'can']);
 
-        $this->assertEquals($type, $customExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $customExtractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
     }
 
     /**
@@ -53,7 +53,7 @@ class CachingPhpDocExtractorTest extends TestCase
     {
         $noPrefixExtractor = new CachingPhpDocExtractor(null, [], [], []);
 
-        $this->assertEquals($type, $noPrefixExtractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $noPrefixExtractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
     }
 
     public function typesProvider()
@@ -76,10 +76,10 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', [new Type(Type::BUILTIN_TYPE_INT)], 'A.', null],
-            ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], 'B.', null],
+            ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], 'B.', null],
             ['c', [new Type(Type::BUILTIN_TYPE_BOOL, true)], null, null],
             ['d', [new Type(Type::BUILTIN_TYPE_BOOL)], null, null],
             ['e', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))], null, null],
@@ -111,7 +111,7 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],
@@ -146,7 +146,7 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -60,6 +60,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
@@ -96,6 +99,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $account = new Account();
         $account->setId(new Uri('http://example.com/1'));
@@ -125,6 +131,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
@@ -159,6 +168,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
@@ -182,6 +194,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
@@ -207,6 +222,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
@@ -239,6 +257,9 @@ class DataObjectFactoryTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -61,6 +61,9 @@ class NotificationListenerTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session, $account);
         $manager = DataServiceManager::basicDiscovery();
@@ -98,6 +101,9 @@ class NotificationListenerTest extends TestCase
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session, $account);
         $manager = DataServiceManager::basicDiscovery();

--- a/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -39,10 +39,12 @@ class ResolveAllUrlsTest extends TestCase
             new JsonResponse(200, [], 'resolveAllUrls.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface $store */
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
-
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $user = new User('mpx/USER-NAME', 'correct-password');
         $userSession = new UserSession($user, $client, $store, $tokenCachePool);
         $session = new AuthenticatedClient($client, $userSession);

--- a/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
@@ -40,9 +40,12 @@ class ResolveDomainTest extends TestCase
             new JsonResponse(200, [], 'resolveDomain.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface $store */
+        /** @var StoreInterface|\PHPUnit\Framework\MockObject\MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
 
         $user = new User('mpx/USER-NAME', 'correct-password');
         $userSession = new UserSession($user, $client, $store, $tokenCachePool);
@@ -69,9 +72,12 @@ class ResolveDomainTest extends TestCase
             new JsonResponse(200, [], 'resolveDomain.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface $store */
+        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
 
         $user = new User('mpx/USER-NAME', 'correct-password');
         $userSession = new UserSession($user, $client, $store, $tokenCachePool);

--- a/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
+++ b/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
@@ -42,6 +42,9 @@ class UserSessionTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         $logger = $this->fetchTokenLogger(1);
@@ -70,6 +73,9 @@ class UserSessionTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         /** @var \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */
         $logger = $this->getMockBuilder(LoggerInterface::class)
             ->getMock();
@@ -100,6 +106,9 @@ class UserSessionTest extends TestCase
         /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMock();
+        $store->expects($this->any())
+            ->method('exists')
+            ->willReturn(false);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
 
         /** @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject $logger */


### PR DESCRIPTION
Updates Symfony dependencies to allow for ^4.4. We're pretty well compatible without any change, there was only issues with test cases and one minor method signature change.

Symfony 5.5 will be another story unfortunately. There are a couple places where we're using code deprecated in 4.x and removed in 5.x. That unfortunately means that we will won't be able to allow for all three major branches, at least that's the case with `symfony/lock` specificially.