### PR TITLE
feat: upgrade to PHP 8.1 using rector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ code_fixer: &code_fixer
           key: v2-test-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
 
       # Run tests!
-      - run: PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --using-cache=no --path-mode=intersection -- src tests
+      - run: vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --using-cache=no --path-mode=intersection -- src tests
 
 jobs:
   build_php81:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,9 +150,9 @@ code_fixer: &code_fixer
       - run: vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection -- src tests
 
 jobs:
-  build_php74:
+  build_php81:
     docker:
-      - image: php:7.4
+      - image: cimg/php:8.1
 
     working_directory: ~/repo
 
@@ -160,7 +160,7 @@ jobs:
 
   code_fixer:
     docker:
-      - image: php:7.4
+      - image: cimg/php:8.1
 
     working_directory: ~/repo
 
@@ -172,7 +172,7 @@ workflows:
   # Declare a workflow that runs all of our jobs in parallel.
   test_cover_workflow:
     jobs:
-      - build_php74
+      - build_php81
       - code_fixer
 
   nightly:
@@ -185,5 +185,5 @@ workflows:
               only:
                 - main
     jobs:
-      - build_php74
+      - build_php81
       - code_fixer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ test_and_cover: &test_and_cover
       - run: |
           mkdir -p build/logs
           mkdir -p build/test-results
+          mkdir -p coverage
           vendor/bin/phpunit --testsuite Unit
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ test: &test
               exit 1
           fi
 
-          php composer-setup.php --quiet --install-dir /usr/local/bin --filename composer
+          php composer-setup.php --quiet --install-dir $HOME/.local/bin --filename composer
 
       - run: composer update -n --prefer-dist $COMPOSER_FLAGS
 
@@ -147,7 +147,7 @@ code_fixer: &code_fixer
           key: v2-test-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
 
       # Run tests!
-      - run: vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection -- src tests
+      - run: PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection -- src tests
 
 jobs:
   build_php81:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,25 +88,19 @@ test_and_cover: &test_and_cover
             - /usr/local/etc/php/conf.d/xdebug.ini
 
           key: v2-test-cover-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
 
       # run tests!
       - run: |
           mkdir -p build/logs
           mkdir -p build/test-results
-          ./cc-test-reporter before-build
           vendor/bin/phpunit --testsuite Unit
 
+      - persist_to_workspace:
+          root: coverage
+          paths:
+            - build/logs/clover.xml
       - store_test_results:
           path: build/test-results
-
-      - run: |
-          sudo apt-get update -y && sudo apt-get install git -y
-           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
 
 code_fixer: &code_fixer
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ test_and_cover: &test_and_cover
 
       - run: |
           sudo apt-get update -y && sudo apt-get install git -y
-           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
+           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? build/coverage-logs/clover.xml
 
 code_fixer: &code_fixer
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,9 @@ test_and_cover: &test_and_cover
           vendor/bin/phpunit --testsuite Unit
 
       - persist_to_workspace:
-          root: coverage
+          root: build
           paths:
-            - build/logs/clover.xml
+            - logs/clover.xml
       - store_test_results:
           path: build/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,11 @@ test: &test
 
       # Run tests!
       - run: |
-          mkdir -p build/logs
+          mkdir -p build/test-results
           vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
-          path: build/logs
+          path: build/test-results
 
 test_and_cover: &test_and_cover
   steps:
@@ -97,15 +97,16 @@ test_and_cover: &test_and_cover
       # run tests!
       - run: |
           mkdir -p build/logs
+          mkdir -p build/test-results
           ./cc-test-reporter before-build
           vendor/bin/phpunit --testsuite Unit
 
       - store_test_results:
-          path: build/logs
+          path: build/test-results
 
       - run: |
           sudo apt-get update -y && sudo apt-get install git -y
-           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? build/coverage-logs/clover.xml
+           ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
 
 code_fixer: &code_fixer
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ test: &test
           - v2-test-dependencies-
 
       # php:* has no zip extension and the CLI is faster to install.
-      - run: apt-get update -y && apt-get install unzip -y
+      - run: sudo apt-get update -y && sudo apt-get install unzip -y
 
       - run: |
           EXPECTED_SIGNATURE=$(curl -L https://composer.github.io/installer.sig)
@@ -59,7 +59,7 @@ test_and_cover: &test_and_cover
           - v2-test-cover-dependencies-
 
       # php:* has no zip extension and the CLI is faster to install.
-      - run: apt-get update -y && apt-get install unzip -y
+      - run: sudo apt-get update -y && sudo apt-get install unzip -y
 
       - run: |
           EXPECTED_SIGNATURE=$(curl -L https://composer.github.io/installer.sig)
@@ -108,7 +108,7 @@ test_and_cover: &test_and_cover
           path: build/logs
 
       - run: |
-          apt-get update -y && apt-get install git -y
+          sudo apt-get update -y && sudo apt-get install git -y
            ./cc-test-reporter after-build --coverage-input-type clover --exit-code $? test-results/clover.xml
 
 code_fixer: &code_fixer
@@ -123,7 +123,7 @@ code_fixer: &code_fixer
           - v2-test-dependencies-
 
       # php:* has no zip extension and the CLI is faster to install.
-      - run: apt-get update -y && apt-get install unzip -y
+      - run: sudo apt-get update -y && sudo apt-get install unzip -y
 
       - run: |
           EXPECTED_SIGNATURE=$(curl -L https://composer.github.io/installer.sig)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ test: &test
 
       - save_cache:
           paths:
-            - /root/.composer/cache/files
+            - $HOME/.composer/cache/files
           key: v2-test-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
 
       # Run tests!
@@ -73,22 +73,18 @@ test_and_cover: &test_and_cover
               exit 1
           fi
 
-          php composer-setup.php --quiet --install-dir /usr/local/bin --filename composer
+          php composer-setup.php --quiet --install-dir $HOME/.local/bin --filename composer
 
       - run: composer update -n --prefer-dist
 
       - run: |
-          rm -f /usr/local/etc/php/conf.d/xdebug.ini
-
-      - run: |
-          [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20200930/xdebug.so ] || pecl install xdebug
-          echo 'zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so' > /usr/local/etc/php/conf.d/xdebug.ini
-          echo 'xdebug.mode="coverage"' >> /usr/local/etc/php/conf.d/xdebug.ini
+          [ -f /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so ] || sudo pecl install xdebug
+          echo 'xdebug.mode=coverage' | sudo tee --append /etc/php.d/circleci.ini
 
       - save_cache:
           paths:
-            - /root/.composer/cache/files
-            - /usr/local/lib/php/extensions/no-debug-non-zts-20190902
+            - $HOME/.composer/cache/files
+            - /usr/local/lib/php/extensions/no-debug-non-zts-20170718
             - /usr/local/etc/php/conf.d/xdebug.ini
 
           key: v2-test-cover-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
@@ -143,7 +139,7 @@ code_fixer: &code_fixer
 
       - save_cache:
           paths:
-            - /root/.composer/cache/files
+            - $HOME/.composer/cache/files
           key: v2-test-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
 
       # Run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ code_fixer: &code_fixer
           key: v2-test-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "composer.json" }}-{{ checksum ".circleci/config.yml" }}
 
       # Run tests!
-      - run: PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection -- src tests
+      - run: PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --using-cache=no --path-mode=intersection -- src tests
 
 jobs:
   build_php81:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ code_fixer: &code_fixer
               exit 1
           fi
 
-          php composer-setup.php --quiet --install-dir /usr/local/bin --filename composer
+          php composer-setup.php --quiet --install-dir $HOME/.local/bin --filename composer
 
       - run: composer update -n --prefer-dist
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,10 +96,9 @@ test_and_cover: &test_and_cover
           mkdir -p coverage
           vendor/bin/phpunit --testsuite Unit
 
-      - persist_to_workspace:
-          root: build
-          paths:
-            - logs/clover.xml
+      - store_artifacts:
+          path: build/logs
+
       - store_test_results:
           path: build/test-results
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor/
 coverage/
 .php_cs.cache
 /.idea
+/build
+.phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
         '@Symfony:risky' => true,
@@ -14,7 +14,6 @@ return PhpCsFixer\Config::create()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__.'/src')
-            ->in(__DIR__.'/tests/src')
-            ->exclude('Fixtures')
+            ->in(__DIR__.'/tests')
     )
 ;

--- a/command/src/ClassGeneratorBase.php
+++ b/command/src/ClassGeneratorBase.php
@@ -15,7 +15,7 @@ abstract class ClassGeneratorBase extends MpxCommandBase
     /**
      * Maps custom mpx field types to PHP datatypes.
      */
-    public const TYPE_MAP = [
+    final public const TYPE_MAP = [
         'AvailabilityState' => 'string',
         'Boolean' => 'bool',
         'dataType[]' => 'array',

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -6,8 +6,8 @@ use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\CustomFieldInterface;
 use Lullabot\Mpx\DataService\DataObjectFactory;
 use Lullabot\Mpx\DataService\DateTime\DateTimeFormatInterface;
-use Lullabot\Mpx\DataService\Field;
 use Lullabot\Mpx\DataService\DateTime\NullDateTime;
+use Lullabot\Mpx\DataService\Field;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\PhpNamespace;
 use Psr\Http\Message\UriInterface;
@@ -105,15 +105,15 @@ EOD;
         $mpxNamespace = (string) $field->getNamespace();
         /** @var PhpNamespace $namespace */
         /** @var ClassType $class */
-        list($namespace, $class) = $this->getClass($input, $mpxNamespace);
+        [$namespace, $class] = $this->getClass($input, $mpxNamespace);
 
         $this->addProperty($class, $field);
         $dataType = $this->getPhpDataType($field);
 
-        $get = $class->addMethod('get'.ucfirst($field->getFieldName()));
+        $get = $class->addMethod('get'.ucfirst((string) $field->getFieldName()));
         $get->setVisibility('public');
         if (!empty($field->getDescription())) {
-            $get->addComment('Returns '.lcfirst($field->getDescription()));
+            $get->addComment('Returns '.lcfirst((string) $field->getDescription()));
             $get->addComment('');
         }
         $get->addComment('@return '.$dataType);
@@ -138,10 +138,10 @@ EOD;
         $get->addBody('return $this->'.$field->getFieldName().';');
 
         // Add a set method for the property.
-        $set = $class->addMethod('set'.ucfirst($field->getFieldName()));
+        $set = $class->addMethod('set'.ucfirst((string) $field->getFieldName()));
         $set->setVisibility('public');
         if (!empty($field->getDescription())) {
-            $set->addComment('Set '.lcfirst($field->getDescription()));
+            $set->addComment('Set '.lcfirst((string) $field->getDescription()));
             $set->addComment('');
         }
         $set->addComment('@param '.$dataType);

--- a/command/src/CreateCustomFieldClassCommand.php
+++ b/command/src/CreateCustomFieldClassCommand.php
@@ -93,7 +93,6 @@ EOD;
     }
 
     /**
-     * @param InputInterface $input
      * @param                $dof
      * @param                $field
      */
@@ -151,12 +150,6 @@ EOD;
         $set->addBody('$this->'.$field->getFieldName().' = '.'$'.$field->getFieldName().';');
     }
 
-    /**
-     * @param InputInterface $input
-     * @param string         $mpxNamespace
-     *
-     * @return array
-     */
     private function getClass(InputInterface $input, string $mpxNamespace): array
     {
         if (!isset($this->namespaceClasses[$mpxNamespace])) {
@@ -185,9 +178,6 @@ EOD;
 
     /**
      * Add a property to a class.
-     *
-     * @param ClassType $class
-     * @param Field     $field
      */
     private function addProperty(ClassType $class, Field $field)
     {
@@ -207,9 +197,7 @@ EOD;
     /**
      * Get the PHP data type for a field, including mapping to arrays.
      *
-     * @param Field $field
      *
-     * @return string
      */
     private function getPhpDataType(Field $field): string
     {

--- a/command/src/CreateDataServiceClassCommand.php
+++ b/command/src/CreateDataServiceClassCommand.php
@@ -42,18 +42,18 @@ class CreateDataServiceClassCommand extends ClassGeneratorBase
             }
             ++$index;
 
-            list($field_name, $attributes, $data_type, $description) = $row;
+            [$field_name, $attributes, $data_type, $description] = $row;
             if (empty($description)) {
                 continue;
             }
 
-            if (strrpos($description, '.') !== (\strlen($description) - 1)) {
+            if (strrpos((string) $description, '.') !== (\strlen((string) $description) - 1)) {
                 $description .= '.';
             }
 
             // Map MPX documentation datatypes to PHP datatypes.
             foreach (static::TYPE_MAP as $search => $replace) {
-                $data_type = str_replace($search, $replace, $data_type);
+                $data_type = str_replace($search, $replace, (string) $data_type);
             }
 
             // Add the protected property.
@@ -70,7 +70,7 @@ class CreateDataServiceClassCommand extends ClassGeneratorBase
             // Add a get method for the property.
             $get = $class->addMethod('get'.ucfirst($property->getName()));
             $get->setVisibility('public');
-            $get->addComment('Returns '.lcfirst($description));
+            $get->addComment('Returns '.lcfirst((string) $description));
             $get->addComment('');
             $get->addComment('@return '.$data_type);
 
@@ -97,7 +97,7 @@ class CreateDataServiceClassCommand extends ClassGeneratorBase
             // Add a set method for the property.
             $set = $class->addMethod('set'.ucfirst($property->getName()));
             $set->setVisibility('public');
-            $set->addComment('Set '.lcfirst($description));
+            $set->addComment('Set '.lcfirst((string) $description));
             $set->addComment('');
             $set->addComment('@param '.$data_type.' $'.$field_name);
             $parameter = $set->addParameter($field_name);

--- a/command/src/MpxCommandBase.php
+++ b/command/src/MpxCommandBase.php
@@ -23,8 +23,6 @@ use Symfony\Component\Lock\Store\FlockStore;
 abstract class MpxCommandBase extends Command
 {
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
      *
      * @return DataObjectFactory
      */
@@ -44,8 +42,6 @@ abstract class MpxCommandBase extends Command
     }
 
     /**
-     * @param \Symfony\Component\Console\Input\InputInterface   $input
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
      * @return \Lullabot\Mpx\AuthenticatedClient
      */

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "homepage": "http://bitbucket.com/lullabot/mpx-php",
   "license": "MIT",
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.1",
     "guzzlehttp/guzzle": "^6.3 || ^7.4.5",
     "guzzlehttp/psr7": "^1.0",
     "psr/log": "^1.0",
@@ -31,8 +31,8 @@
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
     "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",
-    "phpstan/phpstan": "^0.12.82",
-    "phpstan/phpstan-deprecation-rules": "^0.12.6",
+    "phpstan/phpstan": "^1.10.14",
+    "phpstan/phpstan-deprecation-rules": "^1.1.3",
     "phpstan/extension-installer": "^1.1",
     "dms/phpunit-arraysubset-asserts": "^0.4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "phpunit/phpunit": "^8.0 || ^9.0",
     "friendsofphp/php-cs-fixer": "^v2.19 || ^3.13",
     "nette/php-generator": "^3.0",
-    "rtheunissen/guzzle-log-middleware": "^0.4.1",
+    "rtheunissen/guzzle-log-middleware": "^1",
     "mockery/mockery": "^1.0",
     "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",
     "phpstan/phpstan": "^1.10.14",

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0 || ^9.0",
-    "friendsofphp/php-cs-fixer": "2.18.2",
+    "friendsofphp/php-cs-fixer": "^v2.19 || ^3.13",
     "nette/php-generator": "^3.0",
-    "symfony/console": "^3.4",
     "rtheunissen/guzzle-log-middleware": "^0.4.1",
     "mockery/mockery": "^1.0",
     "symfony/phpunit-bridge": "5.2.x-dev#f2f94fd78379cdcdef09dd5025af791301913968",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,48 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-
-    <php>
-        <!-- Specify your MPX username and password for functional testing. -->
-        <env name="MPX_USERNAME" value="" />
-        <env name="MPX_PASSWORD" value="" />
-        <!-- Specify the MPX account URL to test with. -->
-        <env name="MPX_ACCOUNT" value="" />
-
-        <!-- Set to 'true' to log all HTTP requests as curl commands.
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <php>
+    <!-- Specify your MPX username and password for functional testing. -->
+    <env name="MPX_USERNAME" value=""/>
+    <env name="MPX_PASSWORD" value=""/>
+    <!-- Specify the MPX account URL to test with. -->
+    <env name="MPX_ACCOUNT" value=""/>
+    <!-- Set to 'true' to log all HTTP requests as curl commands.
              Note this will EXPOSE PASSWORDS AND TOKENS in logs, so
              this should only be enabled on local environments. -->
-        <env name="MPX_LOGGER" value="false" />
-        <!-- Watch for deprecations, but only fail on direct deprecations,
+    <env name="MPX_LOGGER" value="false"/>
+    <!-- Watch for deprecations, but only fail on direct deprecations,
              not indirect ones. -->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/src/Unit</directory>
-        </testsuite>
-        <testsuite name="Functional">
-            <directory suffix="Test.php">./tests/src/Functional</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-      <log type="junit" target="build/logs/results.xml"/>
-      <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
+  </php>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/src/Unit</directory>
+    </testsuite>
+    <testsuite name="Functional">
+      <directory suffix="Test.php">./tests/src/Functional</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/logs/results.xml"/>
+  </logging>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/logs/html-coverage" lowUpperBound="50" highLowerBound="90"/>
     </report>
   </coverage>
   <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
       <directory suffix=".php">./src</directory>
     </include>
     <report>
-      <clover outputFile="build/logs/clover.xml"/>
+      <clover outputFile="build/coverage-logs/clover.xml"/>
     </report>
   </coverage>
   <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
       <directory suffix=".php">./src</directory>
     </include>
     <report>
-      <clover outputFile="build/coverage-logs/clover.xml"/>
+      <clover outputFile="build/logs/clover.xml"/>
     </report>
   </coverage>
   <php>
@@ -31,7 +31,7 @@
     </testsuite>
   </testsuites>
   <logging>
-    <junit outputFile="build/logs/results.xml"/>
+    <junit outputFile="build/test-results/results.xml"/>
   </logging>
   <listeners>
     <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -163,7 +163,7 @@ class AuthenticatedClient implements ClientInterface
      * @param \Psr\Http\Message\RequestInterface $request The request to send.
      * @param array                              $options Request options to apply.
      */
-    private function sendAsyncWithRetry(RequestInterface $request, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
+    private function sendAsyncWithRetry(RequestInterface $request, array $options): \GuzzleHttp\Promise\PromiseInterface | \Psr\Http\Message\RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -228,7 +228,7 @@ class AuthenticatedClient implements ClientInterface
      * @param string|\Psr\Http\Message\UriInterface $uri     URI object or string.
      * @param array                                 $options Request options to apply.
      */
-    private function requestAsyncWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
+    private function requestAsyncWithRetry(string $method, string | \Psr\Http\Message\UriInterface $uri, array $options): \GuzzleHttp\Promise\PromiseInterface | \Psr\Http\Message\RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -294,7 +294,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @return \Psr\Http\Message\ResponseInterface The response.
      */
-    private function requestWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options)
+    private function requestWithRetry(string $method, string | \Psr\Http\Message\UriInterface $uri, array $options)
     {
         try {
             $merged = $this->mergeAuth($options);

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -165,7 +165,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
-    private function sendAsyncWithRetry(RequestInterface $request, array $options)
+    private function sendAsyncWithRetry(RequestInterface $request, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -188,7 +188,7 @@ class AuthenticatedClient implements ClientInterface
             }
 
             $merged = $this->mergeAuth($options, true);
-            $func = [$this->client, 'send'];
+            $func = $this->client->send(...);
             $args = [$request, $merged];
             $this->finallyResolve($outer, $func, $args);
         });
@@ -232,7 +232,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
-    private function requestAsyncWithRetry(string $method, $uri, array $options)
+    private function requestAsyncWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -255,7 +255,7 @@ class AuthenticatedClient implements ClientInterface
             }
 
             $merged = $this->mergeAuth($options, true);
-            $func = [$this->client, 'request'];
+            $func = $this->client->request(...);
             $args = [$method, $uri, $merged];
             $this->finallyResolve($outer, $func, $args);
         });
@@ -298,7 +298,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @return \Psr\Http\Message\ResponseInterface The response.
      */
-    private function requestWithRetry(string $method, $uri, array $options)
+    private function requestWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options)
     {
         try {
             $merged = $this->mergeAuth($options);
@@ -327,7 +327,7 @@ class AuthenticatedClient implements ClientInterface
             // as callers are concerned there is only one promise.
             try {
                 $inner->wait();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // The inner promise handles all rejections.
             }
         });

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -162,8 +162,6 @@ class AuthenticatedClient implements ClientInterface
      *
      * @param \Psr\Http\Message\RequestInterface $request The request to send.
      * @param array                              $options Request options to apply.
-     *
-     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
     private function sendAsyncWithRetry(RequestInterface $request, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
     {
@@ -229,8 +227,6 @@ class AuthenticatedClient implements ClientInterface
      * @param string                                $method  HTTP method
      * @param string|\Psr\Http\Message\UriInterface $uri     URI object or string.
      * @param array                                 $options Request options to apply.
-     *
-     * @return \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
      */
     private function requestAsyncWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options): \GuzzleHttp\Promise\PromiseInterface|\Psr\Http\Message\RequestInterface
     {

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -163,7 +163,7 @@ class AuthenticatedClient implements ClientInterface
      * @param \Psr\Http\Message\RequestInterface $request The request to send.
      * @param array                              $options Request options to apply.
      */
-    private function sendAsyncWithRetry(RequestInterface $request, array $options): \GuzzleHttp\Promise\PromiseInterface | \Psr\Http\Message\RequestInterface
+    private function sendAsyncWithRetry(RequestInterface $request, array $options): PromiseInterface|RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -228,7 +228,7 @@ class AuthenticatedClient implements ClientInterface
      * @param string|\Psr\Http\Message\UriInterface $uri     URI object or string.
      * @param array                                 $options Request options to apply.
      */
-    private function requestAsyncWithRetry(string $method, string | \Psr\Http\Message\UriInterface $uri, array $options): \GuzzleHttp\Promise\PromiseInterface | \Psr\Http\Message\RequestInterface
+    private function requestAsyncWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options): PromiseInterface|RequestInterface
     {
         // This is the initial API request that we expect to pass.
         $merged = $this->mergeAuth($options);
@@ -294,7 +294,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @return \Psr\Http\Message\ResponseInterface The response.
      */
-    private function requestWithRetry(string $method, string | \Psr\Http\Message\UriInterface $uri, array $options)
+    private function requestWithRetry(string $method, string|\Psr\Http\Message\UriInterface $uri, array $options)
     {
         try {
             $merged = $this->mergeAuth($options);

--- a/src/Client.php
+++ b/src/Client.php
@@ -45,7 +45,7 @@ class Client implements GuzzleClientInterface
      *
      * @return array An array of configuration options suitable for use with Guzzle.
      */
-    public static function getDefaultConfiguration($handler = null)
+    public static function getDefaultConfiguration(mixed $handler = null)
     {
         $config = [
             'headers' => [

--- a/src/DataService/CachingContextFactory.php
+++ b/src/DataService/CachingContextFactory.php
@@ -12,10 +12,10 @@ use phpDocumentor\Reflection\Types\Context;
 final class CachingContextFactory
 {
     /** The literal used at the end of a use statement. */
-    const T_LITERAL_END_OF_USE = ';';
+    public const T_LITERAL_END_OF_USE = ';';
 
     /** The literal used between sets of use statements */
-    const T_LITERAL_USE_SEPARATOR = ',';
+    public const T_LITERAL_USE_SEPARATOR = ',';
 
     /**
      * Build a Context given a Class Reflection.
@@ -59,7 +59,7 @@ final class CachingContextFactory
             $namespace = trim($namespace, '\\');
             $useStatements = [];
             $currentNamespace = '';
-            $tokens = new \ArrayIterator(token_get_all($fileContents));
+            $tokens = new \ArrayIterator(\PhpToken::tokenize($fileContents));
 
             while ($tokens->valid()) {
                 switch ($tokens->current()[0]) {
@@ -136,7 +136,7 @@ final class CachingContextFactory
         while ($continue) {
             $this->skipToNextStringOrNamespaceSeparator($tokens);
 
-            list($alias, $fqnn) = $this->extractUseStatement($tokens);
+            [$alias, $fqnn] = str_split($this->extractUseStatement($tokens));
             $uses[$alias] = $fqnn;
             if (self::T_LITERAL_END_OF_USE === $tokens->current()[0]) {
                 $continue = false;

--- a/src/DataService/CachingPhpDocExtractor.php
+++ b/src/DataService/CachingPhpDocExtractor.php
@@ -36,7 +36,6 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
     private $arrayMutatorPrefixes;
 
     /**
-     * @param DocBlockFactoryInterface $docBlockFactory
      * @param string[]|null            $mutatorPrefixes
      * @param string[]|null            $accessorPrefixes
      * @param string[]|null            $arrayMutatorPrefixes
@@ -194,8 +193,6 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
      *
      * @param string $class
      * @param string $property
-     *
-     * @return DocBlock|null
      */
     private function getDocBlockFromProperty($class, $property): ?\phpDocumentor\Reflection\DocBlock
     {
@@ -215,8 +212,6 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
      * @param string $class
      * @param string $ucFirstProperty
      * @param int    $type
-     *
-     * @return array|null
      */
     private function getDocBlockFromMethod($class, $ucFirstProperty, $type): ?array
     {

--- a/src/DataService/CachingPhpDocExtractor.php
+++ b/src/DataService/CachingPhpDocExtractor.php
@@ -36,9 +36,9 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
     private $arrayMutatorPrefixes;
 
     /**
-     * @param string[]|null            $mutatorPrefixes
-     * @param string[]|null            $accessorPrefixes
-     * @param string[]|null            $arrayMutatorPrefixes
+     * @param string[]|null $mutatorPrefixes
+     * @param string[]|null $accessorPrefixes
+     * @param string[]|null $arrayMutatorPrefixes
      */
     public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
     {
@@ -194,13 +194,13 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
      * @param string $class
      * @param string $property
      */
-    private function getDocBlockFromProperty($class, $property): ?\phpDocumentor\Reflection\DocBlock
+    private function getDocBlockFromProperty($class, $property): ?DocBlock
     {
         // Use a ReflectionProperty instead of $class to get the parent class if applicable
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
         } catch (\ReflectionException) {
-            return NULL;
+            return null;
         }
 
         return $this->docBlockFactory->create($reflectionProperty, $this->contextFactory->createFromReflector($reflectionProperty->getDeclaringClass()));
@@ -239,7 +239,7 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
         }
 
         if (!isset($reflectionMethod)) {
-            return NULL;
+            return null;
         }
 
         return [$this->docBlockFactory->create($reflectionMethod, $this->contextFactory->createFromReflector($reflectionMethod)), $prefix];

--- a/src/DataService/CachingPhpDocExtractor.php
+++ b/src/DataService/CachingPhpDocExtractor.php
@@ -200,7 +200,7 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
         } catch (\ReflectionException) {
-            return;
+            return NULL;
         }
 
         return $this->docBlockFactory->create($reflectionProperty, $this->contextFactory->createFromReflector($reflectionProperty->getDeclaringClass()));
@@ -239,7 +239,7 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
         }
 
         if (!isset($reflectionMethod)) {
-            return;
+            return NULL;
         }
 
         return [$this->docBlockFactory->create($reflectionMethod, $this->contextFactory->createFromReflector($reflectionMethod)), $prefix];

--- a/src/DataService/CustomFieldDiscovery.php
+++ b/src/DataService/CustomFieldDiscovery.php
@@ -24,7 +24,6 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface
      *
      * @param string $namespace The namespace of the plugins.
      * @param string $directory The directory of the plugins.
-     * @param $rootDir
      * @param string $rootDir
      */
     public function __construct(

--- a/src/DataService/CustomFieldDiscovery.php
+++ b/src/DataService/CustomFieldDiscovery.php
@@ -13,39 +13,11 @@ use Symfony\Component\Finder\SplFileInfo;
 class CustomFieldDiscovery implements CustomFieldDiscoveryInterface
 {
     /**
-     * The namespace to search within, such as '\Lullabot\Mpx'.
-     *
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * The root directory of the namespace, such as 'src'.
-     *
-     * @var string
-     */
-    private $directory;
-
-    /**
-     * The class to use for reading annotations.
-     *
-     * @var \Doctrine\Common\Annotations\Reader
-     */
-    private $annotationReader;
-
-    /**
-     * The root directory to discover from, containing the namespace directory.
-     *
-     * @var string
-     */
-    private $rootDir;
-
-    /**
      * The array of discovered data services.
      *
      * @var DiscoveredCustomField[]
      */
-    private $customFields = [];
+    private array $customFields = [];
 
     /**
      * CustomFieldDiscovery constructor.
@@ -53,13 +25,21 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface
      * @param string $namespace The namespace of the plugins.
      * @param string $directory The directory of the plugins.
      * @param $rootDir
+     * @param string $rootDir
      */
-    public function __construct($namespace, $directory, $rootDir, Reader $annotationReader)
+    public function __construct(
+        private $namespace,
+        private $directory,
+        /**
+         * The root directory to discover from, containing the namespace directory.
+         */
+        private $rootDir,
+        /**
+         * The class to use for reading annotations.
+         */
+        private readonly Reader $annotationReader
+    )
     {
-        $this->namespace = $namespace;
-        $this->annotationReader = $annotationReader;
-        $this->directory = $directory;
-        $this->rootDir = $rootDir;
     }
 
     /**
@@ -119,7 +99,7 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface
         /** @var CustomField $annotation */
         if ($annotation = $this->annotationReader->getClassAnnotation(
             new \ReflectionClass($class),
-            'Lullabot\Mpx\DataService\Annotation\CustomField'
+            \Lullabot\Mpx\DataService\Annotation\CustomField::class
         )) {
             if (!is_subclass_of($class, CustomFieldInterface::class)) {
                 throw new \RuntimeException(sprintf('%s must implement %s.', $class, CustomFieldInterface::class));

--- a/src/DataService/CustomFieldDiscovery.php
+++ b/src/DataService/CustomFieldDiscovery.php
@@ -30,16 +30,15 @@ class CustomFieldDiscovery implements CustomFieldDiscoveryInterface
     public function __construct(
         private $namespace,
         private $directory,
-        /**
+        /*
          * The root directory to discover from, containing the namespace directory.
          */
         private $rootDir,
-        /**
+        /*
          * The class to use for reading annotations.
          */
         private readonly Reader $annotationReader
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/DataService/CustomFieldManager.php
+++ b/src/DataService/CustomFieldManager.php
@@ -8,18 +8,12 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 class CustomFieldManager
 {
     /**
-     * @var \Lullabot\Mpx\DataService\CustomFieldDiscoveryInterface
-     */
-    private $discovery;
-
-    /**
      * CustomFieldManager constructor.
      *
      * @param CustomFieldDiscoveryInterface $discovery The class used to discover custom field implementations.
      */
-    public function __construct(CustomFieldDiscoveryInterface $discovery)
+    public function __construct(private readonly CustomFieldDiscoveryInterface $discovery)
     {
-        $this->discovery = $discovery;
     }
 
     /**

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -186,7 +186,7 @@ class DataObjectFactory
         }
 
         $response = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
-            fn(ResponseInterface $response) => $this->deserialize($response->getBody(), $this->dataService->getClass())
+            fn (ResponseInterface $response) => $this->deserialize($response->getBody(), $this->dataService->getClass())
         );
 
         return $response;
@@ -242,7 +242,7 @@ class DataObjectFactory
         $uri = $this->getBaseUri($annotation, true);
 
         $request = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
-            fn(ResponseInterface $response) => $this->deserializeObjectList($response, $objectListQuery)
+            fn (ResponseInterface $response) => $this->deserializeObjectList($response, $objectListQuery)
         );
 
         return $request;

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -118,7 +118,7 @@ class DataObjectFactory
         // there is no way to access it from within the extractor. We can't
         // alter $context in the CJsonEncoder as it is not passed by reference.
         // @todo This feels like a bit of a hack.
-        $decoded = \GuzzleHttp\json_decode($data, true);
+        $decoded = \GuzzleHttp\Utils::jsonDecode($data, true);
         if (isset($decoded['$xmlns'])) {
             $dataServiceExtractor->setNamespaceMapping($decoded['$xmlns']);
         }
@@ -264,7 +264,7 @@ class DataObjectFactory
         $list = $this->deserialize($data, ObjectList::class);
 
         // Set the json representation of each entry in the list.
-        $decoded = \GuzzleHttp\json_decode($data, true);
+        $decoded = \GuzzleHttp\Utils::jsonDecode($data, true);
         foreach ($list as $index => $item) {
             $entry = $decoded['entries'][$index];
             if (isset($decoded['$xmlns'])) {

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -186,9 +186,7 @@ class DataObjectFactory
         }
 
         $response = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
-            function (ResponseInterface $response) {
-                return $this->deserialize($response->getBody(), $this->dataService->getClass());
-            }
+            fn(ResponseInterface $response) => $this->deserialize($response->getBody(), $this->dataService->getClass())
         );
 
         return $response;
@@ -244,9 +242,7 @@ class DataObjectFactory
         $uri = $this->getBaseUri($annotation, true);
 
         $request = $this->authenticatedClient->requestAsync('GET', $uri, $options)->then(
-            function (ResponseInterface $response) use ($objectListQuery) {
-                return $this->deserializeObjectList($response, $objectListQuery);
-            }
+            fn(ResponseInterface $response) => $this->deserializeObjectList($response, $objectListQuery)
         );
 
         return $request;

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -24,7 +24,6 @@ class DataServiceDiscovery
      *
      * @param string $namespace The namespace of the plugins.
      * @param string $directory The directory of the plugins.
-     * @param        $rootDir
      * @param string $rootDir
      */
     public function __construct(

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -30,20 +30,19 @@ class DataServiceDiscovery
     public function __construct(
         private $namespace,
         private $directory,
-        /**
+        /*
          * The root directory to discover from, containing the namespace directory.
          */
         private $rootDir,
-        /**
+        /*
          * The class to use for reading annotations.
          */
         private readonly Reader $annotationReader,
-        /**
+        /*
          * The manager used to discover custom field implementations.
          */
         private readonly CustomFieldManager $customFieldManager
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/DataService/DataServiceDiscovery.php
+++ b/src/DataService/DataServiceDiscovery.php
@@ -13,46 +13,11 @@ use Symfony\Component\Finder\SplFileInfo;
 class DataServiceDiscovery
 {
     /**
-     * The namespace to search within, such as '\Lullabot\Mpx'.
-     *
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * The root directory of the namespace, such as 'src'.
-     *
-     * @var string
-     */
-    private $directory;
-
-    /**
-     * The class to use for reading annotations.
-     *
-     * @var \Doctrine\Common\Annotations\Reader
-     */
-    private $annotationReader;
-
-    /**
-     * The root directory to discover from, containing the namespace directory.
-     *
-     * @var string
-     */
-    private $rootDir;
-
-    /**
      * The array of discovered data services.
      *
      * @var DiscoveredDataService[]
      */
-    private $dataServices = [];
-
-    /**
-     * The manager used to discover custom field implementations.
-     *
-     * @var CustomFieldManager
-     */
-    private $customFieldManager;
+    private array $dataServices = [];
 
     /**
      * DataServiceDiscovery constructor.
@@ -60,14 +25,25 @@ class DataServiceDiscovery
      * @param string $namespace The namespace of the plugins.
      * @param string $directory The directory of the plugins.
      * @param        $rootDir
+     * @param string $rootDir
      */
-    public function __construct($namespace, $directory, $rootDir, Reader $annotationReader, CustomFieldManager $customFieldManager)
+    public function __construct(
+        private $namespace,
+        private $directory,
+        /**
+         * The root directory to discover from, containing the namespace directory.
+         */
+        private $rootDir,
+        /**
+         * The class to use for reading annotations.
+         */
+        private readonly Reader $annotationReader,
+        /**
+         * The manager used to discover custom field implementations.
+         */
+        private readonly CustomFieldManager $customFieldManager
+    )
     {
-        $this->namespace = $namespace;
-        $this->annotationReader = $annotationReader;
-        $this->directory = $directory;
-        $this->rootDir = $rootDir;
-        $this->customFieldManager = $customFieldManager;
     }
 
     /**
@@ -97,7 +73,7 @@ class DataServiceDiscovery
         foreach ($finder as $file) {
             $class = $this->classForFile($file);
             /* @var \Lullabot\Mpx\DataService\Annotation\DataService $annotation */
-            $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), 'Lullabot\Mpx\DataService\Annotation\DataService');
+            $annotation = $this->annotationReader->getClassAnnotation(new \ReflectionClass($class), \Lullabot\Mpx\DataService\Annotation\DataService::class);
             if (!$annotation) {
                 continue;
             }

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -7,14 +7,8 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 class DataServiceManager
 {
-    /**
-     * @var \Lullabot\Mpx\DataService\DataServiceDiscovery
-     */
-    private $discovery;
-
-    public function __construct(DataServiceDiscovery $discovery)
+    public function __construct(private readonly DataServiceDiscovery $discovery)
     {
-        $this->discovery = $discovery;
     }
 
     /**

--- a/src/DataService/DateTime/AvailabilityCalculator.php
+++ b/src/DataService/DateTime/AvailabilityCalculator.php
@@ -17,8 +17,6 @@ class AvailabilityCalculator
     /**
      * Return if the media is available as of the given time.
      *
-     * @param $time
-     *
      * @return bool
      */
     public function isAvailable(Media $media, \DateTime $time)
@@ -28,8 +26,6 @@ class AvailabilityCalculator
 
     /**
      * Return if the media is expired as of the given time.
-     *
-     * @param $time
      *
      * @return bool
      */

--- a/src/DataService/DateTime/ConcreteDateTime.php
+++ b/src/DataService/DateTime/ConcreteDateTime.php
@@ -7,14 +7,8 @@ namespace Lullabot\Mpx\DataService\DateTime;
  */
 class ConcreteDateTime implements ConcreteDateTimeInterface
 {
-    /**
-     * @var \DateTime
-     */
-    private $dateTime;
-
-    public function __construct(\DateTime $dateTime)
+    public function __construct(private readonly \DateTime $dateTime)
     {
-        $this->dateTime = $dateTime;
     }
 
     /**

--- a/src/DataService/DateTime/ConcreteDateTime.php
+++ b/src/DataService/DateTime/ConcreteDateTime.php
@@ -16,10 +16,8 @@ class ConcreteDateTime implements ConcreteDateTimeInterface
      *
      * @param string $time
      *
-     * @return \Lullabot\Mpx\DataService\DateTime\ConcreteDateTime
      *
      * @throws \Exception
-     *
      * @see http://php.net/manual/en/datetime.construct.php
      */
     public static function fromString($time = 'now', \DateTimeZone $timezone = null): self

--- a/src/DataService/DateTime/ConcreteDateTime.php
+++ b/src/DataService/DateTime/ConcreteDateTime.php
@@ -16,8 +16,8 @@ class ConcreteDateTime implements ConcreteDateTimeInterface
      *
      * @param string $time
      *
-     *
      * @throws \Exception
+     *
      * @see http://php.net/manual/en/datetime.construct.php
      */
     public static function fromString($time = 'now', \DateTimeZone $timezone = null): self

--- a/src/DataService/DateTime/ConcreteDateTimeInterface.php
+++ b/src/DataService/DateTime/ConcreteDateTimeInterface.php
@@ -15,6 +15,7 @@ namespace Lullabot\Mpx\DataService\DateTime;
  *      if ($date instanceof \Lullabot\Mpx\DataService\DateTime\ConcreteDateTimeInterface) {
  *          $date->getDateTime()->getTimestamp();
  *      }
+ *
  * @endcode
  *
  * The above example shows the use of a concrete ConcreteDateTimeInterface

--- a/src/DataService/DateTime/DateTimeFormatInterface.php
+++ b/src/DataService/DateTime/DateTimeFormatInterface.php
@@ -19,6 +19,7 @@ namespace Lullabot\Mpx\DataService\DateTime;
  *      $date = $media->getPubDate();
  *      // $formatted will be '' if the media object's published date is undefined.
  *      $formatted = $date->format('Y-m-d H:i:s');
+ *
  * @endcode
  *
  * The above example shows working with a DateTimeFormatInterface object,

--- a/src/DataService/DiscoveredCustomField.php
+++ b/src/DataService/DiscoveredCustomField.php
@@ -10,29 +10,13 @@ use Lullabot\Mpx\DataService\Annotation\CustomField;
 class DiscoveredCustomField
 {
     /**
-     * The fully-qualified class name of the discovered class.
-     *
-     * @var string
-     */
-    private $class;
-
-    /**
-     * The annotation object attached to the class.
-     *
-     * @var CustomField
-     */
-    private $annotation;
-
-    /**
      * DiscoveredCustomField constructor.
      *
      * @param string      $class      The fully-qualified class name of the discovered class.
      * @param CustomField $annotation The annotation object attached to the class.
      */
-    public function __construct(string $class, CustomField $annotation)
+    public function __construct(private readonly string $class, private readonly CustomField $annotation)
     {
-        $this->class = $class;
-        $this->annotation = $annotation;
     }
 
     public function getClass(): string

--- a/src/DataService/DiscoveredDataService.php
+++ b/src/DataService/DiscoveredDataService.php
@@ -9,19 +9,18 @@ class DiscoveredDataService
     /**
      * DiscoveredDataService constructor.
      *
-     * @param string      $class        The class of the discovered data service.
-     * @param DataService $annotation   The annotation of the discovered class.
+     * @param string                                            $class        The class of the discovered data service.
+     * @param DataService                                       $annotation   The annotation of the discovered class.
      * @param \Lullabot\Mpx\DataService\DiscoveredCustomField[] $customFields (optional) The array of custom field classes.
      */
     public function __construct(
         private readonly string $class,
         private readonly DataService $annotation,
-        /**
+        /*
          * The array of custom field objects found for this data service.
          */
         private readonly array $customFields = []
-    )
-    {
+    ) {
     }
 
     public function getClass(): string

--- a/src/DataService/DiscoveredDataService.php
+++ b/src/DataService/DiscoveredDataService.php
@@ -7,34 +7,21 @@ use Lullabot\Mpx\DataService\Annotation\DataService;
 class DiscoveredDataService
 {
     /**
-     * @var string
-     */
-    private $class;
-
-    /**
-     * @var DataService
-     */
-    private $annotation;
-
-    /**
-     * The array of custom field objects found for this data service.
-     *
-     * @var DiscoveredCustomField[]
-     */
-    private $customFields;
-
-    /**
      * DiscoveredDataService constructor.
      *
      * @param string      $class        The class of the discovered data service.
      * @param DataService $annotation   The annotation of the discovered class.
-     * @param array       $customFields (optional) The array of custom field classes.
+     * @param \Lullabot\Mpx\DataService\DiscoveredCustomField[] $customFields (optional) The array of custom field classes.
      */
-    public function __construct(string $class, DataService $annotation, array $customFields = [])
+    public function __construct(
+        private readonly string $class,
+        private readonly DataService $annotation,
+        /**
+         * The array of custom field objects found for this data service.
+         */
+        private readonly array $customFields = []
+    )
     {
-        $this->class = $class;
-        $this->annotation = $annotation;
-        $this->customFields = $customFields;
     }
 
     public function getClass(): string

--- a/src/DataService/Field.php
+++ b/src/DataService/Field.php
@@ -303,7 +303,7 @@ class Field extends ObjectBase
      *
      * @param mixed $defaultValue
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue(mixed $defaultValue)
     {
         $this->defaultValue = $defaultValue;
     }

--- a/src/DataService/Field.php
+++ b/src/DataService/Field.php
@@ -300,8 +300,6 @@ class Field extends ObjectBase
 
     /**
      * Set the default value for this custom field.
-     *
-     * @param mixed $defaultValue
      */
     public function setDefaultValue(mixed $defaultValue)
     {

--- a/src/DataService/JsonInterface.php
+++ b/src/DataService/JsonInterface.php
@@ -20,9 +20,9 @@ interface JsonInterface
     /**
      * Return the JSON of this object as an array.
      *
-     * @throws \LogicException Thrown if no json representation is available.
-     *
      * @return array
+     *
+     * @throws \LogicException Thrown if no json representation is available.
      */
     public function getJson();
 }

--- a/src/DataService/Media/CategoryInfo.php
+++ b/src/DataService/Media/CategoryInfo.php
@@ -2,7 +2,7 @@
 
 namespace Lullabot\Mpx\DataService\Media;
 
-class CategoryInfo
+class CategoryInfo implements \Stringable
 {
     /**
      * The Category object's fullTitle value.
@@ -90,6 +90,6 @@ class CategoryInfo
      */
     public function __toString(): string
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 }

--- a/src/DataService/Media/MediaFile.php
+++ b/src/DataService/Media/MediaFile.php
@@ -1451,8 +1451,6 @@ class MediaFile extends ObjectBase
 
     /**
      * Returns the server information required to transfer the file.
-     *
-     * @return \Lullabot\Mpx\DataService\Media\TransferInfo
      */
     public function getTransferInfo(): TransferInfo
     {
@@ -1461,8 +1459,6 @@ class MediaFile extends ObjectBase
 
     /**
      * Set the server information required to transfer the file.
-     *
-     * @param \Lullabot\Mpx\DataService\Media\TransferInfo $transferInfo
      */
     public function setTransferInfo(TransferInfo $transferInfo)
     {

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -143,7 +143,7 @@ class NotificationListener
 
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
             'query' => $query,
-        ])->then(fn(ResponseInterface $response) => $this->deserializeResponse($response));
+        ])->then(fn (ResponseInterface $response) => $this->deserializeResponse($response));
     }
 
     /**

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -101,7 +101,7 @@ class NotificationListener
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
             'query' => $query,
         ])->then(function (ResponseInterface $response) {
-            $data = \GuzzleHttp\json_decode($response->getBody(), true);
+            $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
 
             return $data[0]['id'];
         });

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -51,11 +51,6 @@ class NotificationListener
     protected $service;
 
     /**
-     * @var string
-     */
-    private $clientId;
-
-    /**
      * NotificationListener constructor.
      *
      * This method always uses the read-only version of a service.
@@ -67,9 +62,8 @@ class NotificationListener
      * @param string                            $clientId      A string to identify this client in debugging.
      * @param CacheItemPoolInterface|null       $cacheItemPool (optional) The cache for API metadata.
      */
-    public function __construct(AuthenticatedClient $session, DiscoveredDataService $service, string $clientId, CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct(AuthenticatedClient $session, DiscoveredDataService $service, private readonly string $clientId, CacheItemPoolInterface $cacheItemPool = null)
     {
-        $this->clientId = $clientId;
         $this->authenticatedClient = $session;
         $this->service = $service;
 
@@ -149,9 +143,7 @@ class NotificationListener
 
         return $this->authenticatedClient->requestAsync('GET', $this->uri, [
             'query' => $query,
-        ])->then(function (ResponseInterface $response) {
-            return $this->deserializeResponse($response);
-        });
+        ])->then(fn(ResponseInterface $response) => $this->deserializeResponse($response));
     }
 
     /**

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -19,18 +19,17 @@ class NotificationTypeExtractor implements PropertyTypeExtractorInterface
     protected $class;
 
     /**
-     * Decorated ReflectionExtractor instance.
-     */
-    protected PropertyTypeExtractorInterface $reflectionExtractor;
-
-    /**
      * NotificationTypeReflectionExtractorDecorator constructor.
      *
      * @param \Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface $reflectionExtractor Reflection extractor instance to decorate.
      */
-    public function __construct(PropertyTypeExtractorInterface $reflectionExtractor)
+    public function __construct(
+        /**
+         * Decorated ReflectionExtractor instance.
+         */
+        protected PropertyTypeExtractorInterface $reflectionExtractor
+    )
     {
-        $this->reflectionExtractor = $reflectionExtractor;
     }
 
     /**

--- a/src/DataService/NotificationTypeExtractor.php
+++ b/src/DataService/NotificationTypeExtractor.php
@@ -24,12 +24,11 @@ class NotificationTypeExtractor implements PropertyTypeExtractorInterface
      * @param \Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface $reflectionExtractor Reflection extractor instance to decorate.
      */
     public function __construct(
-        /**
+        /*
          * Decorated ReflectionExtractor instance.
          */
         protected PropertyTypeExtractorInterface $reflectionExtractor
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/DataService/ObjectBase.php
+++ b/src/DataService/ObjectBase.php
@@ -42,7 +42,7 @@ abstract class ObjectBase implements ObjectInterface
      */
     public function setJson(string $json)
     {
-        $this->json = \GuzzleHttp\json_decode($json, true);
+        $this->json = \GuzzleHttp\Utils::jsonDecode($json, true);
     }
 
     /**

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -206,7 +206,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      *
      * @return PromiseInterface|bool A promise to the next ObjectList, or false if no list exists.
      */
-    public function nextList(): \GuzzleHttp\Promise\PromiseInterface | bool
+    public function nextList(): PromiseInterface|bool
     {
         if (!$this->hasNext()) {
             return false;

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -206,7 +206,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      *
      * @return PromiseInterface|bool A promise to the next ObjectList, or false if no list exists.
      */
-    public function nextList()
+    public function nextList(): \GuzzleHttp\Promise\PromiseInterface|bool
     {
         if (!$this->hasNext()) {
             return false;
@@ -258,7 +258,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->getEntries()[$offset]);
     }
@@ -274,7 +274,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->entries[$offset] = $value;
     }
@@ -282,7 +282,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->entries[$offset]);
     }
@@ -290,7 +290,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->entries[$this->position];
     }
@@ -298,7 +298,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
@@ -306,7 +306,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->entries[$this->position]);
     }
@@ -314,7 +314,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
@@ -322,7 +322,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -330,7 +330,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function setJson(string $json)
+    public function setJson(string $json): void
     {
         $this->json = \GuzzleHttp\json_decode($json, true);
     }
@@ -338,7 +338,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function getJson()
+    public function getJson(): array
     {
         if (!$this->json) {
             throw new \LogicException('This object has no original JSON representation available');

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -266,7 +266,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getEntries()[$offset];
     }
@@ -332,7 +332,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      */
     public function setJson(string $json): void
     {
-        $this->json = \GuzzleHttp\json_decode($json, true);
+        $this->json = \GuzzleHttp\Utils::jsonDecode($json, true);
     }
 
     /**

--- a/src/DataService/ObjectList.php
+++ b/src/DataService/ObjectList.php
@@ -206,7 +206,7 @@ class ObjectList implements \ArrayAccess, \Iterator, JsonInterface
      *
      * @return PromiseInterface|bool A promise to the next ObjectList, or false if no list exists.
      */
-    public function nextList(): \GuzzleHttp\Promise\PromiseInterface|bool
+    public function nextList(): \GuzzleHttp\Promise\PromiseInterface | bool
     {
         if (!$this->hasNext()) {
             return false;

--- a/src/DataService/ObjectListIterator.php
+++ b/src/DataService/ObjectListIterator.php
@@ -71,7 +71,7 @@ class ObjectListIterator extends \NoRewindIterator
     /**
      * {@inheritdoc}
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->list[$this->relative];
     }
@@ -79,7 +79,7 @@ class ObjectListIterator extends \NoRewindIterator
     /**
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -87,7 +87,7 @@ class ObjectListIterator extends \NoRewindIterator
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
@@ -95,7 +95,7 @@ class ObjectListIterator extends \NoRewindIterator
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         // Initial setup if this is the first page.
         if (empty($this->list)) {

--- a/src/DataService/ObjectListQuery.php
+++ b/src/DataService/ObjectListQuery.php
@@ -34,7 +34,7 @@ class ObjectListQuery implements QueryPartsInterface
     /**
      * @var QueryPartsInterface[]
      */
-    private $fields = [];
+    private array $fields = [];
 
     /**
      * ObjectListQuery constructor.

--- a/src/DataService/QQuery/Term.php
+++ b/src/DataService/QQuery/Term.php
@@ -10,7 +10,7 @@ use Lullabot\Mpx\DataService\QueryPartsInterface;
  * @see TermGroup
  * @see https://docs.theplatform.com/help/wsf-selecting-objects-by-using-the-q-query-parameter
  */
-class Term implements QueryPartsInterface, TermInterface
+class Term implements QueryPartsInterface, TermInterface, \Stringable
 {
     /**
      * Character sequences that must be escaped from term values.
@@ -23,7 +23,7 @@ class Term implements QueryPartsInterface, TermInterface
      *
      * @see https://docs.theplatform.com/help/wsf-selecting-objects-by-using-the-q-query-parameter#tp-toc31
      */
-    const ESCAPE_CHARACTERS = [
+    final public const ESCAPE_CHARACTERS = [
         '\\' => '\\\\',
         '+' => '\+',
         '-' => '\-',
@@ -45,24 +45,9 @@ class Term implements QueryPartsInterface, TermInterface
         ';' => '\;',
     ];
 
-    /**
-     * @var string
-     */
-    private $value;
-    /**
-     * @var string
-     */
-    private $field;
+    private ?string $matchType = null;
 
-    /**
-     * @var string
-     */
-    private $matchType;
-
-    /**
-     * @var bool
-     */
-    private $wrap;
+    private ?bool $wrap = null;
 
     public function getValue(): string
     {
@@ -118,9 +103,6 @@ class Term implements QueryPartsInterface, TermInterface
         return $this->boost;
     }
 
-    /**
-     * @return Term
-     */
     public function setBoost(int $boost): self
     {
         $this->boost = $boost;
@@ -133,9 +115,6 @@ class Term implements QueryPartsInterface, TermInterface
         return $this->namespace;
     }
 
-    /**
-     * @return Term
-     */
     public function setNamespace(string $namespace): self
     {
         $this->namespace = $namespace;
@@ -169,8 +148,6 @@ class Term implements QueryPartsInterface, TermInterface
 
     /**
      * @param string $exclude
-     *
-     * @return Term
      */
     public function exclude(): self
     {
@@ -179,25 +156,12 @@ class Term implements QueryPartsInterface, TermInterface
         return $this;
     }
 
-    /**
-     * @var int
-     */
-    private $boost;
-    /**
-     * @var string
-     */
-    private $namespace;
+    private ?int $boost = null;
 
-    /**
-     * @var string
-     */
-    private $plusMinus;
+    private ?string $plusMinus = null;
 
-    public function __construct(string $value, string $field = null, string $namespace = null)
+    public function __construct(private string $value, private string $field = null, private string $namespace = null)
     {
-        $this->value = $value;
-        $this->field = $field;
-        $this->namespace = $namespace;
     }
 
     public function __toString(): string

--- a/src/DataService/QQuery/Term.php
+++ b/src/DataService/QQuery/Term.php
@@ -54,9 +54,6 @@ class Term implements QueryPartsInterface, TermInterface, \Stringable
         return $this->value;
     }
 
-    /**
-     * @return Term
-     */
     public function setValue(string $value): self
     {
         $this->value = $value;
@@ -69,9 +66,6 @@ class Term implements QueryPartsInterface, TermInterface, \Stringable
         return $this->field;
     }
 
-    /**
-     * @return Term
-     */
     public function setField(string $field): self
     {
         $this->field = $field;
@@ -84,9 +78,6 @@ class Term implements QueryPartsInterface, TermInterface, \Stringable
         return $this->matchType;
     }
 
-    /**
-     * @return Term
-     */
     public function setMatchType(string $matchType): self
     {
         if (!isset($this->field)) {

--- a/src/DataService/QQuery/Term.php
+++ b/src/DataService/QQuery/Term.php
@@ -23,7 +23,7 @@ class Term implements QueryPartsInterface, TermInterface, \Stringable
      *
      * @see https://docs.theplatform.com/help/wsf-selecting-objects-by-using-the-q-query-parameter#tp-toc31
      */
-    final public const ESCAPE_CHARACTERS = [
+    public const ESCAPE_CHARACTERS = [
         '\\' => '\\\\',
         '+' => '\+',
         '-' => '\-',

--- a/src/DataService/QQuery/Term.php
+++ b/src/DataService/QQuery/Term.php
@@ -151,7 +151,7 @@ class Term implements QueryPartsInterface, TermInterface, \Stringable
 
     private ?string $plusMinus = null;
 
-    public function __construct(private string $value, private string $field = null, private string $namespace = null)
+    public function __construct(private string $value, private ?string $field = null, private ?string $namespace = null)
     {
     }
 

--- a/src/DataService/QQuery/TermGroup.php
+++ b/src/DataService/QQuery/TermGroup.php
@@ -9,17 +9,11 @@ use Lullabot\Mpx\DataService\QueryPartsInterface;
  *
  * @see https://docs.theplatform.com/help/wsf-selecting-objects-by-using-the-q-query-parameter
  */
-class TermGroup implements QueryPartsInterface, TermInterface
+class TermGroup implements QueryPartsInterface, TermInterface, \Stringable
 {
-    /**
-     * @var array
-     */
-    private $terms = [];
+    private array $terms = [];
 
-    /**
-     * @var bool
-     */
-    private $wrap;
+    private ?bool $wrap = null;
 
     public function __construct(TermInterface $term)
     {
@@ -53,7 +47,7 @@ class TermGroup implements QueryPartsInterface, TermInterface
         return $this;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $query = '';
         foreach ($this->terms as $term) {

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -29,7 +29,7 @@ class CJsonEncoder extends JsonEncoder
      *
      * @param array &$data The data to filter.
      */
-    protected function cleanup(array & $data)
+    protected function cleanup(array &$data)
     {
         foreach ($data as &$value) {
             if (\is_array($value)) {
@@ -55,7 +55,7 @@ class CJsonEncoder extends JsonEncoder
      *
      * @param array &$decoded The data to decode.
      */
-    protected function decodeCustomFields(& $decoded)
+    protected function decodeCustomFields(&$decoded)
     {
         // @todo This is O(namespaces * entries) and can be optimized.
         foreach ($decoded['$xmlns'] as $prefix => $namespace) {
@@ -77,7 +77,7 @@ class CJsonEncoder extends JsonEncoder
      * @param string $namespace The namespace identifier.
      * @param array  $object    The object data to decode.
      */
-    protected function decodeObject($prefix, $namespace, & $object)
+    protected function decodeObject($prefix, $namespace, &$object)
     {
         $customFields = ['namespace' => $namespace];
         foreach ($object as $key => $value) {

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -37,9 +37,7 @@ class CJsonEncoder extends JsonEncoder
             }
         }
 
-        $data = array_filter($data, function ($value) {
-            return null !== $value;
-        });
+        $data = array_filter($data, fn($value) => null !== $value);
     }
 
     /**
@@ -83,7 +81,7 @@ class CJsonEncoder extends JsonEncoder
     {
         $customFields = ['namespace' => $namespace];
         foreach ($object as $key => $value) {
-            if (false !== strpos($key, $prefix.'$')) {
+            if (str_contains($key, $prefix.'$')) {
                 $fieldName = substr($key, \strlen($prefix) + 1);
                 $customFields['data'][$fieldName] = $value;
             }

--- a/src/Encoder/CJsonEncoder.php
+++ b/src/Encoder/CJsonEncoder.php
@@ -29,7 +29,7 @@ class CJsonEncoder extends JsonEncoder
      *
      * @param array &$data The data to filter.
      */
-    protected function cleanup(array &$data)
+    protected function cleanup(array & $data)
     {
         foreach ($data as &$value) {
             if (\is_array($value)) {
@@ -37,7 +37,7 @@ class CJsonEncoder extends JsonEncoder
             }
         }
 
-        $data = array_filter($data, fn($value) => null !== $value);
+        $data = array_filter($data, fn ($value) => null !== $value);
     }
 
     /**
@@ -55,7 +55,7 @@ class CJsonEncoder extends JsonEncoder
      *
      * @param array &$decoded The data to decode.
      */
-    protected function decodeCustomFields(&$decoded)
+    protected function decodeCustomFields(& $decoded)
     {
         // @todo This is O(namespaces * entries) and can be optimized.
         foreach ($decoded['$xmlns'] as $prefix => $namespace) {
@@ -77,7 +77,7 @@ class CJsonEncoder extends JsonEncoder
      * @param string $namespace The namespace identifier.
      * @param array  $object    The object data to decode.
      */
-    protected function decodeObject($prefix, $namespace, &$object)
+    protected function decodeObject($prefix, $namespace, & $object)
     {
         $customFields = ['namespace' => $namespace];
         foreach ($object as $key => $value) {

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -12,8 +12,6 @@ class MpxExceptionFactory
 {
     /**
      * Create a new MPX API exception.
-     *
-     * @return \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException
      */
     public static function create(
         RequestInterface $request,
@@ -31,8 +29,6 @@ class MpxExceptionFactory
 
     /**
      * Create a new MPX API exception from a notification.
-     *
-     * @return ClientException|ServerException
      */
     public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException
     {
@@ -47,9 +43,7 @@ class MpxExceptionFactory
     /**
      * Create a client or server exception.
      *
-     * @param \Exception $previous
      *
-     * @return ClientException|ServerException
      */
     private static function createException(RequestInterface $request,
         ResponseInterface $altered,

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -20,7 +20,7 @@ class MpxExceptionFactory
         ResponseInterface $response,
         \Exception $previous = null,
         array $ctx = []
-    ) {
+    ): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateData($data);
 
@@ -34,7 +34,7 @@ class MpxExceptionFactory
      *
      * @return ClientException|ServerException
      */
-    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = [])
+    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException
     {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateNotificationData($data);
@@ -55,7 +55,7 @@ class MpxExceptionFactory
         ResponseInterface $altered,
         \Exception $previous = null,
         array $ctx = []
-    ) {
+    ): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException {
         if ($altered->getStatusCode() >= 400 && $altered->getStatusCode() < 500) {
             return new ClientException($request, $altered, $previous, $ctx);
         }

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -18,7 +18,7 @@ class MpxExceptionFactory
         ResponseInterface $response,
         \Exception $previous = null,
         array $ctx = []
-    ): ClientException | \Lullabot\Mpx\Exception\ServerException {
+    ): ClientException|ServerException {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateData($data);
 
@@ -30,7 +30,7 @@ class MpxExceptionFactory
     /**
      * Create a new MPX API exception from a notification.
      */
-    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): ClientException | \Lullabot\Mpx\Exception\ServerException
+    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): ClientException|ServerException
     {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateNotificationData($data);
@@ -47,7 +47,7 @@ class MpxExceptionFactory
         ResponseInterface $altered,
         \Exception $previous = null,
         array $ctx = []
-    ): ClientException | \Lullabot\Mpx\Exception\ServerException {
+    ): ClientException|ServerException {
         if ($altered->getStatusCode() >= 400 && $altered->getStatusCode() < 500) {
             return new ClientException($request, $altered, $previous, $ctx);
         }

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -19,8 +19,8 @@ class MpxExceptionFactory
         \Exception $previous = null,
         array $ctx = []
     ): ClientException|ServerException {
-        $data = \GuzzleHttp\json_decode($response->getBody(), true);
-        MpxExceptionTrait::validateData($data);
+        $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
+        ClientException::validateData($data);
 
         $altered = $response->withStatus($data['responseCode'], $data['title']);
 
@@ -32,8 +32,8 @@ class MpxExceptionFactory
      */
     public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): ClientException|ServerException
     {
-        $data = \GuzzleHttp\json_decode($response->getBody(), true);
-        MpxExceptionTrait::validateNotificationData($data);
+        $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
+        ServerException::validateNotificationData($data);
 
         $altered = $response->withStatus($data[0]['entry']['responseCode'], $data[0]['entry']['title']);
 

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -18,7 +18,7 @@ class MpxExceptionFactory
         ResponseInterface $response,
         \Exception $previous = null,
         array $ctx = []
-    ): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException {
+    ): ClientException | \Lullabot\Mpx\Exception\ServerException {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateData($data);
 
@@ -30,7 +30,7 @@ class MpxExceptionFactory
     /**
      * Create a new MPX API exception from a notification.
      */
-    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException
+    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): ClientException | \Lullabot\Mpx\Exception\ServerException
     {
         $data = \GuzzleHttp\json_decode($response->getBody(), true);
         MpxExceptionTrait::validateNotificationData($data);
@@ -42,14 +42,12 @@ class MpxExceptionFactory
 
     /**
      * Create a client or server exception.
-     *
-     *
      */
     private static function createException(RequestInterface $request,
         ResponseInterface $altered,
         \Exception $previous = null,
         array $ctx = []
-    ): \Lullabot\Mpx\Exception\ClientException|\Lullabot\Mpx\Exception\ServerException {
+    ): ClientException | \Lullabot\Mpx\Exception\ServerException {
         if ($altered->getStatusCode() >= 400 && $altered->getStatusCode() < 500) {
             return new ClientException($request, $altered, $previous, $ctx);
         }

--- a/src/Exception/MpxExceptionTrait.php
+++ b/src/Exception/MpxExceptionTrait.php
@@ -2,6 +2,7 @@
 
 namespace Lullabot\Mpx\Exception;
 
+use GuzzleHttp\Utils;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -162,7 +163,7 @@ trait MpxExceptionTrait
      */
     protected function parseResponse(ResponseInterface $response): string
     {
-        $data = \GuzzleHttp\json_decode($response->getBody(), true);
+        $data = Utils::jsonDecode($response->getBody(), true);
         isset($data[0]) ? $this->setNotificationData($data) : $this->setData($data);
         $message = sprintf('HTTP %s Error %s', $response->getStatusCode(), $this->data['title']);
         if (isset($this->data['description'])) {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -37,7 +37,7 @@ $handler($request, $options)->then(
             return $response;
         }
 
-        $data = \GuzzleHttp\json_decode($response->getBody(), true);
+        $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
 
         // Notification responses have a different exception format.
         if (isset($data[0]) && isset($data[0]['type']) && 'Exception' == $data[0]['type']) {

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -23,7 +23,7 @@ class Middleware
         // Guzzle's built-in middlewares also have this level of nested
         // functions, so we follow the same pattern even though it's difficult
         // to read.
-        return fn(callable $handler) => fn(RequestInterface $request, array $options) => // We only need to process after the request has been sent.
+        return fn (callable $handler) => fn (RequestInterface $request, array $options) => // We only need to process after the request has been sent.
 $handler($request, $options)->then(
             function (ResponseInterface $response) use ($request) {
                 // While it's not documented, we want to be sure that

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -23,37 +23,33 @@ class Middleware
         // Guzzle's built-in middlewares also have this level of nested
         // functions, so we follow the same pattern even though it's difficult
         // to read.
-        return function (callable $handler) {
-            return function (RequestInterface $request, array $options) use ($handler) {
-                // We only need to process after the request has been sent.
-                return $handler($request, $options)->then(
-                    function (ResponseInterface $response) use ($request) {
-                        // While it's not documented, we want to be sure that
-                        // any 4XX or 5XX errors that break through suppression
-                        // are still parsed. In other words, this handler should
-                        // be executed before the normal Guzzle error handler.
+        return fn(callable $handler) => fn(RequestInterface $request, array $options) => // We only need to process after the request has been sent.
+$handler($request, $options)->then(
+            function (ResponseInterface $response) use ($request) {
+                // While it's not documented, we want to be sure that
+                // any 4XX or 5XX errors that break through suppression
+                // are still parsed. In other words, this handler should
+                // be executed before the normal Guzzle error handler.
 
-                        // If our response isn't JSON, we can't parse it.
-                        $contentType = $response->getHeaderLine('Content-Type');
-                        if (0 === preg_match('!^(application|text)\/json!', $contentType)) {
-                            return $response;
-                        }
+                // If our response isn't JSON, we can't parse it.
+                $contentType = $response->getHeaderLine('Content-Type');
+                if (0 === preg_match('!^(application|text)\/json!', $contentType)) {
+                    return $response;
+                }
 
-                        $data = \GuzzleHttp\json_decode($response->getBody(), true);
+                $data = \GuzzleHttp\json_decode($response->getBody(), true);
 
-                        // Notification responses have a different exception format.
-                        if (isset($data[0]) && isset($data[0]['type']) && 'Exception' == $data[0]['type']) {
-                            throw MpxExceptionFactory::createFromNotificationException($request, $response);
-                        }
+                // Notification responses have a different exception format.
+                if (isset($data[0]) && isset($data[0]['type']) && 'Exception' == $data[0]['type']) {
+                    throw MpxExceptionFactory::createFromNotificationException($request, $response);
+                }
 
-                        if (empty($data['responseCode']) && empty($data['isException'])) {
-                            return $response;
-                        }
+                if (empty($data['responseCode']) && empty($data['isException'])) {
+                    return $response;
+                }
 
-                        throw MpxExceptionFactory::create($request, $response);
-                    }
-                );
-            };
-        };
+                throw MpxExceptionFactory::create($request, $response);
+            }
+        );
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -25,31 +25,31 @@ class Middleware
         // to read.
         return fn (callable $handler) => fn (RequestInterface $request, array $options) => // We only need to process after the request has been sent.
 $handler($request, $options)->then(
-            function (ResponseInterface $response) use ($request) {
-                // While it's not documented, we want to be sure that
-                // any 4XX or 5XX errors that break through suppression
-                // are still parsed. In other words, this handler should
-                // be executed before the normal Guzzle error handler.
+    function (ResponseInterface $response) use ($request) {
+        // While it's not documented, we want to be sure that
+        // any 4XX or 5XX errors that break through suppression
+        // are still parsed. In other words, this handler should
+        // be executed before the normal Guzzle error handler.
 
-                // If our response isn't JSON, we can't parse it.
-                $contentType = $response->getHeaderLine('Content-Type');
-                if (0 === preg_match('!^(application|text)\/json!', $contentType)) {
-                    return $response;
-                }
+        // If our response isn't JSON, we can't parse it.
+        $contentType = $response->getHeaderLine('Content-Type');
+        if (0 === preg_match('!^(application|text)\/json!', $contentType)) {
+            return $response;
+        }
 
-                $data = \GuzzleHttp\json_decode($response->getBody(), true);
+        $data = \GuzzleHttp\json_decode($response->getBody(), true);
 
-                // Notification responses have a different exception format.
-                if (isset($data[0]) && isset($data[0]['type']) && 'Exception' == $data[0]['type']) {
-                    throw MpxExceptionFactory::createFromNotificationException($request, $response);
-                }
+        // Notification responses have a different exception format.
+        if (isset($data[0]) && isset($data[0]['type']) && 'Exception' == $data[0]['type']) {
+            throw MpxExceptionFactory::createFromNotificationException($request, $response);
+        }
 
-                if (empty($data['responseCode']) && empty($data['isException'])) {
-                    return $response;
-                }
+        if (empty($data['responseCode']) && empty($data['isException'])) {
+            return $response;
+        }
 
-                throw MpxExceptionFactory::create($request, $response);
-            }
-        );
+        throw MpxExceptionFactory::create($request, $response);
+    }
+);
     }
 }

--- a/src/Normalizer/CustomFieldsNormalizer.php
+++ b/src/Normalizer/CustomFieldsNormalizer.php
@@ -33,12 +33,11 @@ class CustomFieldsNormalizer implements DenormalizerInterface
      * @param DiscoveredCustomField[] $customFields An array of discovered custom field classes, indexed by namespace.
      */
     public function __construct(
-        /**
+        /*
          * The array of discovered custom field classes, indexed by namespace.
          */
         private array $customFields
-    )
-    {
+    ) {
     }
 
     /**

--- a/src/Normalizer/CustomFieldsNormalizer.php
+++ b/src/Normalizer/CustomFieldsNormalizer.php
@@ -28,20 +28,17 @@ class CustomFieldsNormalizer implements DenormalizerInterface
     use SerializerAwareTrait;
 
     /**
-     * The array of discovered custom field classes, indexed by namespace.
-     *
-     * @var DiscoveredCustomField[]
-     */
-    private $customFields;
-
-    /**
      * CustomFieldsNormalizer constructor.
      *
      * @param DiscoveredCustomField[] $customFields An array of discovered custom field classes, indexed by namespace.
      */
-    public function __construct(array $customFields)
+    public function __construct(
+        /**
+         * The array of discovered custom field classes, indexed by namespace.
+         */
+        private array $customFields
+    )
     {
-        $this->customFields = $customFields;
     }
 
     /**

--- a/src/Normalizer/UnixMillisecondNormalizer.php
+++ b/src/Normalizer/UnixMillisecondNormalizer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
  */
 class UnixMillisecondNormalizer extends DateTimeNormalizer
 {
-    private static $supportedTypes = [
+    private static array $supportedTypes = [
         DateTimeFormatInterface::class => true,
         ConcreteDateTimeInterface::class => true,
         ConcreteDateTime::class => true,

--- a/src/Normalizer/UriNormalizer.php
+++ b/src/Normalizer/UriNormalizer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class UriNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    private static $supportedTypes = [
+    private static array $supportedTypes = [
         Uri::class => true,
         UriInterface::class => true,
     ];

--- a/src/Service/AccessManagement/ResolveAllUrls.php
+++ b/src/Service/AccessManagement/ResolveAllUrls.php
@@ -25,12 +25,12 @@ class ResolveAllUrls extends ResolveBase
      * The URL of the method. Note that we hardcode the whole path as this is
      * where other services are bootstrapped from.
      */
-    const RESOLVE_ALL_URLS_URL = 'https://access.auth.theplatform.com/web/Registry/resolveAllUrls';
+    final public const RESOLVE_ALL_URLS_URL = 'https://access.auth.theplatform.com/web/Registry/resolveAllUrls';
 
     /**
      * While this method is not a data service, it still has a schema version.
      */
-    const SCHEMA_VERSION = '1.0';
+    final public const SCHEMA_VERSION = '1.0';
 
     /**
      * Fetch URLs and return the response.

--- a/src/Service/AccessManagement/ResolveBase.php
+++ b/src/Service/AccessManagement/ResolveBase.php
@@ -38,9 +38,6 @@ abstract class ResolveBase
         $this->cache = $cache;
     }
 
-    /**
-     * @param $resolved
-     */
     protected function saveCache($key, $resolved)
     {
         $item = new CacheItem($key);

--- a/src/Service/AccessManagement/ResolveDomain.php
+++ b/src/Service/AccessManagement/ResolveDomain.php
@@ -19,12 +19,12 @@ class ResolveDomain extends ResolveBase
     /**
      * The method endpoint (this is not a true REST service).
      */
-    const RESOLVE_DOMAIN_URL = 'https://access.auth.theplatform.com/web/Registry/resolveDomain';
+    final public const RESOLVE_DOMAIN_URL = 'https://access.auth.theplatform.com/web/Registry/resolveDomain';
 
     /**
      * The schema version of resolveDomain.
      */
-    const SCHEMA_VERSION = '1.0';
+    final public const SCHEMA_VERSION = '1.0';
 
     /**
      * Resolve all URLs for an account.

--- a/src/Service/Feeds/MediaFeedUrl.php
+++ b/src/Service/Feeds/MediaFeedUrl.php
@@ -28,12 +28,12 @@ use Psr\Http\Message\UriInterface;
  * @see IdMediaFeedUrl
  * @see GuidMediaFeedUrl
  */
-class MediaFeedUrl implements ToUriInterface
+class MediaFeedUrl implements ToUriInterface, \Stringable
 {
     /**
      * The base URL for all feed requests.
      */
-    const BASE_URL = 'https://feed.media.theplatform.com/f/';
+    final public const BASE_URL = 'https://feed.media.theplatform.com/f/';
 
     /**
      * The account the feed is associated with.
@@ -168,7 +168,7 @@ class MediaFeedUrl implements ToUriInterface
     /**
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->toUri();
     }

--- a/src/Service/Feeds/MediaFeedUrl.php
+++ b/src/Service/Feeds/MediaFeedUrl.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\UriInterface;
  *
  * @code
  *      http[s]://feed.media.theplatform.com/f/<account PID>/<feed PID>[/<feed type>][/feed][/<ID>][/guid/<owner ID>/<GUIDs>][/<SEO terms>][?<query parameters>]
+ *
  * @endcode
  *
  * While mpx supports http URLs, this class only supports https URLs by default.

--- a/src/Service/IdentityManagement/User.php
+++ b/src/Service/IdentityManagement/User.php
@@ -16,24 +16,18 @@ class User implements UserInterface
     private $username;
 
     /**
-     * @var string
-     */
-    private $password;
-
-    /**
      * Construct a new mpx user.
      *
      * @param string $username The mpx user name, including the leading directory such as 'mpx/'.
      * @param string $password The user password.
      */
-    public function __construct($username, $password)
+    public function __construct($username, private $password)
     {
-        if (false === strpos($username, '/')) {
+        if (!str_contains($username, '/')) {
             throw new \InvalidArgumentException(sprintf('The mpx user name %s must contain a leading directory such as "mpx/"', $username));
         }
 
         $this->username = $username;
-        $this->password = $password;
     }
 
     /**

--- a/src/Service/IdentityManagement/UserSession.php
+++ b/src/Service/IdentityManagement/UserSession.php
@@ -25,12 +25,12 @@ class UserSession
     /**
      * The URL to sign in a user.
      */
-    const SIGN_IN_URL = 'https://identity.auth.theplatform.com/idm/web/Authentication/signIn';
+    final public const SIGN_IN_URL = 'https://identity.auth.theplatform.com/idm/web/Authentication/signIn';
 
     /**
      * The URL to sign out a given token for a user.
      */
-    const SIGN_OUT_URL = 'https://identity.auth.theplatform.com/idm/web/Authentication/signOut';
+    final public const SIGN_OUT_URL = 'https://identity.auth.theplatform.com/idm/web/Authentication/signOut';
 
     /**
      * @var Client
@@ -103,7 +103,7 @@ class UserSession
         // token between the above delete and the next try block.
         try {
             $token = $this->tokenCachePool->getToken($this);
-        } catch (TokenNotFoundException $e) {
+        } catch (TokenNotFoundException) {
             $token = $this->signInWithLock($duration);
         }
 
@@ -181,7 +181,7 @@ class UserSession
         try {
             // It's possible another thread has signed in for us, so check for a token first.
             $token = $this->tokenCachePool->getToken($this);
-        } catch (TokenNotFoundException $e) {
+        } catch (TokenNotFoundException) {
             // We have the lock, and there's no token, so sign in.
             $token = $this->signIn($duration);
         }

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -2,12 +2,13 @@
 
 namespace Lullabot\Mpx\Service\Player;
 
-use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
+
+use function GuzzleHttp\Psr7\build_query;
 
 /**
  * Represents a player URL, suitable for embedding with an iframe.

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -111,8 +111,6 @@ class Url implements ToUriInterface, \Stringable
      * @see https://docs.theplatform.com/help/player-player-autoplay
      *
      * @param bool $autoPlay True to enable autoPlay, false otherwise.
-     *
-     * @return Url
      */
     public function withAutoplay(bool $autoPlay): self
     {
@@ -130,8 +128,6 @@ class Url implements ToUriInterface, \Stringable
      * Override the player's playAll setting for playlist auto-advance for this URL.
      *
      * @see https://docs.theplatform.com/help/player-player-playall
-     *
-     * @return Url
      */
     public function withPlayAll(bool $playAll): self
     {
@@ -145,9 +141,6 @@ class Url implements ToUriInterface, \Stringable
         return $url;
     }
 
-    /**
-     * @return Url
-     */
     public function withEmbed(bool $embed): self
     {
         if ($this->embed === $embed) {
@@ -162,8 +155,6 @@ class Url implements ToUriInterface, \Stringable
 
     /**
      * Return a Url using media reference GUIDs instead of media public IDs.
-     *
-     * @return Url
      */
     public function withMediaByGuid(): self
     {
@@ -179,8 +170,6 @@ class Url implements ToUriInterface, \Stringable
 
     /**
      * Return a Url using media public IDs instead of media reference Ids.
-     *
-     * @return Url
      */
     public function withMediaByPublicId(): self
     {

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -2,12 +2,12 @@
 
 namespace Lullabot\Mpx\Service\Player;
 
+use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
-use function GuzzleHttp\Psr7\build_query;
 
 /**
  * Represents a player URL, suitable for embedding with an iframe.

--- a/src/Service/Player/Url.php
+++ b/src/Service/Player/Url.php
@@ -2,12 +2,12 @@
 
 namespace Lullabot\Mpx\Service\Player;
 
-use function GuzzleHttp\Psr7\build_query;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\DataService\PublicIdentifierInterface;
 use Lullabot\Mpx\DataService\PublicIdWithGuidInterface;
 use Lullabot\Mpx\ToUriInterface;
 use Psr\Http\Message\UriInterface;
+use function GuzzleHttp\Psr7\build_query;
 
 /**
  * Represents a player URL, suitable for embedding with an iframe.
@@ -17,63 +17,34 @@ use Psr\Http\Message\UriInterface;
  * @see https://docs.theplatform.com/help/displaying-mpx-players-to-your-audience
  * @see https://docs.theplatform.com/help/generate-a-player-url-for-a-media
  */
-class Url implements ToUriInterface
+class Url implements ToUriInterface, \Stringable
 {
     /**
      * The base URL for all players.
      */
-    const BASE_URL = 'https://player.theplatform.com/p/';
-
-    /**
-     * The account the player belongs to.
-     *
-     * @var \Lullabot\Mpx\DataService\PublicIdentifierInterface
-     */
-    private $account;
-
-    /**
-     * The player object the URL is being generated for.
-     *
-     * @var PublicIdentifierInterface
-     */
-    private $player;
-
-    /**
-     * The media that is being played.
-     *
-     * @var PublicIdWithGuidInterface
-     */
-    private $media;
+    final public const BASE_URL = 'https://player.theplatform.com/p/';
 
     /**
      * Should autoPlay be overridden?
-     *
-     * @var bool
      */
-    private $autoPlay;
+    private ?bool $autoPlay = null;
 
     /**
      * Should the playAll setting be overridden?
-     *
-     * @var bool
      */
-    private $playAll;
+    private ?bool $playAll = null;
 
     /**
      * Should this player URL be rendered so it can be embedded?
      *
      * @see https://docs.theplatform.com/help/displaying-mpx-players-to-your-audience#tp-toc17
-     *
-     * @var bool
      */
-    private $embed;
+    private ?bool $embed = null;
 
     /**
      * Should this player URL be rendered using media GUIDs instead of public IDs?
-     *
-     * @var bool
      */
-    private $byGuid;
+    private ?bool $byGuid = null;
 
     /**
      * Url constructor.
@@ -82,11 +53,8 @@ class Url implements ToUriInterface
      * @param PublicIdentifierInterface $player  The player to play $media with.
      * @param PublicIdWithGuidInterface $media   The media to play.
      */
-    public function __construct(PublicIdentifierInterface $account, PublicIdentifierInterface $player, PublicIdWithGuidInterface $media)
+    public function __construct(private readonly PublicIdentifierInterface $account, private readonly PublicIdentifierInterface $player, private readonly PublicIdWithGuidInterface $media)
     {
-        $this->player = $player;
-        $this->media = $media;
-        $this->account = $account;
     }
 
     /**
@@ -132,7 +100,7 @@ class Url implements ToUriInterface
      *
      * @return string The player URL.
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->toUri();
     }

--- a/src/Token.php
+++ b/src/Token.php
@@ -141,8 +141,6 @@ class Token implements \Stringable
 
     /**
      * Return the value of this token.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/Token.php
+++ b/src/Token.php
@@ -7,7 +7,7 @@ namespace Lullabot\Mpx;
  *
  * @see https://docs.theplatform.com/help/wsf-signin-method
  */
-class Token
+class Token implements \Stringable
 {
     /**
      * The value of the token, as returned by the signIn() method.
@@ -144,7 +144,7 @@ class Token
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -58,7 +58,9 @@ class Dummy extends ParentDummy
     public $mixedCollection;
 
     /**
-     * @var ParentDummy
+     * B.
+     *
+     * @var ParentDummy|null
      */
     public $B;
 

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -42,6 +42,7 @@ class Dummy extends ParentDummy
 
     /**
      * @var \DateTime[]
+     *
      * @Groups({"a", "b"})
      */
     public $collection;
@@ -105,8 +106,6 @@ class Dummy extends ParentDummy
 
     /**
      * This should not be removed.
-     *
-     * @var
      */
     public $emptyVar;
 

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -136,8 +136,6 @@ class Dummy extends ParentDummy
 
     /**
      * B.
-     *
-     * @param ParentDummy|null $parent
      */
     public function setB(ParentDummy $parent = null)
     {

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -163,16 +163,10 @@ class Dummy extends ParentDummy
     {
     }
 
-    /**
-     * @param self $self
-     */
     public function setSelf(self $self)
     {
     }
 
-    /**
-     * @param parent $realParent
-     */
     public function setRealParent(parent $realParent)
     {
     }

--- a/tests/src/Fixtures/DummyStoreInterface.php
+++ b/tests/src/Fixtures/DummyStoreInterface.php
@@ -10,5 +10,4 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 interface DummyStoreInterface extends PersistingStoreInterface, BlockingStoreInterface
 {
-
 }

--- a/tests/src/Fixtures/DummyStoreInterface.php
+++ b/tests/src/Fixtures/DummyStoreInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Lullabot\Mpx\Tests\Fixtures;
+
+use Symfony\Component\Lock\BlockingStoreInterface;
+use Symfony\Component\Lock\PersistingStoreInterface;
+
+/**
+ * Dummy interface to use with getMockBuilder().
+ */
+interface DummyStoreInterface extends PersistingStoreInterface, BlockingStoreInterface
+{
+
+}

--- a/tests/src/Fixtures/ParentDummy.php
+++ b/tests/src/Fixtures/ParentDummy.php
@@ -48,10 +48,7 @@ class ParentDummy
      */
     public $files;
 
-    /**
-     * @return bool|null
-     */
-    public function isC()
+    public function isC(): ?bool
     {
     }
 
@@ -69,9 +66,6 @@ class ParentDummy
     {
     }
 
-    /**
-     * @param \DateTime $f
-     */
     public function removeF(\DateTime $f)
     {
     }

--- a/tests/src/Functional/FunctionalTestBase.php
+++ b/tests/src/Functional/FunctionalTestBase.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Lock\StoreInterface;
 
 abstract class FunctionalTestBase extends TestCase
 {
@@ -76,8 +75,8 @@ abstract class FunctionalTestBase extends TestCase
 
         // Since this is a single thread within a test, we know it's impossible
         // for the lock to fail so we can stub out the entire class.
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStorageInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStorageInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -13,6 +13,7 @@ use Lullabot\Mpx\Client;
 use Lullabot\Mpx\DataService\Access\Account;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\Token;
@@ -21,7 +22,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * @coversDefaultClass \Lullabot\Mpx\AuthenticatedClient
@@ -62,8 +62,8 @@ class AuthenticatedClientTest extends TestCase
                 return new JsonResponse(200, [], 'getSelfId.json');
             },
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -107,8 +107,8 @@ class AuthenticatedClientTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'getSelfId.json'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -149,8 +149,8 @@ class AuthenticatedClientTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(403, [], '{}'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -189,8 +189,8 @@ class AuthenticatedClientTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(503, [], '{}'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')

--- a/tests/src/Unit/AuthenticatedClientTest.php
+++ b/tests/src/Unit/AuthenticatedClientTest.php
@@ -248,7 +248,7 @@ class AuthenticatedClientTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $authenticatedClient = new AuthenticatedClient($client, $userSession);
-        $duration = rand(1, 3600);
+        $duration = random_int(1, 3600);
         $userSession->expects($this->once())->method('acquireToken')
             ->with($duration, false)
             ->willReturn(new Token('mpx/USER-ID', 'abcdef', $duration));
@@ -319,7 +319,7 @@ class AuthenticatedClientTest extends TestCase
                                 'Retrieved a new mpx token {token} for user {username} that expires on {date}.',
                                 $message
                             );
-                        } catch (ExpectationFailedException $e) {
+                        } catch (ExpectationFailedException) {
                             return false;
                         }
 
@@ -334,7 +334,7 @@ class AuthenticatedClientTest extends TestCase
                                 '!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!',
                                 $context['date']
                             );
-                        } catch (ExpectationFailedException $e) {
+                        } catch (ExpectationFailedException) {
                             return false;
                         }
 

--- a/tests/src/Unit/DataService/Access/AccountTest.php
+++ b/tests/src/Unit/DataService/Access/AccountTest.php
@@ -35,7 +35,7 @@ class AccountTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Annotation/DataServiceTest.php
+++ b/tests/src/Unit/DataService/Annotation/DataServiceTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
 class DataServiceTest extends TestCase
 {
     /**
-     * @param $property
-     * @param $get
-     * @param $value
      * @dataProvider getSetDataProvider
      */
     public function testGetSet($property, $get, $value, $return)

--- a/tests/src/Unit/DataService/CachingContextFactoryTest.php
+++ b/tests/src/Unit/DataService/CachingContextFactoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 namespace Lullabot\Mpx\Tests\Unit\DataService {
-// Added imports on purpose as mock for the unit tests, please do not remove.
+    // Added imports on purpose as mock for the unit tests, please do not remove.
     use Lullabot\Mpx\DataService\CachingContextFactory;
     use Mockery as m;
     use phpDocumentor\Reflection\DocBlock;
@@ -13,6 +13,7 @@ namespace Lullabot\Mpx\Tests\Unit\DataService {
 
     /**
      * @coversDefaultClass \Lullabot\Mpx\DataService\CachingContextFactory
+     *
      * @covers ::<private>
      */
     class CachingContextFactoryTest extends TestCase

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -173,8 +173,6 @@ class OmittedParamTagTypeDocBlock
 {
     /**
      * The type is omitted here to ensure that the extractor doesn't choke on missing types.
-     *
-     * @param $omittedTagType
      */
     public function setOmittedType(array $omittedTagType)
     {

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -11,10 +11,7 @@ use Symfony\Component\PropertyInfo\Type;
  */
 class CachingPhpDocExtractorTest extends TestCase
 {
-    /**
-     * @var CachingPhpDocExtractor
-     */
-    private $extractor;
+    private \Lullabot\Mpx\DataService\CachingPhpDocExtractor $extractor;
 
     protected function setUp(): void
     {
@@ -24,11 +21,11 @@ class CachingPhpDocExtractorTest extends TestCase
     /**
      * @dataProvider typesProvider
      */
-    public function testExtract($property, array $type = null, $shortDescription, $longDescription)
+    public function testExtract($property, $shortDescription, $longDescription, array $type = null)
     {
-        $this->assertEquals($type, $this->extractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
-        $this->assertSame($shortDescription, $this->extractor->getShortDescription('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
-        $this->assertSame($longDescription, $this->extractor->getLongDescription('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $this->extractor->getTypes(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
+        $this->assertSame($shortDescription, $this->extractor->getShortDescription(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
+        $this->assertSame($longDescription, $this->extractor->getLongDescription(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
     }
 
     public function testParamTagTypeIsOmitted()
@@ -43,7 +40,7 @@ class CachingPhpDocExtractorTest extends TestCase
     {
         $customExtractor = new CachingPhpDocExtractor(null, ['add', 'remove'], ['is', 'can']);
 
-        $this->assertEquals($type, $customExtractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $customExtractor->getTypes(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
     }
 
     /**
@@ -53,7 +50,7 @@ class CachingPhpDocExtractorTest extends TestCase
     {
         $noPrefixExtractor = new CachingPhpDocExtractor(null, [], [], []);
 
-        $this->assertEquals($type, $noPrefixExtractor->getTypes('Lullabot\Mpx\Tests\Fixtures\Dummy', $property));
+        $this->assertEquals($type, $noPrefixExtractor->getTypes(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
     }
 
     public function typesProvider()
@@ -76,10 +73,10 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', [new Type(Type::BUILTIN_TYPE_INT)], 'A.', null],
-            ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], 'B.', null],
+            ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], 'B.', null],
             ['c', [new Type(Type::BUILTIN_TYPE_BOOL, true)], null, null],
             ['d', [new Type(Type::BUILTIN_TYPE_BOOL)], null, null],
             ['e', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))], null, null],
@@ -111,7 +108,7 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],
@@ -146,7 +143,7 @@ class CachingPhpDocExtractorTest extends TestCase
                 null,
             ],
             ['bal', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime')], null, null],
-            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Lullabot\Mpx\Tests\Fixtures\ParentDummy')], null, null],
+            ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -21,7 +21,7 @@ class CachingPhpDocExtractorTest extends TestCase
     /**
      * @dataProvider typesProvider
      */
-    public function testExtract($property, $shortDescription, $longDescription, array $type = null)
+    public function testExtract($property, $type, $shortDescription, $longDescription)
     {
         $this->assertEquals($type, $this->extractor->getTypes(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
         $this->assertSame($shortDescription, $this->extractor->getShortDescription(\Lullabot\Mpx\Tests\Fixtures\Dummy::class, $property));
@@ -76,11 +76,9 @@ class CachingPhpDocExtractorTest extends TestCase
             ['parent', [new Type(Type::BUILTIN_TYPE_OBJECT, false, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], null, null],
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', [new Type(Type::BUILTIN_TYPE_INT)], 'A.', null],
-            ['b', [new Type(Type::BUILTIN_TYPE_OBJECT, true, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], 'B.', null],
-            ['c', [new Type(Type::BUILTIN_TYPE_BOOL, true)], null, null],
+            ['B', [new Type(Type::BUILTIN_TYPE_OBJECT, true, \Lullabot\Mpx\Tests\Fixtures\ParentDummy::class)], 'B.', null],
             ['d', [new Type(Type::BUILTIN_TYPE_BOOL)], null, null],
             ['e', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))], null, null],
-            ['f', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['g', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)], 'Nullable array.', null],
             ['donotexist', null, null, null],
             ['staticGetter', null, null, null],
@@ -112,10 +110,8 @@ class CachingPhpDocExtractorTest extends TestCase
             ['collection', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['a', null, 'A.', null],
             ['b', null, 'B.', null],
-            ['c', [new Type(Type::BUILTIN_TYPE_BOOL, true)], null, null],
             ['d', [new Type(Type::BUILTIN_TYPE_BOOL)], null, null],
             ['e', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_RESOURCE))], null, null],
-            ['f', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'DateTime'))], null, null],
             ['g', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)], 'Nullable array.', null],
             ['donotexist', null, null, null],
             ['staticGetter', null, null, null],

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -18,13 +18,13 @@ use Lullabot\Mpx\DataService\ObjectListIterator;
 use Lullabot\Mpx\DataService\ObjectListQuery;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\Tests\Unit\DataService\CustomField\NeverUsedCustomField;
 use Lullabot\Mpx\Tests\Unit\DataService\CustomField\SeriesCustomField;
 use Lullabot\Mpx\TokenCachePool;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * Tests the DataObjectFactory.
@@ -51,15 +51,17 @@ class DataObjectFactoryTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             function (\Psr\Http\Message\RequestInterface $request) {
                 $this->assertEquals('https', $request->getUri()->getScheme());
-                $this->assertEquals('/media/data/Media/2602559', $request->getUri()->getPath());
+                $this->assertEquals('/media/data/Media/2602559', $request->getUri()
+                    ->getPath());
 
                 return new JsonResponse(200, [], 'media-object.json');
             },
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
+            ->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -90,15 +92,16 @@ class DataObjectFactoryTest extends TestCase
             new JsonResponse(200, [], 'resolveDomain.json'),
             function (\Psr\Http\Message\RequestInterface $request) {
                 $this->assertEquals('https', $request->getUri()->getScheme());
-                $this->assertEquals('/media/data/Media/12345', $request->getUri()->getPath());
+                $this->assertEquals('/media/data/Media/12345', $request->getUri()
+                    ->getPath());
 
                 return new JsonResponse(200, [], 'media-object.json');
             },
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -129,8 +132,8 @@ class DataObjectFactoryTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -166,8 +169,8 @@ class DataObjectFactoryTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -192,8 +195,8 @@ class DataObjectFactoryTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -220,8 +223,8 @@ class DataObjectFactoryTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -255,8 +258,8 @@ class DataObjectFactoryTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);

--- a/tests/src/Unit/DataService/DataObjectFactoryTest.php
+++ b/tests/src/Unit/DataService/DataObjectFactoryTest.php
@@ -228,7 +228,7 @@ class DataObjectFactoryTest extends TestCase
         $session = new UserSession($user, $client, $store, $tokenCachePool);
         $authenticatedClient = new AuthenticatedClient($client, $session);
         $factory = new DataObjectFactory($service, $authenticatedClient);
-        $media = $factory->loadByNumericId(2602559)->wait();
+        $media = $factory->loadByNumericId(2_602_559)->wait();
         $this->assertInstanceOf(Media::class, $media);
         $this->assertEquals('http://data.media.theplatform.com/media/data/Media/2602559', $media->getId());
     }
@@ -265,7 +265,7 @@ class DataObjectFactoryTest extends TestCase
         $factory = new DataObjectFactory($service, $authenticatedClient);
 
         /** @var Media $media */
-        $media = $factory->loadByNumericId(2602559)->wait();
+        $media = $factory->loadByNumericId(2_602_559)->wait();
         $customFields = $media->getCustomFields();
         $this->assertInstanceOf(SeriesCustomField::class, $customFields['http://www.example.com/xml']);
 

--- a/tests/src/Unit/DataService/DataType/ImageTest.php
+++ b/tests/src/Unit/DataService/DataType/ImageTest.php
@@ -16,6 +16,7 @@ class ImageTest extends TestCase
      *
      * @param string $property
      * @param string $value
+     *
      * @dataProvider getSetMethodDataProvider
      */
     public function testGetSet($property, $value)

--- a/tests/src/Unit/DataService/DataType/LinkTest.php
+++ b/tests/src/Unit/DataService/DataType/LinkTest.php
@@ -16,6 +16,7 @@ class LinkTest extends TestCase
      *
      * @param string $property
      * @param string $value
+     *
      * @dataProvider getSetMethodDataProvider
      */
     public function testGetSet($property, $value)

--- a/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
+++ b/tests/src/Unit/DataService/Feeds/FeedConfigTest.php
@@ -36,7 +36,7 @@ class FeedConfigTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Feeds/SortKeyTest.php
+++ b/tests/src/Unit/DataService/Feeds/SortKeyTest.php
@@ -34,7 +34,7 @@ class SortKeyTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Feeds/SubFeedTest.php
+++ b/tests/src/Unit/DataService/Feeds/SubFeedTest.php
@@ -34,7 +34,7 @@ class SubFeedTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/FieldTest.php
+++ b/tests/src/Unit/DataService/FieldTest.php
@@ -34,7 +34,7 @@ class FieldTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/AvailabilityWindowTest.php
+++ b/tests/src/Unit/DataService/Media/AvailabilityWindowTest.php
@@ -36,7 +36,7 @@ class AvailabilityWindowTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/CategoryInfoTest.php
+++ b/tests/src/Unit/DataService/Media/CategoryInfoTest.php
@@ -35,7 +35,7 @@ class CategoryInfoTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/ChapterTest.php
+++ b/tests/src/Unit/DataService/Media/ChapterTest.php
@@ -35,7 +35,7 @@ class ChapterTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/CreditTest.php
+++ b/tests/src/Unit/DataService/Media/CreditTest.php
@@ -35,7 +35,7 @@ class CreditTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/MediaFileTest.php
+++ b/tests/src/Unit/DataService/Media/MediaFileTest.php
@@ -40,7 +40,7 @@ class MediaFileTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/MediaTest.php
+++ b/tests/src/Unit/DataService/Media/MediaTest.php
@@ -42,7 +42,7 @@ class MediaTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/RatingTest.php
+++ b/tests/src/Unit/DataService/Media/RatingTest.php
@@ -35,7 +35,7 @@ class RatingTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Media/ReleaseTest.php
+++ b/tests/src/Unit/DataService/Media/ReleaseTest.php
@@ -35,7 +35,7 @@ class ReleaseTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -3,7 +3,6 @@
 namespace Lullabot\Mpx\Tests\Unit\DataService;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
-use function GuzzleHttp\Psr7\parse_query;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
@@ -18,6 +17,8 @@ use Lullabot\Mpx\TokenCachePool;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Lock\StoreInterface;
+
+use function GuzzleHttp\Psr7\parse_query;
 
 /**
  * Tests listening for notifications.
@@ -119,7 +120,7 @@ class NotificationListenerTest extends TestCase
 
             $this->assertEquals($index, $notification->getId());
 
-            (1 == $index ? $method = 'put' : $method = 'post');
+            1 == $index ? $method = 'put' : $method = 'post';
             $this->assertEquals($method, $notification->getMethod());
             $this->assertEquals('Media', $notification->getType());
 

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -3,6 +3,7 @@
 namespace Lullabot\Mpx\Tests\Unit\DataService;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Uri;
 use Lullabot\Mpx\AuthenticatedClient;
 use Lullabot\Mpx\DataService\Access\Account;
@@ -11,14 +12,12 @@ use Lullabot\Mpx\DataService\Media\Media;
 use Lullabot\Mpx\DataService\NotificationListener;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\TokenCachePool;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use Symfony\Component\Lock\StoreInterface;
-
-use function GuzzleHttp\Psr7\parse_query;
 
 /**
  * Tests listening for notifications.
@@ -47,7 +46,7 @@ class NotificationListenerTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'resolveAllUrls.json'),
             function (RequestInterface $request) use ($notification_id, $account_id) {
-                $params = parse_query($request->getUri()->getQuery());
+                $params = Query::parse($request->getUri()->getQuery());
                 $this->assertArrayHasKey('account', $params);
                 $this->assertEquals($account_id, $params['account']);
 
@@ -60,8 +59,8 @@ class NotificationListenerTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);
@@ -91,7 +90,7 @@ class NotificationListenerTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'resolveAllUrls.json'),
             function (RequestInterface $request) use ($account_id) {
-                $params = parse_query($request->getUri()->getQuery());
+                $params = Query::parse($request->getUri()->getQuery());
                 $this->assertArrayHasKey('account', $params);
                 $this->assertEquals($account_id, $params['account']);
 
@@ -100,8 +99,8 @@ class NotificationListenerTest extends TestCase
         ]);
         $user = new User('mpx/username', 'password');
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)->getMock();
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)->getMock();
         $store->expects($this->any())
             ->method('exists')
             ->willReturn(false);

--- a/tests/src/Unit/DataService/NotificationListenerTest.php
+++ b/tests/src/Unit/DataService/NotificationListenerTest.php
@@ -36,7 +36,7 @@ class NotificationListenerTest extends TestCase
      */
     public function testSync()
     {
-        $notification_id = rand(1, getrandmax());
+        $notification_id = random_int(1, mt_getrandmax());
 
         $account_id = 'https://www.example.com/12345';
         $account = new Account();
@@ -130,7 +130,7 @@ class NotificationListenerTest extends TestCase
             $this->assertEquals('http://data.media.theplatform.com/media/data/Media/'.$index, $media->getId());
             $this->assertEquals('http://access.auth.theplatform.com/data/Account/'.$index, $media->getOwnerId());
             $this->assertEquals('https://identity.auth.theplatform.com/idm/data/User/service/'.$index, $media->getUpdatedByUserId());
-            $this->assertEquals(1521790000 + ($index - 1) * 1000, $media->getUpdated()->format('U'));
+            $this->assertEquals(1_521_790_000 + ($index - 1) * 1000, $media->getUpdated()->format('U'));
         }
     }
 }

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -36,7 +36,7 @@ class NotificationTest extends ObjectTestBase
     public function testGetSet(string $field)
     {
         /** @var Notification[] $notifications */
-        $notifications = $this->serializer->deserialize(json_encode($this->decoded), Notification::class.'[]', 'json');
+        $notifications = $this->serializer->deserialize(json_encode($this->decoded, JSON_THROW_ON_ERROR), Notification::class.'[]', 'json');
         $method = 'get'.ucfirst($field);
         foreach ($notifications as $index => $notification) {
             if ('entry' == $field) {

--- a/tests/src/Unit/DataService/NotificationTest.php
+++ b/tests/src/Unit/DataService/NotificationTest.php
@@ -36,7 +36,7 @@ class NotificationTest extends ObjectTestBase
     public function testGetSet(string $field)
     {
         /** @var Notification[] $notifications */
-        $notifications = $this->serializer->deserialize(json_encode($this->decoded, JSON_THROW_ON_ERROR), Notification::class.'[]', 'json');
+        $notifications = $this->serializer->deserialize(json_encode($this->decoded, \JSON_THROW_ON_ERROR), Notification::class.'[]', 'json');
         $method = 'get'.ucfirst($field);
         foreach ($notifications as $index => $notification) {
             if ('entry' == $field) {

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -38,7 +38,7 @@ class ObjectListTest extends TestCase
      * @param mixed  $value  The value to set and get.
      * @dataProvider getSetData
      */
-    public function testGetSet($method, $value)
+    public function testGetSet($method, mixed $value)
     {
         $get = 'get'.ucfirst($method);
         $set = 'set'.ucfirst($method);
@@ -53,11 +53,11 @@ class ObjectListTest extends TestCase
     {
         return [
             ['xmlNs', ['first', 'second']],
-            ['startIndex', rand(1, getrandmax())],
-            ['itemsPerPage', rand(1, getrandmax())],
-            ['entryCount', rand(1, getrandmax())],
+            ['startIndex', random_int(1, mt_getrandmax())],
+            ['itemsPerPage', random_int(1, mt_getrandmax())],
+            ['entryCount', random_int(1, mt_getrandmax())],
             ['entries', [new \stdClass()]],
-            ['totalResults', rand(1, getrandmax())],
+            ['totalResults', random_int(1, mt_getrandmax())],
             ['objectListQuery', new ObjectListQuery()],
         ];
     }

--- a/tests/src/Unit/DataService/ObjectListTest.php
+++ b/tests/src/Unit/DataService/ObjectListTest.php
@@ -36,6 +36,7 @@ class ObjectListTest extends TestCase
      *
      * @param string $method The method base name to test.
      * @param mixed  $value  The value to set and get.
+     *
      * @dataProvider getSetData
      */
     public function testGetSet($method, mixed $value)

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -71,7 +71,7 @@ abstract class ObjectTestBase extends TestCase
         $this->serializer = new Serializer($normalizers, $encoders);
 
         $data = file_get_contents(__DIR__."/../../../fixtures/$fixture");
-        $this->decoded = \GuzzleHttp\json_decode($data, true);
+        $this->decoded = \GuzzleHttp\Utils::jsonDecode($data, true);
     }
 
     protected function assertObjectClass($class, string $field, $expected)

--- a/tests/src/Unit/DataService/ObjectTestBase.php
+++ b/tests/src/Unit/DataService/ObjectTestBase.php
@@ -56,10 +56,6 @@ abstract class ObjectTestBase extends TestCase
         return $tests;
     }
 
-    /**
-     * @param $fixture
-     * @param $propertyTypeExtractor
-     */
     protected function loadFixture($fixture, PropertyTypeExtractorInterface $propertyTypeExtractor)
     {
         $encoders = [new CJsonEncoder()];
@@ -78,10 +74,6 @@ abstract class ObjectTestBase extends TestCase
         $this->decoded = \GuzzleHttp\json_decode($data, true);
     }
 
-    /**
-     * @param $class
-     * @param $expected
-     */
     protected function assertObjectClass($class, string $field, $expected)
     {
         $object = $this->deserialize($class, $field);
@@ -99,8 +91,6 @@ abstract class ObjectTestBase extends TestCase
     }
 
     /**
-     * @param $class
-     *
      * @return object
      */
     protected function deserialize($class, string $field)

--- a/tests/src/Unit/DataService/Player/PlayerTest.php
+++ b/tests/src/Unit/DataService/Player/PlayerTest.php
@@ -35,7 +35,7 @@ class PlayerTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/Player/PlugInInstanceTest.php
+++ b/tests/src/Unit/DataService/Player/PlugInInstanceTest.php
@@ -35,7 +35,7 @@ class PlugInInstanceTest extends ObjectTestBase
      *
      * @dataProvider getSetMethods
      */
-    public function testGetSet(string $field, $expected = null)
+    public function testGetSet(string $field, mixed $expected = null)
     {
         $this->assertObjectClass($this->class, $field, $expected);
     }

--- a/tests/src/Unit/DataService/QQuery/TermTest.php
+++ b/tests/src/Unit/DataService/QQuery/TermTest.php
@@ -106,8 +106,6 @@ class TermTest extends TestCase
     }
 
     /**
-     * @param $value
-     * @param $escaped
      * @dataProvider escapeDataProvider
      */
     public function testEscape($value, $escaped)

--- a/tests/src/Unit/DataService/RangeTest.php
+++ b/tests/src/Unit/DataService/RangeTest.php
@@ -19,8 +19,8 @@ class RangeTest extends TestCase
     public function testNextRange()
     {
         $list = new ObjectList();
-        $start = rand(1, getrandmax());
-        $entryCount = rand(1, 10);
+        $start = random_int(1, mt_getrandmax());
+        $entryCount = random_int(1, 10);
         $list->setStartIndex($start);
         $list->setEntryCount($entryCount);
         $list->setItemsPerPage($entryCount);
@@ -39,8 +39,8 @@ class RangeTest extends TestCase
     public function testToQueryParts()
     {
         $range = new Range();
-        $start = rand(1, getrandmax());
-        $end = $start + rand(1, 10);
+        $start = random_int(1, mt_getrandmax());
+        $end = $start + random_int(1, 10);
         $parts = $range->setStartIndex($start)
             ->setEndIndex($end)
             ->toQueryParts();
@@ -86,12 +86,12 @@ class RangeTest extends TestCase
     public function testNextRanges()
     {
         $list = new ObjectList();
-        $start = rand(1, getrandmax());
-        $entryCount = rand(1, 10);
+        $start = random_int(1, mt_getrandmax());
+        $entryCount = random_int(1, 10);
         $list->setStartIndex($start);
         $list->setEntryCount($entryCount);
         $list->setItemsPerPage($entryCount);
-        $remainingPages = rand(1, 10);
+        $remainingPages = random_int(1, 10);
         $list->setTotalResults($start + ($entryCount * $remainingPages));
         $ranges = Range::nextRanges($list);
 

--- a/tests/src/Unit/Exception/MpxExceptionTraitTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionTraitTest.php
@@ -95,6 +95,7 @@ class MpxExceptionTraitTest extends TestCase
      * @doesNotPerformAssertions
      *
      * @covers ::validateData
+     *
      * @doesNotPerformAssertions
      */
     public function testValidateData()

--- a/tests/src/Unit/Exception/MpxExceptionTraitTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionTraitTest.php
@@ -186,8 +186,7 @@ class MpxExceptionTraitTest extends TestCase
             'title' => 'the title',
         ];
         $data = array_map(function ($value) use (&$required) {
-            end($required);
-            $key = key($required);
+            $key = array_key_last($required);
             array_pop($required);
 
             return [$required, $key];
@@ -213,8 +212,7 @@ class MpxExceptionTraitTest extends TestCase
             ],
         ];
         $data = array_map(function ($value) use (&$required) {
-            end($required);
-            $key = key($required);
+            $key = array_key_last($required);
             array_pop($required);
 
             return [[$required], $key];

--- a/tests/src/Unit/Exception/MpxExceptionTraitTest.php
+++ b/tests/src/Unit/Exception/MpxExceptionTraitTest.php
@@ -2,7 +2,9 @@
 
 namespace Lullabot\Mpx\Tests\Unit\Exception;
 
+use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Exception\MpxExceptionTrait;
+use Lullabot\Mpx\Exception\ServerException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -106,7 +108,7 @@ class MpxExceptionTraitTest extends TestCase
             'title' => 'the title',
             'description' => 'the description',
         ];
-        MpxExceptionTrait::validateData($data);
+        ClientException::validateData($data);
     }
 
     /**
@@ -154,7 +156,7 @@ class MpxExceptionTraitTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Required key %s is missing.', $key));
-        MpxExceptionTrait::validateData($data);
+        ServerException::validateData($data);
     }
 
     /**
@@ -171,7 +173,7 @@ class MpxExceptionTraitTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf('Required key %s is missing.', $key));
-        MpxExceptionTrait::validateNotificationData($data);
+        ServerException::validateNotificationData($data);
     }
 
     /**

--- a/tests/src/Unit/MiddlewareTest.php
+++ b/tests/src/Unit/MiddlewareTest.php
@@ -107,7 +107,7 @@ class MiddlewareTest extends TestCase
      */
     private function getResponse(RequestInterface $request, ResponseInterface $response, callable $errorHandler)
     {
-        $handler = fn(RequestInterface $request, array $options) => new FulfilledPromise($response);
+        $handler = fn (RequestInterface $request, array $options) => new FulfilledPromise($response);
         $fn = $errorHandler($handler);
 
         /** @var \GuzzleHttp\Promise\FulfilledPromise $promise */

--- a/tests/src/Unit/MiddlewareTest.php
+++ b/tests/src/Unit/MiddlewareTest.php
@@ -107,9 +107,7 @@ class MiddlewareTest extends TestCase
      */
     private function getResponse(RequestInterface $request, ResponseInterface $response, callable $errorHandler)
     {
-        $handler = function (RequestInterface $request, array $options) use ($response) {
-            return new FulfilledPromise($response);
-        };
+        $handler = fn(RequestInterface $request, array $options) => new FulfilledPromise($response);
         $fn = $errorHandler($handler);
 
         /** @var \GuzzleHttp\Promise\FulfilledPromise $promise */

--- a/tests/src/Unit/Normalizer/UnixMillisecondNormalizerTest.php
+++ b/tests/src/Unit/Normalizer/UnixMillisecondNormalizerTest.php
@@ -23,8 +23,8 @@ class UnixMillisecondNormalizerTest extends TestCase
         $normalizer = new UnixMillisecondNormalizer();
         $normalized = $normalizer->denormalize(0, \DateTime::class);
         $this->assertEquals(0, $normalized->format('U'));
-        $normalized = $normalizer->denormalize(1521719898123, \DateTime::class);
-        $this->assertEquals(1521719898.123, $normalized->format('U.u'));
+        $normalized = $normalizer->denormalize(1_521_719_898_123, \DateTime::class);
+        $this->assertEquals(1_521_719_898.123, $normalized->format('U.u'));
     }
 
     /**

--- a/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveAllUrlsTest.php
@@ -8,13 +8,13 @@ use Lullabot\Mpx\Service\AccessManagement\ResolveAllUrls;
 use Lullabot\Mpx\Service\AccessManagement\ResolveAllUrlsResponse;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\TokenCachePool;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * Test resolving all URLs for a given MPX service.
@@ -39,8 +39,8 @@ class ResolveAllUrlsTest extends TestCase
             new JsonResponse(200, [], 'resolveAllUrls.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -79,7 +79,7 @@ class ResolveAllUrlsTest extends TestCase
         $client = $this->getMockClient();
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
 
         $user = new User('mpx/USER-NAME', 'correct-password');

--- a/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
+++ b/tests/src/Unit/Service/AccessManagement/ResolveDomainTest.php
@@ -10,13 +10,13 @@ use Lullabot\Mpx\Service\AccessManagement\ResolveDomain;
 use Lullabot\Mpx\Service\AccessManagement\ResolveDomainResponse;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\TokenCachePool;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * Tests resolving mpx domains and services.
@@ -41,7 +41,7 @@ class ResolveDomainTest extends TestCase
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
         /** @var StoreInterface|\PHPUnit\Framework\MockObject\MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -72,8 +72,8 @@ class ResolveDomainTest extends TestCase
             new JsonResponse(200, [], 'resolveDomain.json'),
         ]);
         $tokenCachePool = new TokenCachePool(new ArrayCachePool());
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')

--- a/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
@@ -15,6 +15,7 @@ class MediaFeedUrlTest extends TestCase
 {
     /**
      * @param string $property
+     *
      * @dataProvider getSetDataProvider
      */
     public function testGetSet($get, $set, mixed $value)

--- a/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
+++ b/tests/src/Unit/Service/Feeds/MediaFeedUrlTest.php
@@ -15,10 +15,9 @@ class MediaFeedUrlTest extends TestCase
 {
     /**
      * @param string $property
-     * @param mixed  $value
      * @dataProvider getSetDataProvider
      */
-    public function testGetSet($get, $set, $value)
+    public function testGetSet($get, $set, mixed $value)
     {
         $account = new Account();
         $account->setPid('account-pid');

--- a/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
+++ b/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
@@ -7,6 +7,7 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Lullabot\Mpx\Exception\ClientException;
 use Lullabot\Mpx\Service\IdentityManagement\User;
 use Lullabot\Mpx\Service\IdentityManagement\UserSession;
+use Lullabot\Mpx\Tests\Fixtures\DummyStoreInterface;
 use Lullabot\Mpx\Tests\JsonResponse;
 use Lullabot\Mpx\Tests\MockClientTrait;
 use Lullabot\Mpx\TokenCachePool;
@@ -15,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Lock\Exception\LockConflictedException;
-use Symfony\Component\Lock\StoreInterface;
 
 /**
  * Tests mpx user accounts.
@@ -42,8 +42,8 @@ class UserSessionTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'signout.json'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -73,8 +73,8 @@ class UserSessionTest extends TestCase
             new JsonResponse(200, [], 'signin-fail.json'),
         ]);
 
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -106,8 +106,8 @@ class UserSessionTest extends TestCase
             new JsonResponse(200, [], 'signin-success.json'),
             new JsonResponse(200, [], 'signin-success.json'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->any())
             ->method('exists')
@@ -170,8 +170,8 @@ class UserSessionTest extends TestCase
         $client = $this->getMockClient([
             new JsonResponse(200, [], 'signin-success.json'),
         ]);
-        /** @var StoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
-        $store = $this->getMockBuilder(StoreInterface::class)
+        /** @var DummyStoreInterface|\PHPUnit_Framework_MockObject_MockObject $store */
+        $store = $this->getMockBuilder(DummyStoreInterface::class)
             ->getMock();
         $store->expects($this->once())->method('waitAndSave')
             ->willThrowException(new LockConflictedException());

--- a/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
+++ b/tests/src/Unit/Service/IdentityManagement/UserSessionTest.php
@@ -127,7 +127,7 @@ class UserSessionTest extends TestCase
                             'username' => 'mpx/USER-NAME',
                         ], $context);
                         $this->assertMatchesRegularExpression('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
-                    } catch (ExpectationFailedException $e) {
+                    } catch (ExpectationFailedException) {
                         return false;
                     }
 
@@ -142,7 +142,7 @@ class UserSessionTest extends TestCase
                             'username' => 'mpx/USER-NAME',
                         ], $context);
                         $this->assertMatchesRegularExpression('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
-                    } catch (ExpectationFailedException $e) {
+                    } catch (ExpectationFailedException) {
                         return false;
                     }
 
@@ -213,7 +213,7 @@ class UserSessionTest extends TestCase
                                 'username' => 'mpx/USER-NAME',
                             ], $context);
                             $this->assertMatchesRegularExpression('!\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}!', $context['date']);
-                        } catch (ExpectationFailedException $e) {
+                        } catch (ExpectationFailedException) {
                             return false;
                         }
 

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -96,7 +96,7 @@ class TokenTest extends TestCase
      */
     public function testFromResponseData()
     {
-        $data = json_decode(file_get_contents(__DIR__.'/../../fixtures/signin-success.json'), true);
+        $data = json_decode(file_get_contents(__DIR__.'/../../fixtures/signin-success.json'), true, 512, JSON_THROW_ON_ERROR);
         $token = Token::fromResponseData($data);
         $this->assertSame('TOKEN-VALUE', (string) $token);
         $this->assertSame('TOKEN-VALUE', $token->getValue());
@@ -142,8 +142,7 @@ class TokenTest extends TestCase
             'token' => 'token-value',
         ];
         $data = array_map(function ($value) use (&$required) {
-            end($required);
-            $key = key($required);
+            $key = array_key_last($required);
             array_pop($required);
 
             return [$required, $key];

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -120,6 +120,7 @@ class TokenTest extends TestCase
      * Test missing required keys within a signInResponse.
      *
      * @dataProvider validateDataProvider
+     *
      * @covers ::validateData
      */
     public function testInvalidResponseData($data, $key)

--- a/tests/src/Unit/TokenTest.php
+++ b/tests/src/Unit/TokenTest.php
@@ -96,7 +96,7 @@ class TokenTest extends TestCase
      */
     public function testFromResponseData()
     {
-        $data = json_decode(file_get_contents(__DIR__.'/../../fixtures/signin-success.json'), true, 512, JSON_THROW_ON_ERROR);
+        $data = json_decode(file_get_contents(__DIR__.'/../../fixtures/signin-success.json'), true, 512, \JSON_THROW_ON_ERROR);
         $token = Token::fromResponseData($data);
         $this->assertSame('TOKEN-VALUE', (string) $token);
         $this->assertSame('TOKEN-VALUE', $token->getValue());


### PR DESCRIPTION
BREAKING CHANGE: This version is no longer compatible with PHP7.4. We'll be tagging 2.0.0 with this commit.

This upgrade took an unreasonable amount of effort. Some of the highlights:

- Updated the CircleCI base image to use PHP8.1. This image didn't have some packages that were available in the previous image that we needed: imagik. This package is no longer accessible via docker-pecl-extension, so we had to do it manually.
- Updated the codebase using Rector.
- Updated the Symfony version, and find all the breaking changes. Thankfully there is an amazing test coverage that sprung all the BC break booby traps.
- Updated all the tests to make them compatible with all the BC breaks of PHPUnit versions.
- CS-Fixer also had breaking changes.
- Several dependencies had inter-locking combinations due to upgrade to PHP8.1.
- Access to Code Climate was impossible to resolve, so I decided to stop updating coverage info there, and upload the HTML report to CicleCI artifacts instead. 