### PR TITLE
Issue #180 Use a version alias for cache/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
-    "cache/cache": "dev-master#83fabc5bad8b90f7981c97898345df8935b0bf55 as 1.0",
+    "cache/cache": "2.0.x-dev#83fabc5bad8b90f7981c97898345df8935b0bf55 as 1.0",
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
-    "cache/cache": "dev-master#83fabc5bad8b90f7981c97898345df8935b0bf55",
+    "cache/cache": "dev-master#83fabc5bad8b90f7981c97898345df8935b0bf55 as 1.0",
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",


### PR DESCRIPTION
For some reason, packagist.org no longer offers `dev-master` as a valid version for `cache/cache`, even though that branch is definately [still active and used](https://github.com/php-cache/cache). Packagist.org does offer `2.0.x-dev` as a version though, which maps to the packages `2.0` branch https://github.com/php-cache/cache/tree/2.0. That branch includes the commit we're wanting to pin to, so as a workaround for now, I'm pinning the commit againts the `2.0.x-dev` branch as 1.0, which seems to work.