### PR TITLE
Update DataService Uri vars to fully qualified names

### DIFF
--- a/src/DataService/DataType/Image.php
+++ b/src/DataService/DataType/Image.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\UriInterface;
 class Image extends Link
 {
     /**
-     * @var UriInterface
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $anchorHref;
 

--- a/src/DataService/DataType/Link.php
+++ b/src/DataService/DataType/Link.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\UriInterface;
 class Link
 {
     /**
-     * @var UriInterface
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $href;
 

--- a/src/DataService/Field.php
+++ b/src/DataService/Field.php
@@ -116,7 +116,7 @@ class Field extends ObjectBase
     /**
      * The namespace this custom field belongs to.
      *
-     * @var UriInterface
+     * @var \Psr\Http\Message\UriInterface
      */
     protected $namespace;
 

--- a/src/DataService/Media/Chapter.php
+++ b/src/DataService/Media/Chapter.php
@@ -23,7 +23,7 @@ class Chapter
     /**
      * A link to the thumbnail image for this chapter.
      *
-     * @var Uri
+     * @var \GuzzleHttp\Psr7\Uri
      */
     protected $thumbnailUrl;
 

--- a/src/DataService/Media/Media.php
+++ b/src/DataService/Media/Media.php
@@ -173,7 +173,7 @@ class Media extends ObjectBase implements PublicIdWithGuidInterface
     /**
      * The streamingUrl of the default thumbnail for this Media.
      *
-     * @var Uri
+     * @var \GuzzleHttp\Psr7\Uri
      */
     protected $defaultThumbnailUrl;
 
@@ -320,7 +320,7 @@ class Media extends ObjectBase implements PublicIdWithGuidInterface
     /**
      * The public URL for this media.
      *
-     * @var Uri
+     * @var \GuzzleHttp\Psr7\Uri
      */
     protected $publicUrl;
 


### PR DESCRIPTION
Some DataService var namespaces (Uri and UriInterface) aren't resolved properly (by PhpDocExtractor I believe) without fully qualified names.