### PR TITLE
fix: cuzzle is a soft & optional dependency

### DIFF
--- a/command/src/MpxCommandBase.php
+++ b/command/src/MpxCommandBase.php
@@ -65,18 +65,10 @@ abstract class MpxCommandBase extends Command
 
         $config = Client::getDefaultConfiguration();
 
-        $cl = new ConsoleLogger($output);
-
-        // Cuzzle is a soft & optional dependency. Its classes may not exist.
-        if (class_exists('Namshi\Cuzzle\Middleware\CurlFormatterMiddleware')) { // phpcs:ignore
-            /** @var $handler \GuzzleHttp\HandlerStack */
-            $handler = $config['handler'];
-            $handler->after('cookies', new Namshi\Cuzzle\Middleware\CurlFormatterMiddleware($cl)); // phpcs:ignore
-        }
-
-        $responseLogger = new Logger($cl);
+        $responseLogger = new Logger(new ConsoleLogger($output));
         $responseLogger->setLogLevel(LogLevel::DEBUG);
         $responseLogger->setFormatter(new MessageFormatter(MessageFormatter::DEBUG));
+        $handler = $config['handler'];
         $handler->after('cookies', $responseLogger);
 
         $client = new Client(new \GuzzleHttp\Client($config));

--- a/command/src/MpxCommandBase.php
+++ b/command/src/MpxCommandBase.php
@@ -12,7 +12,6 @@ use Lullabot\Mpx\DataService\DataServiceManager;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Lullabot\Mpx\TokenCachePool;
-use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -67,9 +66,13 @@ abstract class MpxCommandBase extends Command
         $config = Client::getDefaultConfiguration();
 
         $cl = new ConsoleLogger($output);
-        /** @var $handler \GuzzleHttp\HandlerStack */
-        $handler = $config['handler'];
-        $handler->after('cookies', new CurlFormatterMiddleware($cl));
+
+        // Cuzzle is a soft & optional dependency. Its classes may not exist.
+        if (class_exists('Namshi\Cuzzle\Middleware\CurlFormatterMiddleware')) { // phpcs:ignore
+            /** @var $handler \GuzzleHttp\HandlerStack */
+            $handler = $config['handler'];
+            $handler->after('cookies', new Namshi\Cuzzle\Middleware\CurlFormatterMiddleware($cl)); // phpcs:ignore
+        }
 
         $responseLogger = new Logger($cl);
         $responseLogger->setLogLevel(LogLevel::DEBUG);

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "friendsofphp/php-cs-fixer": "2.18.2",
     "nette/php-generator": "^3.0",
     "symfony/console": "^3.4",
-    "namshi/cuzzle": "^2.0",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
     "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,7 @@
         <!-- Set to 'true' to log all HTTP requests as curl commands.
              Note this will EXPOSE PASSWORDS AND TOKENS in logs, so
              this should only be enabled on local environments. -->
-        <env name="MPX_LOG_CURL" value="false" />
+        <env name="MPX_LOGGER" value="false" />
         <!-- Watch for deprecations, but only fail on direct deprecations,
              not indirect ones. -->
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -12,7 +12,6 @@ use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
 use Lullabot\Mpx\TokenCachePool;
-use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Logger\ConsoleLogger;
@@ -62,17 +61,14 @@ abstract class FunctionalTestBase extends TestCase
 
         $config = Client::getDefaultConfiguration();
 
-        if (getenv('MPX_LOG_CURL')) {
+        if (getenv('MPX_LOGGER')) {
             $output = new ConsoleOutput();
             $output->setVerbosity(ConsoleOutput::VERBOSITY_DEBUG);
-            $cl = new ConsoleLogger($output);
-            /** @var $handler \GuzzleHttp\HandlerStack */
-            $handler = $config['handler'];
-            $handler->after('cookies', new CurlFormatterMiddleware($cl));
-
-            $responseLogger = new Logger($cl);
+            $responseLogger = new Logger(new ConsoleLogger($output));
             $responseLogger->setLogLevel(LogLevel::DEBUG);
             $responseLogger->setFormatter(new MessageFormatter(MessageFormatter::DEBUG));
+            /** @var $handler \GuzzleHttp\HandlerStack */
+            $handler = $config['handler'];
             $handler->after('cookies', $responseLogger);
         }
 


### PR DESCRIPTION
We should be careful using the classes defined in `namshi/cuzzle`. I am not familiar with the whole code base. It is possible that `MpxCommandBase` is only used in a `dev` context.