### PR TITLE
Add support for PHP 8.0 and 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Quick Start
 
-* PHP 7.3 or PHP 7.4 (8.0 is not supported yet, help welcome!)
+* PHP >= 7.4
 * Composer
 
 `composer require lullabot/mpx-php`

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,15 @@
     "guzzlehttp/guzzle": "^6.3",
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
-    "cache/cache": "2.0.x-dev#83fabc5bad8b90f7981c97898345df8935b0bf55 as 1.0",
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4 || ^4.4",
     "symfony/lock": "^3.4 || ^4.4",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-    "phpdocumentor/reflection-docblock": "^5.2"
+    "phpdocumentor/reflection-docblock": "^5.2",
+    "cache/array-adapter": "^1.0",
+    "psr/http-message": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5||^7.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
     "symfony/serializer": "^3.4 || ^4.4",
-    "symfony/property-access": "^3.4 || ^4.4",
+    "symfony/property-access": "^4.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4 || ^4.4",
     "symfony/lock": "^3.4 || ^4.4",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
-    "symfony/property-info": "^4.4",
+    "symfony/property-info": "^3.4 || ^4.4",
     "symfony/lock": "^3.4 || ^4.4",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0",
     "phpdocumentor/reflection-docblock": "^5.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "psr/http-message": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5||^7.0",
+    "phpunit/phpunit": "^8.0 || ^9.0",
     "friendsofphp/php-cs-fixer": "2.18.2",
     "nette/php-generator": "^3.0",
     "symfony/console": "^3.4",
@@ -34,7 +34,8 @@
     "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",
     "phpstan/phpstan": "^0.12.82",
     "phpstan/phpstan-deprecation-rules": "^0.12.6",
-    "phpstan/extension-installer": "^1.1"
+    "phpstan/extension-installer": "^1.1",
+    "dms/phpunit-arraysubset-asserts": "^0.4.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
     "symfony/serializer": "^3.4 || ^4.4",
-    "symfony/property-access": "^4.4",
+    "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
     "symfony/property-info": "^3.4 || ^4.4",
     "symfony/lock": "^3.4 || ^4.4",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "symfony/serializer": "^3.4 || ^4.4",
     "symfony/property-access": "^3.4 || ^4.4",
     "doctrine/annotations": "^1.2",
-    "symfony/property-info": "^3.4 || ^4.4",
+    "symfony/property-info": "^4.4",
     "symfony/lock": "^3.4 || ^4.4",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0",
     "phpdocumentor/reflection-docblock": "^5.2",

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -165,7 +165,7 @@ class NotificationListener
         $encoders = [new JsonEncoder()];
 
         // Attempt normalizing each key in this order, including denormalizing recursively.
-        $extractor = new NotificationTypeExtractor();
+        $extractor = NotificationTypeExtractor::create();
         $extractor->setClass($this->service->getClass());
         $normalizers = [
             new UnixMillisecondNormalizer(),

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -3,15 +3,13 @@
 namespace Lullabot\Mpx\DataService;
 
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
-use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
-use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
  * A property extractor to extract the type from a notification entry.
  */
-class NotificationTypeExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface
+class NotificationTypeExtractor implements PropertyTypeExtractorInterface
 {
     /**
      * The class each entry is, such as \Lullabot\Mpx\DataService\Media\Media.
@@ -23,14 +21,14 @@ class NotificationTypeExtractor implements PropertyListExtractorInterface, Prope
     /**
      * Decorated ReflectionExtractor instance.
      */
-    protected ReflectionExtractor $reflectionExtractor;
+    protected PropertyTypeExtractorInterface $reflectionExtractor;
 
     /**
      * NotificationTypeReflectionExtractorDecorator constructor.
      *
-     * @param \Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor $reflectionExtractor Reflection extractor instance to decorate.
+     * @param \Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface $reflectionExtractor Reflection extractor instance to decorate.
      */
-    public function __construct(ReflectionExtractor $reflectionExtractor)
+    public function __construct(PropertyTypeExtractorInterface $reflectionExtractor)
     {
         $this->reflectionExtractor = $reflectionExtractor;
     }
@@ -69,29 +67,5 @@ class NotificationTypeExtractor implements PropertyListExtractorInterface, Prope
         }
 
         return [new Type('object', false, $this->class)];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isReadable($class, $property, array $context = [])
-    {
-        return $this->reflectionExtractor->isReadable($class, $property, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isWritable($class, $property, array $context = [])
-    {
-        return $this->reflectionExtractor->isWritable($class, $property, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getProperties($class, array $context = [])
-    {
-        return $this->reflectionExtractor->getProperties($class, $context);
     }
 }

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -4,7 +4,6 @@ namespace Lullabot\Mpx\DataService;
 
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
-use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
@@ -12,7 +11,7 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * A property extractor to extract the type from a notification entry.
  */
-class NotificationTypeExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface
+class NotificationTypeExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface
 {
     /**
      * The class each entry is, such as \Lullabot\Mpx\DataService\Media\Media.
@@ -86,17 +85,6 @@ class NotificationTypeExtractor implements PropertyListExtractorInterface, Prope
     public function isWritable($class, $property, array $context = [])
     {
         return $this->reflectionExtractor->isWritable($class, $property, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isInitializable(
-        string $class,
-        string $property,
-        array $context = []
-    ): ?bool {
-        return $this->reflectionExtractor->isInitializable($class, $property, $context);
     }
 
     /**

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -3,12 +3,16 @@
 namespace Lullabot\Mpx\DataService;
 
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyInitializableExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
+use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
  * A property extractor to extract the type from a notification entry.
  */
-class NotificationTypeExtractor extends ReflectionExtractor
+class NotificationTypeExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface
 {
     /**
      * The class each entry is, such as \Lullabot\Mpx\DataService\Media\Media.
@@ -16,6 +20,31 @@ class NotificationTypeExtractor extends ReflectionExtractor
      * @var string
      */
     protected $class;
+
+    /**
+     * Decorated ReflectionExtractor instance.
+     */
+    protected ReflectionExtractor $reflectionExtractor;
+
+    /**
+     * NotificationTypeReflectionExtractorDecorator constructor.
+     *
+     * @param \Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor $reflectionExtractor Reflection extractor instance to decorate.
+     */
+    public function __construct(ReflectionExtractor $reflectionExtractor)
+    {
+        $this->reflectionExtractor = $reflectionExtractor;
+    }
+
+    /**
+     * Create a new NotificationTypeExtractor.
+     *
+     * @return static
+     */
+    public static function create(): self
+    {
+        return new static(new ReflectionExtractor());
+    }
 
     /**
      * Set the class that is being extracted, such as \Lullabot\Mpx\DataService\Media\Media.
@@ -33,7 +62,7 @@ class NotificationTypeExtractor extends ReflectionExtractor
     public function getTypes($class, $property, array $context = []): ?array
     {
         if ('entry' !== $property) {
-            return parent::getTypes($class, $property, $context);
+            return $this->reflectionExtractor->getTypes($class, $property, $context);
         }
 
         if (!isset($this->class)) {
@@ -41,5 +70,40 @@ class NotificationTypeExtractor extends ReflectionExtractor
         }
 
         return [new Type('object', false, $this->class)];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable($class, $property, array $context = [])
+    {
+        return $this->reflectionExtractor->isReadable($class, $property, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable($class, $property, array $context = [])
+    {
+        return $this->reflectionExtractor->isWritable($class, $property, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isInitializable(
+        string $class,
+        string $property,
+        array $context = []
+    ): ?bool {
+        return $this->reflectionExtractor->isInitializable($class, $property, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties($class, array $context = [])
+    {
+        return $this->reflectionExtractor->getProperties($class, $context);
     }
 }

--- a/tests/src/Functional/DataService/Access/AccountQueryTest.php
+++ b/tests/src/Functional/DataService/Access/AccountQueryTest.php
@@ -17,7 +17,7 @@ class AccountQueryTest extends FunctionalTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -46,7 +46,7 @@ abstract class FunctionalTestBase extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Functional/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -18,6 +18,6 @@ class ResolveAllUrlsTest extends FunctionalTestBase
         /** @var ResolveAllUrls $resolved */
         $resolver = new ResolveAllUrls($this->authenticatedClient);
         $resolved = $resolver->resolve('Media Data Service');
-        $this->assertInternalType('string', $resolved->getService());
+        $this->assertIsString($resolved->getService());
     }
 }

--- a/tests/src/SerializerDenormalizerInterface.php
+++ b/tests/src/SerializerDenormalizerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Lullabot\Mpx\Tests;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+interface SerializerDenormalizerInterface extends SerializerInterface, DenormalizerInterface
+{
+}

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -322,7 +322,7 @@ class AuthenticatedClientTest extends TestCase
                         'token' => 'TOKEN-VALUE',
                         'username' => 'mpx/USER-NAME',
                     ], $context);
-                    $this->assertRegExp('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
+                    $this->assertMatchesRegularExpression('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
                 });
         }
 

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -26,6 +27,7 @@ use Symfony\Component\Lock\StoreInterface;
  */
 class AuthenticatedClientTest extends TestCase
 {
+    use ArraySubsetAsserts;
     use MockClientTrait;
 
     /**

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -17,6 +17,7 @@ use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\Token;
 use Lullabot\Mpx\TokenCachePool;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
@@ -306,24 +307,39 @@ class AuthenticatedClientTest extends TestCase
         $logger = $this->getMockBuilder(LoggerInterface::class)
             ->getMock();
 
-        $call = 0;
         for ($tokens = 0; $tokens < $count; ++$tokens) {
             // Since our class instantiates the Lock and passes in the logger, we have to expect these method calls
             // if we want to assert the last method call in this loop.
-            $logger->expects($this->at($call++))->method('info')
-                ->with('Successfully acquired the "{resource}" lock.');
-            $logger->expects($this->at($call++))->method('info')
-                ->with('Expiration defined for "{resource}" lock for "{ttl}" seconds.');
+            $logger->expects($this->any())->method('info')
+                ->withConsecutive(['Successfully acquired the "{resource}" lock.'],
+                    ['Expiration defined for "{resource}" lock for "{ttl}" seconds.'],
+                    [$this->callback(function ($message) {
+                        try {
+                            $this->assertEquals(
+                                'Retrieved a new mpx token {token} for user {username} that expires on {date}.',
+                                $message
+                            );
+                        } catch (ExpectationFailedException $e) {
+                            return false;
+                        }
 
-            $logger->expects($this->at($call++))->method('info')
-                ->willReturnCallback(function ($message, $context) {
-                    $this->assertEquals('Retrieved a new mpx token {token} for user {username} that expires on {date}.', $message);
-                    $this->assertArraySubset([
-                        'token' => 'TOKEN-VALUE',
-                        'username' => 'mpx/USER-NAME',
-                    ], $context);
-                    $this->assertMatchesRegularExpression('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
-                });
+                        return true;
+                    }), $this->callback(function ($context) {
+                        try {
+                            $this->assertArraySubset([
+                                'token' => 'TOKEN-VALUE',
+                                'username' => 'mpx/USER-NAME',
+                            ], $context);
+                            $this->assertMatchesRegularExpression(
+                                '!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!',
+                                $context['date']
+                            );
+                        } catch (ExpectationFailedException $e) {
+                            return false;
+                        }
+
+                        return true;
+                    })]);
         }
 
         return $logger;

--- a/tests/src/Unit/DataService/Access/AccountTest.php
+++ b/tests/src/Unit/DataService/Access/AccountTest.php
@@ -19,7 +19,7 @@ class AccountTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/CachingContextFactoryTest.php
+++ b/tests/src/Unit/DataService/CachingContextFactoryTest.php
@@ -186,7 +186,7 @@ PHP
             $this->assertSame([], $context->getNamespaceAliases());
         }
 
-        protected function tearDown()
+        protected function tearDown(): void
         {
             \Mockery::close();
         }

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -16,7 +16,7 @@ class CachingPhpDocExtractorTest extends TestCase
      */
     private $extractor;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extractor = new CachingPhpDocExtractor();
     }

--- a/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
@@ -20,7 +20,7 @@ class FeedConfigTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Feeds/SortKeyTest.php
+++ b/tests/src/Unit/DataService/Feeds/SortKeyTest.php
@@ -18,7 +18,7 @@ class SortKeyTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Feeds/SubFeedTest.php
+++ b/tests/src/Unit/DataService/Feeds/SubFeedTest.php
@@ -18,7 +18,7 @@ class SubFeedTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/FieldTest.php
+++ b/tests/src/Unit/DataService/FieldTest.php
@@ -18,7 +18,7 @@ class FieldTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();
@@ -47,7 +47,7 @@ class FieldTest extends ObjectTestBase
     public function getSetMethods()
     {
         $tests = parent::getSetMethods();
-        $tests['added'] = ['added', new \Lullabot\Mpx\DataService\DateTime\ConcreteDateTime(\DateTime::createFromFormat('U.u', '1236030615.000'))];
+        $tests['added'] = ['added', new ConcreteDateTime(\DateTime::createFromFormat('U.u', '1236030615.000'))];
         $tests['updated'] = ['updated', new ConcreteDateTime(\DateTime::createFromFormat('U.u', '1236030615.000'))];
 
         return $tests;

--- a/tests/src/Unit/DataService/Media/AvailabilityWindowTest.php
+++ b/tests/src/Unit/DataService/Media/AvailabilityWindowTest.php
@@ -19,7 +19,7 @@ class AvailabilityWindowTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/CategoryInfoTest.php
+++ b/tests/src/Unit/DataService/Media/CategoryInfoTest.php
@@ -18,7 +18,7 @@ class CategoryInfoTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/ChapterTest.php
+++ b/tests/src/Unit/DataService/Media/ChapterTest.php
@@ -18,7 +18,7 @@ class ChapterTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/CreditTest.php
+++ b/tests/src/Unit/DataService/Media/CreditTest.php
@@ -18,7 +18,7 @@ class CreditTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/MediaFileTest.php
+++ b/tests/src/Unit/DataService/Media/MediaFileTest.php
@@ -26,7 +26,7 @@ class MediaFileTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->loadFixture('mediafile-object.json', new DataServiceExtractor());

--- a/tests/src/Unit/DataService/Media/MediaTest.php
+++ b/tests/src/Unit/DataService/Media/MediaTest.php
@@ -26,7 +26,7 @@ class MediaTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/RatingTest.php
+++ b/tests/src/Unit/DataService/Media/RatingTest.php
@@ -18,7 +18,7 @@ class RatingTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/Media/ReleaseTest.php
+++ b/tests/src/Unit/DataService/Media/ReleaseTest.php
@@ -19,7 +19,7 @@ class ReleaseTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -18,7 +18,7 @@ class NotificationTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $notificationExtractor = new NotificationTypeExtractor();

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -21,7 +21,7 @@ class NotificationTest extends ObjectTestBase
     protected function setUp(): void
     {
         parent::setUp();
-        $notificationExtractor = new NotificationTypeExtractor();
+        $notificationExtractor = NotificationTypeExtractor::create();
         $notificationExtractor->setClass(Media::class);
         $this->loadFixture('notification.json', $notificationExtractor);
     }

--- a/tests/src/Unit/DataService/NotificationTypeExtractorTest.php
+++ b/tests/src/Unit/DataService/NotificationTypeExtractorTest.php
@@ -20,7 +20,7 @@ class NotificationTypeExtractorTest extends TestCase
      */
     public function testGetTypes()
     {
-        $extractor = new NotificationTypeExtractor();
+        $extractor = NotificationTypeExtractor::create();
         $extractor->setClass(static::class);
         $type = $extractor->getTypes('', 'entry');
         $this->assertEquals(static::class, $type[0]->getClassName());
@@ -33,7 +33,7 @@ class NotificationTypeExtractorTest extends TestCase
      */
     public function testNotEntry()
     {
-        $extractor = new NotificationTypeExtractor();
+        $extractor = NotificationTypeExtractor::create();
         $extractor->setClass(static::class);
         $this->assertNull($extractor->getTypes('', 'not-entry'));
     }
@@ -45,7 +45,7 @@ class NotificationTypeExtractorTest extends TestCase
      */
     public function testClassNotSet()
     {
-        $extractor = new NotificationTypeExtractor();
+        $extractor = NotificationTypeExtractor::create();
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('setClass() must be called before using this extractor.');
         $extractor->getTypes('', 'entry');

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -25,7 +25,7 @@ class ObjectListTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->list = new ObjectList();

--- a/tests/src/Unit/DataService/Player/PlayerTest.php
+++ b/tests/src/Unit/DataService/Player/PlayerTest.php
@@ -21,7 +21,7 @@ class PlayerTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->loadFixture('player-object.json', new ReflectionExtractor());

--- a/tests/src/Unit/DataService/Player/PlugInInstanceTest.php
+++ b/tests/src/Unit/DataService/Player/PlugInInstanceTest.php
@@ -18,7 +18,7 @@ class PlugInInstanceTest extends ObjectTestBase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $dataServiceExtractor = new DataServiceExtractor();

--- a/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/CustomFieldsNormalizerTest.php
@@ -10,6 +10,7 @@ use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\ObjectBase;
 use Lullabot\Mpx\Normalizer\CustomFieldsNormalizer;
 use Lullabot\Mpx\Normalizer\MissingCustomFieldsClass;
+use Lullabot\Mpx\Tests\SerializerDenormalizerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
@@ -50,7 +51,7 @@ class CustomFieldsNormalizerTest extends TestCase
         ]);
 
         /** @var SerializerInterface|MockObject|DenormalizerInterface $serializer */
-        $serializer = $this->getMockBuilder([SerializerInterface::class, DenormalizerInterface::class])
+        $serializer = $this->getMockBuilder(SerializerDenormalizerInterface::class)
             ->getMock();
         $serializer->expects($this->once())->method('denormalize')
             ->with($data['data'], DummyCustomFields::class)

--- a/tests/src/Unit/Normalizer/UriNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/UriNormalizerTest.php
@@ -22,7 +22,7 @@ class UriNormalizerTest extends TestCase
     {
         $normalizer = new UriNormalizer();
         $expected = $normalizer->normalize(new Uri('http://example.com'));
-        $this->assertInternalType('string', $expected);
+        $this->assertIsString($expected);
         $this->assertEquals('http://example.com', $expected);
     }
 

--- a/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
@@ -96,7 +96,7 @@ class ResolveDomainTest extends TestCase
 
         $item->expects($this->exactly(2))->method('isHit')
             ->willReturnOnConsecutiveCalls(false, true);
-        $item->expects($this->at(0))->method('set');
+        $item->expects($this->exactly(1))->method('set');
 
         $resolveDomain = new ResolveDomain($authenticatedClient, $cache);
 

--- a/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
+++ b/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
@@ -130,6 +130,7 @@ class UserSessionTest extends TestCase
                     } catch (ExpectationFailedException $e) {
                         return false;
                     }
+
                     return true;
                 })],
                 ['Successfully acquired the "{resource}" lock.'],
@@ -144,6 +145,7 @@ class UserSessionTest extends TestCase
                     } catch (ExpectationFailedException $e) {
                         return false;
                     }
+
                     return true;
                 })]
             );
@@ -198,7 +200,6 @@ class UserSessionTest extends TestCase
         $logger = $this->getMockBuilder(LoggerInterface::class)
             ->getMock();
 
-        $call = 0;
         for ($tokens = 0; $tokens < $count; ++$tokens) {
             // Since our class instantiates the Lock and passes in the logger, we have to expect these method calls
             // if we want to assert the last method call in this loop.
@@ -215,6 +216,7 @@ class UserSessionTest extends TestCase
                         } catch (ExpectationFailedException $e) {
                             return false;
                         }
+
                         return true;
                     })]
                 );

--- a/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
+++ b/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit\Service\IdentityManagement;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
@@ -22,6 +23,7 @@ use Symfony\Component\Lock\StoreInterface;
  */
 class UserSessionTest extends TestCase
 {
+    use ArraySubsetAsserts;
     use MockClientTrait;
 
     /**

--- a/tests/src/Unit/TokenCachePoolTest.php
+++ b/tests/src/Unit/TokenCachePoolTest.php
@@ -27,7 +27,7 @@ class TokenCachePoolTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         /* @var \Lullabot\Mpx\Service\IdentityManagement\UserSession|\PHPUnit_Framework_MockObject_MockObject $user */
         $this->user = $this->getMockBuilder(UserSession::class)

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -85,7 +85,7 @@ class TokenTest extends TestCase
     public function testCreated()
     {
         $token = new Token('https://identity.auth.theplatform.com/idm/data/User/mpx/2685072', 'value', 59);
-        $this->assertInternalType('integer', $token->getCreated());
+        $this->assertIsInt($token->getCreated());
     }
 
     /**


### PR DESCRIPTION
- Updates Phpunit to versions that support PHP8
- Adds a dependency on the PHP cache adapter directly and removes the dependency on `cache/cache`. `cache/cache` adds all adapters, which may not be needed.
    - `cache/cache` currently does not have a stable release for PHP >= 8.0.
    - `cache/array-adapter` (the only adapter I could find in use in the library) does support the latest versions of PHP.
    
    
Motivation: PHP 7.4 will become EOL and stop receiving security support on Nov 28, 2022.

Note: There may be additional modifications needed to support PHP >= 8.0 . These changes mainly focused on modifications needed to install the package when using PHP 8.1.
