### PR TITLE
Apply CS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage/
 /.idea
 /build
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,6 +8,8 @@ return (new PhpCsFixer\Config())
         'no_unreachable_default_argument_value' => false,
         'heredoc_to_nowdoc' => false,
         'phpdoc_annotation_without_dot' => false,
+        // Disabled as they are needed for the Serializer.
+        'fully_qualified_strict_types' => false,
     ))
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/AuthenticatedClient.php
+++ b/src/AuthenticatedClient.php
@@ -54,7 +54,7 @@ class AuthenticatedClient implements ClientInterface
      * @param UserSession $userSession The user associated with this client.
      * @param IdInterface $account     (optional) The account to use as the account context for requests.
      */
-    public function __construct(Client $client, UserSession $userSession, IdInterface $account = null)
+    public function __construct(Client $client, UserSession $userSession, ?IdInterface $account = null)
     {
         $this->client = $client;
         $this->userSession = $userSession;
@@ -94,7 +94,7 @@ class AuthenticatedClient implements ClientInterface
      *
      * @param int|null $duration The duration in seconds, or null to not use a specific lifetime.
      */
-    public function setTokenDuration(int $duration = null): void
+    public function setTokenDuration(?int $duration = null): void
     {
         $this->duration = $duration;
     }

--- a/src/Cache/Adapter/PHPArray/ArrayCachePool.php
+++ b/src/Cache/Adapter/PHPArray/ArrayCachePool.php
@@ -51,8 +51,7 @@ class ArrayCachePool implements LoggerAwareInterface, CacheInterface, CacheItemP
                 $item = $this->cache->getItem($key);
 
                 return $item->isHit() ? $item->get() : $default;
-            }
-        , $keys);
+            }, $keys);
     }
 
     public function setMultiple($values, $ttl = null): bool

--- a/src/DataService/CachingPhpDocExtractor.php
+++ b/src/DataService/CachingPhpDocExtractor.php
@@ -40,7 +40,7 @@ class CachingPhpDocExtractor implements PropertyDescriptionExtractorInterface, P
      * @param string[]|null $accessorPrefixes
      * @param string[]|null $arrayMutatorPrefixes
      */
-    public function __construct(DocBlockFactoryInterface $docBlockFactory = null, array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null)
+    public function __construct(?DocBlockFactoryInterface $docBlockFactory = null, ?array $mutatorPrefixes = null, ?array $accessorPrefixes = null, ?array $arrayMutatorPrefixes = null)
     {
         if (!class_exists(DocBlockFactory::class)) {
             throw new \RuntimeException(sprintf('Unable to use the "%s" class as the "phpdocumentor/reflection-docblock" package is not installed.', self::class));

--- a/src/DataService/DataObjectFactory.php
+++ b/src/DataService/DataObjectFactory.php
@@ -65,7 +65,7 @@ class DataObjectFactory
      * @param \Lullabot\Mpx\AuthenticatedClient $authenticatedClient A client to make authenticated MPX calls.
      * @param CacheItemPoolInterface|null       $cacheItemPool       (optional) Cache to store API metadata.
      */
-    public function __construct(DiscoveredDataService $dataService, AuthenticatedClient $authenticatedClient, CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct(DiscoveredDataService $dataService, AuthenticatedClient $authenticatedClient, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         $this->authenticatedClient = $authenticatedClient;
         $this->dataService = $dataService;
@@ -201,7 +201,7 @@ class DataObjectFactory
      *
      * @return ObjectListIterator An iterator over the full result set.
      */
-    public function select(ObjectListQuery $objectListQuery = null, array $options = []): ObjectListIterator
+    public function select(?ObjectListQuery $objectListQuery = null, array $options = []): ObjectListIterator
     {
         return new ObjectListIterator($this->selectRequest($objectListQuery, $options));
     }
@@ -217,7 +217,7 @@ class DataObjectFactory
      *
      * @return PromiseInterface A promise to return an ObjectList.
      */
-    public function selectRequest(ObjectListQuery $objectListQuery = null, array $options = []): PromiseInterface
+    public function selectRequest(?ObjectListQuery $objectListQuery = null, array $options = []): PromiseInterface
     {
         if (!$objectListQuery) {
             $objectListQuery = new ObjectListQuery();

--- a/src/DataService/DataServiceManager.php
+++ b/src/DataService/DataServiceManager.php
@@ -18,7 +18,7 @@ class DataServiceManager
      *
      * @return static
      */
-    public static function basicDiscovery(CustomFieldManager $customFieldManager = null)
+    public static function basicDiscovery(?CustomFieldManager $customFieldManager = null)
     {
         if (!$customFieldManager) {
             $customFieldManager = CustomFieldManager::basicDiscovery();

--- a/src/DataService/DateTime/ConcreteDateTime.php
+++ b/src/DataService/DateTime/ConcreteDateTime.php
@@ -20,7 +20,7 @@ class ConcreteDateTime implements ConcreteDateTimeInterface
      *
      * @see http://php.net/manual/en/datetime.construct.php
      */
-    public static function fromString($time = 'now', \DateTimeZone $timezone = null): self
+    public static function fromString($time = 'now', ?\DateTimeZone $timezone = null): self
     {
         return new static(new \DateTime($time, $timezone));
     }

--- a/src/DataService/NotificationListener.php
+++ b/src/DataService/NotificationListener.php
@@ -62,7 +62,7 @@ class NotificationListener
      * @param string                            $clientId      A string to identify this client in debugging.
      * @param CacheItemPoolInterface|null       $cacheItemPool (optional) The cache for API metadata.
      */
-    public function __construct(AuthenticatedClient $session, DiscoveredDataService $service, private readonly string $clientId, CacheItemPoolInterface $cacheItemPool = null)
+    public function __construct(AuthenticatedClient $session, DiscoveredDataService $service, private readonly string $clientId, ?CacheItemPoolInterface $cacheItemPool = null)
     {
         $this->authenticatedClient = $session;
         $this->service = $service;

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -21,7 +21,7 @@ class ClientException extends GuzzleClientException implements MpxExceptionInter
      * @param \Exception|null                          $previous       (optional) The previous exception.
      * @param array                                    $handlerContext (optional) Custom HTTP handler context, if available.
      */
-    public function __construct(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $handlerContext = [])
+    public function __construct(RequestInterface $request, ResponseInterface $response, ?\Exception $previous = null, array $handlerContext = [])
     {
         $message = $this->parseResponse($response);
         parent::__construct($message, $request, $response, $previous, $handlerContext);

--- a/src/Exception/MpxExceptionFactory.php
+++ b/src/Exception/MpxExceptionFactory.php
@@ -16,7 +16,7 @@ class MpxExceptionFactory
     public static function create(
         RequestInterface $request,
         ResponseInterface $response,
-        \Exception $previous = null,
+        ?\Exception $previous = null,
         array $ctx = []
     ): ClientException|ServerException {
         $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
@@ -30,7 +30,7 @@ class MpxExceptionFactory
     /**
      * Create a new MPX API exception from a notification.
      */
-    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $ctx = []): ClientException|ServerException
+    public static function createFromNotificationException(RequestInterface $request, ResponseInterface $response, ?\Exception $previous = null, array $ctx = []): ClientException|ServerException
     {
         $data = \GuzzleHttp\Utils::jsonDecode($response->getBody(), true);
         ServerException::validateNotificationData($data);
@@ -45,7 +45,7 @@ class MpxExceptionFactory
      */
     private static function createException(RequestInterface $request,
         ResponseInterface $altered,
-        \Exception $previous = null,
+        ?\Exception $previous = null,
         array $ctx = []
     ): ClientException|ServerException {
         if ($altered->getStatusCode() >= 400 && $altered->getStatusCode() < 500) {

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -18,7 +18,7 @@ class ServerException extends GuzzleServerException implements MpxExceptionInter
      * @param \Exception|null                          $previous       (optional) The previous exception.
      * @param array                                    $handlerContext (optional) Custom HTTP handler context, if available.
      */
-    public function __construct(RequestInterface $request, ResponseInterface $response, \Exception $previous = null, array $handlerContext = [])
+    public function __construct(RequestInterface $request, ResponseInterface $response, ?\Exception $previous = null, array $handlerContext = [])
     {
         $message = $this->parseResponse($response);
         parent::__construct($message, $request, $response, $previous, $handlerContext);

--- a/src/Exception/TokenNotFoundException.php
+++ b/src/Exception/TokenNotFoundException.php
@@ -16,7 +16,7 @@ class TokenNotFoundException extends \RuntimeException
      * @param int                                                  $code        The exception code.
      * @param \Throwable|null                                      $previous    The previous exception, if available.
      */
-    public function __construct(UserSession $userSession, int $code = 0, \Throwable $previous = null)
+    public function __construct(UserSession $userSession, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf('Token not found for %s.', $userSession->getUser()->getMpxUsername()), $code, $previous);
     }

--- a/src/Normalizer/UnixMillisecondNormalizer.php
+++ b/src/Normalizer/UnixMillisecondNormalizer.php
@@ -53,17 +53,17 @@ class UnixMillisecondNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         return $this->decorated->normalize($object, $format, $context);
     }
 
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
         return $this->decorated->supportsNormalization($data, $format);
     }
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): ConcreteDateTime
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): ConcreteDateTime
     {
         if (!\is_int($data)) {
             throw new NotNormalizableValueException('The data is not an integer, you should pass an integer representing the unix time in milliseconds.');
@@ -80,7 +80,7 @@ class UnixMillisecondNormalizer implements NormalizerInterface, DenormalizerInte
         return new ConcreteDateTime($date);
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null): bool
     {
         return isset(self::$supportedTypes[$type]);
     }

--- a/src/Service/AccessManagement/ResolveBase.php
+++ b/src/Service/AccessManagement/ResolveBase.php
@@ -27,7 +27,7 @@ abstract class ResolveBase
      * @param AuthenticatedClient         $authenticatedClient The client used to access mpx.
      * @param CacheItemPoolInterface|null $cache               (optional) The cache to store responses in. Defaults to an array cache.
      */
-    public function __construct(AuthenticatedClient $authenticatedClient, CacheItemPoolInterface $cache = null)
+    public function __construct(AuthenticatedClient $authenticatedClient, ?CacheItemPoolInterface $cache = null)
     {
         $this->authenticatedClient = $authenticatedClient;
 

--- a/src/Service/IdentityManagement/UserSession.php
+++ b/src/Service/IdentityManagement/UserSession.php
@@ -68,7 +68,7 @@ class UserSession
      *
      * @see \Psr\Log\NullLogger To disable logging of token requests.
      */
-    public function __construct(UserInterface $user, Client $client, PersistingStoreInterface $store = null, TokenCachePool $tokenCachePool = null)
+    public function __construct(UserInterface $user, Client $client, ?PersistingStoreInterface $store = null, ?TokenCachePool $tokenCachePool = null)
     {
         $this->user = $user;
         $this->client = $client;
@@ -92,7 +92,7 @@ class UserSession
      *
      * @return Token A valid mpx authentication token.
      */
-    public function acquireToken(int $duration = null, bool $reset = false): Token
+    public function acquireToken(?int $duration = null, bool $reset = false): Token
     {
         if ($reset) {
             $this->tokenCachePool->deleteToken($this);
@@ -169,7 +169,7 @@ class UserSession
      *
      * @return \Lullabot\Mpx\Token The token.
      */
-    protected function signInWithLock(int $duration = null): Token
+    protected function signInWithLock(?int $duration = null): Token
     {
         if ($this->store) {
             $factory = new LockFactory($this->store);

--- a/tests/src/Fixtures/Dummy.php
+++ b/tests/src/Fixtures/Dummy.php
@@ -138,7 +138,7 @@ class Dummy extends ParentDummy
     /**
      * B.
      */
-    public function setB(ParentDummy $parent = null)
+    public function setB(?ParentDummy $parent = null)
     {
     }
 

--- a/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
+++ b/tests/src/Unit/DataService/CachingPhpDocExtractorTest.php
@@ -36,7 +36,7 @@ class CachingPhpDocExtractorTest extends TestCase
     /**
      * @dataProvider typesWithCustomPrefixesProvider
      */
-    public function testExtractTypesWithCustomPrefixes($property, array $type = null)
+    public function testExtractTypesWithCustomPrefixes($property, ?array $type = null)
     {
         $customExtractor = new CachingPhpDocExtractor(null, ['add', 'remove'], ['is', 'can']);
 
@@ -46,7 +46,7 @@ class CachingPhpDocExtractorTest extends TestCase
     /**
      * @dataProvider typesWithNoPrefixesProvider
      */
-    public function testExtractTypesWithNoPrefixes($property, array $type = null)
+    public function testExtractTypesWithNoPrefixes($property, ?array $type = null)
     {
         $noPrefixExtractor = new CachingPhpDocExtractor(null, [], [], []);
 


### PR DESCRIPTION
I would have expected this to fail the PR where things were upgrade. It's surprising, I no longer see any job data for PRs like this one: https://github.com/Lullabot/mpx-php/pull/192

I'm not sure I like removing the fqcn's from docblocks on imported classes, but I don't see an easy way to disable that and if Symfony is doing it we may as well follow.